### PR TITLE
Remove first-person camera option and related code paths

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -1019,7 +1019,7 @@ async function initCore(runtimeContext) {
     return 'day';
   };
   const loadDisplaySettings = () => {
-    const defaults = { mode: 'auto', firstPerson: false, ...DISPLAY_PRESETS.day };
+    const defaults = { mode: 'auto', ...DISPLAY_PRESETS.day };
     const raw = localStorage.getItem(DISPLAY_SETTINGS_KEY);
     if (!raw) return defaults;
     try {
@@ -1046,7 +1046,6 @@ async function initCore(runtimeContext) {
   if (!DISPLAY_MODES.has(displaySettings.mode)) {
     displaySettings.mode = 'auto';
   }
-  displaySettings.firstPerson = Boolean(displaySettings.firstPerson);
   if (displaySettings.mode === 'auto') {
     lastAutoMode = getAutoMode();
     applyPresetForMode(lastAutoMode);
@@ -1075,7 +1074,6 @@ async function initCore(runtimeContext) {
     if (dirLight) {
       dirLight.intensity = clampValue(displaySettings.directionalIntensity, 0, 2);
     }
-    playerControls?.setFirstPersonEnabled?.(displaySettings.firstPerson);
     applyMaterialBrightness(groundTiles?.material, groundMaterialBase, displaySettings.groundBrightness);
     applyMaterialBrightness(buildingsRenderer?.materials?.extruded, buildingMaterialBase?.extruded, displaySettings.buildingBrightness);
     applyMaterialBrightness(buildingsRenderer?.materials?.flat, buildingMaterialBase?.flat, displaySettings.buildingBrightness);
@@ -1129,12 +1127,6 @@ async function initCore(runtimeContext) {
   };
 
   const setDisplaySetting = (key, value) => {
-    if (key === 'firstPerson') {
-      displaySettings.firstPerson = Boolean(value);
-      saveDisplaySettings();
-      applyDisplaySettings();
-      return;
-    }
     if (!Number.isFinite(value)) return;
     displaySettings[key] = value;
     saveDisplaySettings();

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -321,7 +321,6 @@ export class PlayerControls {
     this.engagedDirection = null;
     this.freeYaw = null;
     this.freePitch = null;
-    this.firstPersonEnabled = false;
 
     if (this.interactionPromptEl) {
       const activateInteraction = (event) => {
@@ -2664,15 +2663,6 @@ export class PlayerControls {
         .add(new THREE.Vector3(0, cameraHeight + ENGAGED_CAMERA_OFFSET.up, 0))
         .add(behindOffset)
         .addScaledVector(engagedRight, ENGAGED_CAMERA_OFFSET.right);
-    } else if (this.firstPersonEnabled) {
-      desiredCameraPosition = orbitCenter.clone().add(new THREE.Vector3(0, 0.62, 0));
-      const cosPitch = Math.cos(this.pitch);
-      const forward = new THREE.Vector3(
-        Math.sin(this.yaw) * cosPitch,
-        Math.sin(this.pitch),
-        Math.cos(this.yaw) * cosPitch
-      ).normalize();
-      cameraLookTarget = desiredCameraPosition.clone().addScaledVector(forward, 10);
     } else {
       const rotatedOffset = new THREE.Vector3(
         offset.x * Math.cos(this.yaw) - offset.z * Math.sin(this.yaw),
@@ -3223,13 +3213,6 @@ export class PlayerControls {
 
   isProjectileWeapon(weapon) {
     return !!weapon && (weapon.type === 'gun' || weapon.type === 'bow' || weapon.type === 'bomb');
-  }
-
-  setFirstPersonEnabled(enabled) {
-    this.firstPersonEnabled = Boolean(enabled);
-    if (this.firstPersonEnabled) {
-      this.setAiming(false);
-    }
   }
 
   setAiming(active) {

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -655,14 +655,6 @@ function buildDisplayPanel() {
     step: 0.05
   });
 
-  const firstPersonRow = createElement('div', 'settings-row');
-  const firstPersonLabel = createElement('label', 'settings-label', 'First Person Camera');
-  firstPersonLabel.setAttribute('for', 'settings-display-first-person');
-  const firstPersonToggle = createElement('input', 'settings-checkbox');
-  firstPersonToggle.type = 'checkbox';
-  firstPersonToggle.id = 'settings-display-first-person';
-  firstPersonRow.append(firstPersonLabel, firstPersonToggle);
-
   const hint = createElement('div', 'settings-muted');
   hint.textContent = 'Auto mode uses local time to switch between day and night lighting.';
 
@@ -673,7 +665,6 @@ function buildDisplayPanel() {
     groundField.field,
     buildingField.field,
     skyField.field,
-    firstPersonRow,
     hint
   );
 
@@ -692,8 +683,7 @@ function buildDisplayPanel() {
       groundBrightness: groundField.valueLabel,
       buildingBrightness: buildingField.valueLabel,
       skyBrightness: skyField.valueLabel
-    },
-    firstPersonToggle
+    }
   };
 
   return panelEl;
@@ -1428,12 +1418,6 @@ function bindEvents() {
     });
   }
 
-  if (elements.displayFields?.firstPersonToggle) {
-    elements.displayFields.firstPersonToggle.addEventListener('change', (event) => {
-      context.appState?.setDisplaySetting?.('firstPerson', event.target.checked);
-    });
-  }
-
   window.addEventListener('resize', () => {
     refreshLayout();
   });
@@ -1826,9 +1810,6 @@ export function updateUI() {
         elements.displayFields.values[key].textContent = formatRangeValue(value);
       }
     });
-    if (elements.displayFields.firstPersonToggle) {
-      elements.displayFields.firstPersonToggle.checked = Boolean(displaySettings?.firstPerson);
-    }
   }
 
   renderInventory();


### PR DESCRIPTION
### Motivation
- Remove the First Person camera UI option and all runtime usage so the app no longer exposes or relies on a first-person camera mode.

### Description
- Removed the First Person Camera toggle and its DOM wiring from `controls/settingsPanel.js` so the display panel only exposes lighting/display controls.
- Removed the `firstPerson` default, persistence and special-case handling from `app/bootstrapGameApp.js` so display settings no longer include or apply a first-person flag.
- Removed first-person camera behavior from `controls/controls.js` by deleting the `firstPersonEnabled` state, the first-person camera branch in camera computation, and the `setFirstPersonEnabled` method.
- Updated display settings flow and UI synchronization to eliminate listeners and fields that referenced the removed `firstPerson` option.

### Testing
- Performed a code search for `firstPerson`/`First Person`/`setFirstPersonEnabled` to confirm the UI and code paths were removed, and the search returned no remaining usage in the edited locations.
- Ran `npm run build` which completed successfully and produced a production build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80462fd908333ac1bb5e5cbfe5427)