### PR TITLE
Refine mobile controls layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -328,19 +328,6 @@ async function main() {
     onBurstStop: () => stopBurst()
   });
 
-  // Rain toggle button
-  const rainBtn = document.getElementById('rain-toggle');
-  if (rainBtn) {
-    let active = false;
-    const updateLabel = () => { rainBtn.textContent = active ? "⛅" : "🌧️"; };
-    updateLabel();
-    rainBtn.addEventListener('click', () => {
-      active = !active;
-      rain.setActive(active);
-      updateLabel();
-    });
-  }
-
   // ESC toggles Pause/Resume
   window.addEventListener('keydown', (e) => {
     if (e.code === 'Escape') {
@@ -625,17 +612,93 @@ async function main() {
 
   let localStream = null;
   let micActive = false;
-  const voiceButton = document.getElementById('voice-button');
+  const moreActionsButton = document.getElementById('more-actions-button');
+  const moreActionsMenu = document.getElementById('more-actions-menu');
+  let collapseMoreActionsMenu = null;
 
-  voiceButton.addEventListener('click', async () => {
-    if (!micActive) {
+  if (moreActionsButton && moreActionsMenu) {
+    const closeMenu = () => {
+      if (moreActionsMenu.classList.contains('hidden')) return;
+      moreActionsMenu.classList.add('hidden');
+      moreActionsButton.setAttribute('aria-expanded', 'false');
+      moreActionsMenu.setAttribute('aria-hidden', 'true');
+    };
+    const openMenu = () => {
+      moreActionsMenu.classList.remove('hidden');
+      moreActionsButton.setAttribute('aria-expanded', 'true');
+      moreActionsMenu.setAttribute('aria-hidden', 'false');
+    };
+    collapseMoreActionsMenu = closeMenu;
+    moreActionsButton.setAttribute('aria-expanded', 'false');
+    moreActionsMenu.setAttribute('aria-hidden', 'true');
+
+    moreActionsButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (moreActionsMenu.classList.contains('hidden')) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!moreActionsMenu.contains(event.target) && event.target !== moreActionsButton) {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') closeMenu();
+    });
+
+    moreActionsMenu.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+  }
+
+  const voiceToggleBtn = document.getElementById('voice-toggle');
+  const voiceStateLabel = voiceToggleBtn?.querySelector('.state') ?? null;
+  const settingsVoiceToggle = document.getElementById('settings-voice-enabled');
+
+  function updateMicUI() {
+    if (voiceToggleBtn) {
+      voiceToggleBtn.classList.toggle('active', micActive);
+      voiceToggleBtn.setAttribute('aria-pressed', micActive ? 'true' : 'false');
+      if (voiceStateLabel) voiceStateLabel.textContent = micActive ? 'On' : 'Off';
+    }
+    if (settingsVoiceToggle) {
+      settingsVoiceToggle.checked = micActive;
+    }
+  }
+
+  async function setMicActive(next) {
+    const desired = !!next;
+    if (desired === micActive) {
+      updateMicUI();
+      return micActive;
+    }
+
+    if (desired) {
+      if (typeof navigator === 'undefined' || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        console.warn('Microphone access is not supported in this browser.');
+        micActive = false;
+        updateMicUI();
+        return micActive;
+      }
       try {
         localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
         multiplayer.startVoice(localStream);
         micActive = true;
-        voiceButton.textContent = "Mute";
       } catch (err) {
-        console.error("Microphone access denied:", err);
+        console.error('Microphone access denied:', err);
+        micActive = false;
+        updateMicUI();
+        if (voiceStateLabel) {
+          voiceStateLabel.textContent = 'Denied';
+          setTimeout(updateMicUI, 1600);
+        }
+        return micActive;
       }
     } else {
       if (localStream) {
@@ -644,9 +707,75 @@ async function main() {
         localStream = null;
       }
       micActive = false;
-      voiceButton.textContent = "Unmute";
     }
-  });
+
+    updateMicUI();
+    return micActive;
+  }
+
+  if (voiceToggleBtn) {
+    voiceToggleBtn.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const result = await setMicActive(!micActive);
+      if (settingsVoiceToggle && settingsVoiceToggle.checked !== result) {
+        settingsVoiceToggle.checked = result;
+      }
+      if (collapseMoreActionsMenu) collapseMoreActionsMenu();
+    });
+  }
+
+  if (settingsVoiceToggle) {
+    settingsVoiceToggle.addEventListener('change', async (event) => {
+      const result = await setMicActive(event.target.checked);
+      if (settingsVoiceToggle.checked !== result) {
+        settingsVoiceToggle.checked = result;
+      }
+    });
+  }
+
+  updateMicUI();
+
+  const rainBtn = document.getElementById('rain-toggle');
+  const rainStateLabel = rainBtn?.querySelector('.state') ?? null;
+  const settingsRainToggle = document.getElementById('settings-rain-enabled');
+  let rainActive = typeof rain?.isActive === 'function' ? rain.isActive() : false;
+
+  function updateRainUI() {
+    if (rainBtn) {
+      rainBtn.classList.toggle('active', rainActive);
+      rainBtn.setAttribute('aria-pressed', rainActive ? 'true' : 'false');
+      if (rainStateLabel) rainStateLabel.textContent = rainActive ? 'On' : 'Off';
+    }
+    if (settingsRainToggle) {
+      settingsRainToggle.checked = rainActive;
+    }
+  }
+
+  function setRainActive(next) {
+    rainActive = !!next;
+    if (rain && typeof rain.setActive === 'function') {
+      rain.setActive(rainActive);
+    }
+    updateRainUI();
+  }
+
+  if (rainBtn) {
+    rainBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setRainActive(!rainActive);
+      if (collapseMoreActionsMenu) collapseMoreActionsMenu();
+    });
+  }
+
+  if (settingsRainToggle) {
+    settingsRainToggle.addEventListener('change', (event) => {
+      setRainActive(event.target.checked);
+    });
+  }
+
+  updateRainUI();
 
   const settingsBtn = document.getElementById('settings-button');
   const overlay = document.getElementById('settings-overlay');
