### PR TITLE
Handle mobile background audio autoplay restrictions

### DIFF
--- a/audioManager.js
+++ b/audioManager.js
@@ -14,17 +14,34 @@ export class AudioManager {
       'SFX/Attacks/Sword Attacks Hits and Blocks/Sword Attack 2.ogg',
       'SFX/Attacks/Sword Attacks Hits and Blocks/Sword Attack 3.ogg'
     ];
+    this.pendingBackground = null;
+    this._backgroundUnlockHandler = null;
+    this._backgroundUnlockEvents = ['pointerdown', 'touchstart', 'keydown'];
   }
 
   playBGS(name) {
     if (this.background) {
       this.background.pause();
     }
+    this._resetBackgroundUnlock();
     const path = `assets/audio/BGS Loops/${name}`;
     this.background = new Audio(path);
     this.background.loop = true;
     this.background.volume = 0.5;
-    this.background.play().catch(err => console.error('BGS play failed', err));
+    const playPromise = this.background.play();
+    if (playPromise && typeof playPromise.then === 'function') {
+      playPromise.then(() => {
+        this.pendingBackground = null;
+      }).catch((err) => {
+        if (this._isAutoplayBlocked(err)) {
+          console.info('Background music will start after the first user interaction.');
+          this.pendingBackground = this.background;
+          this._awaitUserInteractionForBackground();
+        } else {
+          console.error('BGS play failed', err);
+        }
+      });
+    }
   }
 
   playSFX(path, volume = 0.7) {
@@ -45,5 +62,39 @@ export class AudioManager {
     this.lastFootstep = now;
     const clip = this.footsteps[Math.floor(Math.random() * this.footsteps.length)];
     this.playSFX(clip, 0.4);
+  }
+
+  _isAutoplayBlocked(err) {
+    if (!err) return false;
+    if (err.name === 'NotAllowedError' || err.name === 'SecurityError') return true;
+    return typeof err.message === 'string' && err.message.includes('NotAllowedError');
+  }
+
+  _awaitUserInteractionForBackground() {
+    if (typeof document === 'undefined' || this._backgroundUnlockHandler) {
+      return;
+    }
+    const handler = () => {
+      const pending = this.pendingBackground;
+      this._resetBackgroundUnlock();
+      if (pending) {
+        pending.play().catch(err => console.error('BGS play failed after user interaction', err));
+      }
+    };
+    this._backgroundUnlockHandler = handler;
+    const options = { once: true };
+    this._backgroundUnlockEvents.forEach(event => {
+      document.addEventListener(event, handler, options);
+    });
+  }
+
+  _resetBackgroundUnlock() {
+    if (typeof document !== 'undefined' && this._backgroundUnlockHandler) {
+      this._backgroundUnlockEvents.forEach(event => {
+        document.removeEventListener(event, this._backgroundUnlockHandler);
+      });
+    }
+    this._backgroundUnlockHandler = null;
+    this.pendingBackground = null;
   }
 }


### PR DESCRIPTION
## Summary
- defer background music playback until the first user gesture so mobile browsers no longer throw autoplay errors
- add reusable unlock logic to retry background playback and clean up event listeners when switching tracks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c97ea9384483258d93647c3d229749