@@ -677,6 +806,8 @@ async function main() {
   settingsBtn.addEventListener('click', () => {
     nameInput.value = playerName;
     characterSelect.value = characterModel;
+    if (settingsVoiceToggle) settingsVoiceToggle.checked = micActive;
+    if (settingsRainToggle) settingsRainToggle.checked = rainActive;
     overlay.style.display = 'flex';
   });
 

--- a/index.html
+++ b/index.html
@@ -16,10 +16,21 @@
     <div class="crosshair"></div>
   </div>
   <div id="health-bar"><div id="health-fill"></div></div>
-  <div id="action-buttons">
-    <button id="voice-button" class="action-button">Unmute</button>
-    <button id="talk-button" class="action-button">🎤</button>
-    <button id="rain-toggle" class="action-button" title="Toggle Rain">🌧️</button>
+  <div id="floating-controls">
+    <button id="talk-button" class="fab-button" aria-label="Hold to talk" title="Hold to talk">🎤</button>
+    <div id="more-actions">
+      <button id="more-actions-button" class="fab-button" aria-label="More actions" title="More actions">⋯</button>
+      <div id="more-actions-menu" class="hidden" role="menu" aria-hidden="true">
+        <button id="voice-toggle" class="menu-action" role="menuitem" aria-pressed="false">
+          <span class="label">Microphone</span>
+          <span class="state">Off</span>
+        </button>
+        <button id="rain-toggle" class="menu-action" role="menuitem" aria-pressed="false">
+          <span class="label">Rain Effects</span>
+          <span class="state">Off</span>
+        </button>
+      </div>
+    </div>
   </div>
   
   <!-- Settings Button -->
@@ -33,6 +44,18 @@
       <label for="character-select">Character:</label>
       <select id="character-select"></select>
       <button id="save-settings">Save</button>
+
+      <div class="settings-section">
+        <h3>Audio &amp; Effects</h3>
+        <label class="settings-toggle" for="settings-voice-enabled">
+          <span>Microphone</span>
+          <input type="checkbox" id="settings-voice-enabled" class="toggle-input" />
+        </label>
+        <label class="settings-toggle" for="settings-rain-enabled">
+          <span>Rain Effects</span>
+          <input type="checkbox" id="settings-rain-enabled" class="toggle-input" />
+        </label>
+      </div>
 
       <button id="toggle-console">Show Console</button>
 

--- a/styles.css
+++ b/styles.css
@@ -100,29 +100,110 @@ body {
   user-select: none;
 }
 
-#action-buttons {
+#floating-controls {
   position: fixed;
   bottom: 20px;
   left: 20px;
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  align-items: flex-end;
+  gap: 12px;
   z-index: 1000;
 }
 
-.action-button {
-  width: 60px;
-  height: 60px;
-  background-color: rgba(255, 255, 255, 0.5);
+.fab-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
   border: none;
-  border-radius: 8px;
-  font-weight: bold;
-  color: #333;
+  background: rgba(18, 22, 32, 0.78);
+  color: #f8fafc;
+  font-size: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
-  touch-action: none;
   cursor: pointer;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  transition: transform 0.18s ease, background 0.2s ease, box-shadow 0.2s ease;
+  touch-action: manipulation;
+}
+
+.fab-button:hover {
+  background: rgba(28, 32, 44, 0.92);
+}
+
+.fab-button:active {
+  transform: translateY(1px) scale(0.97);
+}
+
+#talk-button {
+  background: linear-gradient(140deg, rgba(220, 38, 38, 0.92), rgba(239, 68, 68, 0.92));
+  font-size: 24px;
+}
+
+#talk-button:hover {
+  background: linear-gradient(140deg, rgba(185, 28, 28, 0.98), rgba(220, 38, 38, 0.98));
+}
+
+#more-actions {
+  position: relative;
+}
+
+#more-actions-button[aria-expanded="true"] {
+  background: rgba(28, 32, 44, 0.98);
+}
+
+#more-actions-menu {
+  position: absolute;
+  bottom: 70px;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(10, 14, 24, 0.92);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(14px);
+  min-width: 180px;
+  color: #e2e8f0;
+}
+
+#more-actions-menu.hidden {
+  display: none;
+}
+
+.menu-action {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: 500 14px/1.2 "Inter", "Segoe UI", sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.16s ease;
+}
+
+.menu-action:hover {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.menu-action:active {
+  transform: translateY(1px);
+}
+
+.menu-action .state {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(148, 197, 255, 0.95);
+}
+
+#voice-toggle.active .state,
+#rain-toggle.active .state {
+  color: #34d399;
 }
 
 #camera-controls {
@@ -240,13 +321,6 @@ body {
   width: 100%;
 }
 
-#voice-button {
-}
-
-#voice-button.active {
-  background-color: rgba(255, 0, 0, 0.5);
-}
-
 #chat-ui {
   position: absolute;
   bottom: 10px;
@@ -310,21 +384,119 @@ body {
   justify-content: center;
   align-items: center;
   z-index: 999;
+  padding: 20px;
 }
 
 #settings-panel {
-  background: white;
-  padding: 20px;
-  border-radius: 8px;
-  text-align: center;
+  background: rgba(248, 250, 252, 0.95);
+  padding: 24px 28px;
+  border-radius: 18px;
+  text-align: left;
+  width: min(90vw, 420px);
+  max-height: 92vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(8px);
 }
 
-#settings-panel input,
+#settings-panel input:not(.toggle-input),
 #settings-panel select {
   margin-top: 8px;
   margin-bottom: 12px;
-  padding: 4px;
-  width: 200px;
+  padding: 10px 12px;
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+#settings-panel button {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: none;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+#save-settings {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.3);
+  margin-bottom: 12px;
+}
+
+#save-settings:hover {
+  filter: brightness(1.05);
+}
+
+#toggle-console {
+  background: rgba(15, 23, 42, 0.08);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  margin-top: 6px;
+}
+
+.settings-section {
+  margin-top: 18px;
+}
+
+.settings-section h3 {
+  font-size: 16px;
+  margin-bottom: 10px;
+  color: #0f172a;
+}
+
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.15);
+  margin-top: 10px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.toggle-input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.6);
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  outline: none;
+}
+
+.toggle-input::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.toggle-input:checked {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.toggle-input:checked::after {
+  transform: translateX(20px);
+}
+
+.toggle-input:not(:checked):active::after {
+  transform: translateX(2px);
 }
 
 
@@ -356,11 +528,55 @@ body {
     bottom: 20px;
   }
 
-  #action-buttons {
+  #floating-controls {
     left: auto;
     right: 120px;
     bottom: 20px;
-    flex-direction: column;
+    transform: none;
+  }
+}
+
+@media (max-width: 768px) {
+  #floating-controls {
+    left: 50%;
+    right: auto;
+    bottom: 18px;
+    transform: translateX(-50%);
+  }
+
+  .fab-button {
+    width: 60px;
+    height: 60px;
+    font-size: 22px;
+  }
+
+  #talk-button {
+    width: 74px;
+    height: 74px;
+    font-size: 28px;
+  }
+
+  #more-actions-menu {
+    bottom: 88px;
+    left: 50%;
+    transform: translateX(-50%);
+    align-items: stretch;
+  }
+
+  #settings-panel {
+    padding: 20px;
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  #settings-panel {
+    width: 100%;
+    padding: 18px;
+  }
+
+  .settings-toggle {
+    padding: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace the on-screen action buttons with a compact floating control cluster and move audio/effect toggles into the settings panel.
- Restyle floating controls and the settings sheet to improve spacing, readability, and mobile responsiveness.
- Update the client logic to drive the new quick actions menu and keep microphone and rain toggles in sync across the UI.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9730fb6308325a16ea9a479e64b0d