### PR TITLE
Throttle & coalesce high-frequency multiplayer sends; add deadbands and RTT-based profile gating

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -256,7 +256,7 @@ const WORLD_ORIGIN_STORAGE_KEY = 'worldOrigin';
 const METERS_PER_DEGREE_LAT = 111_132.92;
 const PLAYER_VISIBILITY_RADIUS_M = 200;
 const PRESENCE_STALE_MS = 5000;
-const PRESENCE_SEND_MS = 250;
+const PRESENCE_SEND_MS = 350;
 const PRESENCE_SWEEP_MS = 250;
 const REMOTE_LERP_ALPHA = 0.15;
 const REMOTE_TELEPORT_THRESHOLD_M = 25;
@@ -737,10 +737,29 @@ async function initCore(runtimeContext) {
   let lastEntityBroadcast = 0;
   let lastFullEntityBroadcast = 0;
   let lastControlSend = 0;
-  const ENTITY_BROADCAST_INTERVAL = 200;
+  let entityBroadcastIntervalMs = 260;
   const ENTITY_STATE_DIRTY_THRESHOLD = 0.01;
   const ENTITY_FULL_SNAPSHOT_INTERVAL = 5000;
-  const CONTROL_SEND_INTERVAL = 140;
+  let controlSendIntervalMs = 220;
+  let presenceSendIntervalMs = PRESENCE_SEND_MS;
+  const POSITION_DEADBAND_SQ = 0.03 * 0.03;
+  const ROTATION_DEADBAND_RAD = 0.045;
+  const netSendQueue = new Map();
+  const netStats = {
+    sentInWindow: 0,
+    windowStartMs: performance.now(),
+    messagesPerSecond: 0,
+    coalesced: 0,
+    dropped: 0
+  };
+  const lastSentPresenceState = {
+    x: null,
+    y: null,
+    z: null,
+    rotation: null,
+    action: null
+  };
+  const lastSentEntityControlStates = new Map();
   const projectiles = [];
   const iceMists = [];
   const bombMists = [];
@@ -819,6 +838,84 @@ async function initCore(runtimeContext) {
     const safeMax = Number.isFinite(max) ? max : safeMin;
     if (safeMax <= safeMin) return safeMin;
     return safeMin + Math.random() * (safeMax - safeMin);
+  };
+  const wrapDeltaRad = (value) => {
+    let wrapped = value;
+    while (wrapped > Math.PI) wrapped -= Math.PI * 2;
+    while (wrapped < -Math.PI) wrapped += Math.PI * 2;
+    return wrapped;
+  };
+  const getNetworkTier = () => {
+    const pingMs = multiplayer?.lastPingMs;
+    const pingAgeMs = Number.isFinite(multiplayer?.lastPingAt) ? (Date.now() - multiplayer.lastPingAt) : Infinity;
+    const hasLag = Number.isFinite(pingMs) && pingMs >= 220;
+    const stalePing = pingAgeMs > 20000;
+    const deviceTier = getDevicePerformanceProfile().tier;
+    if (deviceTier === 'low' || hasLag || stalePing) return 'low';
+    if (deviceTier === 'mid' || (Number.isFinite(pingMs) && pingMs >= 120)) return 'mid';
+    return 'high';
+  };
+  const applyRuntimeNetworkProfile = () => {
+    const tier = getNetworkTier();
+    if (tier === 'low') {
+      presenceSendIntervalMs = 550;
+      entityBroadcastIntervalMs = 380;
+      controlSendIntervalMs = 320;
+      return;
+    }
+    if (tier === 'mid') {
+      presenceSendIntervalMs = 420;
+      entityBroadcastIntervalMs = 300;
+      controlSendIntervalMs = 240;
+      return;
+    }
+    presenceSendIntervalMs = 350;
+    entityBroadcastIntervalMs = 260;
+    controlSendIntervalMs = 200;
+  };
+  const recordNetSent = (count = 1) => {
+    netStats.sentInWindow += count;
+  };
+  const queueNetMessage = (payload, coalesceKey = null) => {
+    if (!multiplayer || !payload) {
+      netStats.dropped += 1;
+      return false;
+    }
+    if (!coalesceKey) {
+      multiplayer.send(payload);
+      recordNetSent(1);
+      return true;
+    }
+    if (netSendQueue.has(coalesceKey)) {
+      netStats.coalesced += 1;
+    }
+    netSendQueue.set(coalesceKey, payload);
+    return true;
+  };
+  const flushNetSendQueue = () => {
+    if (!multiplayer || netSendQueue.size === 0) return;
+    const pending = Array.from(netSendQueue.values());
+    netSendQueue.clear();
+    pending.forEach((payload) => multiplayer.send(payload));
+    recordNetSent(pending.length);
+  };
+  const tickNetStats = (nowMs) => {
+    const elapsed = nowMs - netStats.windowStartMs;
+    if (elapsed < 1000) return;
+    netStats.messagesPerSecond = (netStats.sentInWindow * 1000) / elapsed;
+    netStats.sentInWindow = 0;
+    netStats.windowStartMs = nowMs;
+    window.netRuntimeStats = {
+      msgsPerSecond: Number(netStats.messagesPerSecond.toFixed(2)),
+      coalesced: netStats.coalesced,
+      dropped: netStats.dropped,
+      queueDepth: netSendQueue.size,
+      intervals: {
+        presenceSendIntervalMs,
+        entityBroadcastIntervalMs,
+        controlSendIntervalMs
+      }
+    };
   };
   const getVolumeByDistance = (distance, maxDistance, maxVolume) => {
     if (!Number.isFinite(distance) || !Number.isFinite(maxDistance) || maxDistance <= 0) return 0;
@@ -1407,7 +1504,7 @@ async function initCore(runtimeContext) {
       updateAuthoritativeState(id, state, myId);
       return;
     }
-    multiplayer.send({ type: 'entityControl', id, state, sourceId: myId });
+    queueNetMessage({ type: 'entityControl', id, state, sourceId: myId }, `entityControl:${id}`);
   }
 
   const worldAnchorMatchesLocal = (anchor) => {
@@ -2018,6 +2115,15 @@ async function initCore(runtimeContext) {
 
   multiplayer = new Multiplayer(playerName, handleIncomingData);
   window.multiplayer = multiplayer;
+  multiplayer.queueCoalesced = (payload, key) => queueNetMessage(payload, key);
+  multiplayer.sendHighFrequency = (payload, typeKey, targetKey = 'global') => {
+    const key = `${typeKey}:${targetKey}`;
+    return queueNetMessage(payload, key);
+  };
+  multiplayer.getNetRuntimeStats = () => ({ ...window.netRuntimeStats });
+  multiplayer.onPingUpdate = () => {
+    applyRuntimeNetworkProfile();
+  };
   multiplayer.onHostChange = ({ previousHostId, newHostId, isCurrentHost }) => {
     isHost = !!isCurrentHost;
     setMonsterPersistenceHost(isHost);
@@ -10935,22 +11041,40 @@ async function initCore(runtimeContext) {
         updateAuthoritativeState(id, state, sourceId);
       });
 
-      if (now - lastEntityBroadcast >= ENTITY_BROADCAST_INTERVAL) {
+      if (now - lastEntityBroadcast >= entityBroadcastIntervalMs) {
         const shouldSendFull = now - lastFullEntityBroadcast >= ENTITY_FULL_SNAPSHOT_INTERVAL;
         const payload = shouldSendFull
           ? serializeFullAuthoritativeStates()
           : serializeDirtyAuthoritativeStates();
         if (Object.keys(payload).length > 0) {
-          multiplayer.send({ type: 'entityStates', states: payload });
+          queueNetMessage({ type: 'entityStates', states: payload }, 'entityStates:host');
           if (shouldSendFull) {
             lastFullEntityBroadcast = now;
           }
         }
         lastEntityBroadcast = now;
       }
-    } else if (localStates.size > 0 && now - lastControlSend >= CONTROL_SEND_INTERVAL) {
+    } else if (localStates.size > 0 && now - lastControlSend >= controlSendIntervalMs) {
       localStates.forEach(({ state, sourceId }, id) => {
-        multiplayer.send({ type: 'entityControl', id, state, sourceId });
+        const prev = lastSentEntityControlStates.get(id);
+        const dx = (state.x ?? 0) - (prev?.x ?? 0);
+        const dy = (state.y ?? 0) - (prev?.y ?? 0);
+        const dz = (state.z ?? 0) - (prev?.z ?? 0);
+        const moved = ((dx * dx) + (dy * dy) + (dz * dz)) > POSITION_DEADBAND_SQ;
+        const rotDelta = Math.abs(wrapDeltaRad((state.rotation ?? 0) - (prev?.rotation ?? 0)));
+        const changedAction = (state.action ?? null) !== (prev?.action ?? null);
+        if (!prev || moved || rotDelta >= ROTATION_DEADBAND_RAD || changedAction) {
+          lastSentEntityControlStates.set(id, {
+            x: state.x ?? 0,
+            y: state.y ?? 0,
+            z: state.z ?? 0,
+            rotation: state.rotation ?? 0,
+            action: state.action ?? null
+          });
+          queueNetMessage({ type: 'entityControl', id, state, sourceId }, `entityControl:${id}`);
+        } else {
+          netStats.dropped += 1;
+        }
       });
       lastControlSend = now;
     }
@@ -11215,7 +11339,7 @@ async function initCore(runtimeContext) {
       player.model.quaternion.slerp(player.targetQuat, REMOTE_LERP_ALPHA);
     });
 
-    if (now - lastPresenceSend >= PRESENCE_SEND_MS) {
+    if (now - lastPresenceSend >= presenceSendIntervalMs) {
       const localFix = getLatestLocationFix();
       const mapOrigin = getLocalMapOrigin();
       const payload = {
@@ -11258,9 +11382,27 @@ async function initCore(runtimeContext) {
           : (isInventoryItemEquipped('bomb')
             ? 'bomb'
             : (isInventoryItemEquipped('autumnSword') ? 'sword' : null)));
-      multiplayer.send(payload);
+      const dx = payload.x - (lastSentPresenceState.x ?? payload.x);
+      const dy = payload.y - (lastSentPresenceState.y ?? payload.y);
+      const dz = payload.z - (lastSentPresenceState.z ?? payload.z);
+      const moved = ((dx * dx) + (dy * dy) + (dz * dz)) > POSITION_DEADBAND_SQ;
+      const rotated = Math.abs(wrapDeltaRad((payload.rotation ?? 0) - (lastSentPresenceState.rotation ?? 0))) >= ROTATION_DEADBAND_RAD;
+      const actionChanged = payload.action !== lastSentPresenceState.action;
+      if (lastSentPresenceState.x == null || moved || rotated || actionChanged) {
+        queueNetMessage(payload, 'presence:self');
+        lastSentPresenceState.x = payload.x;
+        lastSentPresenceState.y = payload.y;
+        lastSentPresenceState.z = payload.z;
+        lastSentPresenceState.rotation = payload.rotation ?? 0;
+        lastSentPresenceState.action = payload.action ?? null;
+      } else {
+        netStats.dropped += 1;
+      }
       lastPresenceSend = now;
     }
+    applyRuntimeNetworkProfile();
+    flushNetSendQueue();
+    tickNetStats(now);
 
     Object.entries(otherPlayers).forEach(([id, { model, nameLabel }]) => {
       if (!model.visible) {

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -116,6 +116,8 @@ const MERCHANT_DIALOGUE = {
 };
 const ACTION_LOCKED_ATTACKS = ['mutantPunch', 'swordSlash', 'swordSlashLeft', 'swordSpin', 'swordFwdSpin', 'leftPunch', 'mmaKick', 'runningKick', 'roll'];
 const MOBILE_EQUIP_HOLD_MS = 1500;
+const GRAB_MOVE_SEND_INTERVAL_MS = 110;
+const GRAB_MOVE_MIN_DELTA_SQ = 0.02 * 0.02;
 
 export class PlayerControls {
   constructor({
@@ -169,6 +171,8 @@ export class PlayerControls {
     this.isGrabbed = false;
     this.grabberId = null;
     this.externalGrabPos = null;
+    this.lastGrabMoveSentAt = 0;
+    this.lastGrabMoveSentPos = null;
     this.isClimbing = false;
     this.activeClimbArea = null;
 
@@ -3336,7 +3340,28 @@ export class PlayerControls {
     const target = this.grabbedTarget;
     if (target.type === 'player') {
       target.model.position.copy(targetPos);
-      this.multiplayer.send({ type: 'grabMove', from: this.multiplayer.getId(), target: target.id, position: targetPos.toArray() });
+      const now = performance.now();
+      if (now - this.lastGrabMoveSentAt < GRAB_MOVE_SEND_INTERVAL_MS) {
+        return;
+      }
+      const lastPos = this.lastGrabMoveSentPos;
+      if (lastPos) {
+        const dx = targetPos.x - lastPos.x;
+        const dy = targetPos.y - lastPos.y;
+        const dz = targetPos.z - lastPos.z;
+        if (((dx * dx) + (dy * dy) + (dz * dz)) < GRAB_MOVE_MIN_DELTA_SQ) {
+          return;
+        }
+      }
+      const payload = { type: 'grabMove', from: this.multiplayer.getId(), target: target.id, position: targetPos.toArray() };
+      const sendHighFrequency = this.multiplayer?.sendHighFrequency;
+      if (typeof sendHighFrequency === 'function') {
+        sendHighFrequency(payload, 'grabMove', target.id);
+      } else {
+        this.multiplayer.send(payload);
+      }
+      this.lastGrabMoveSentAt = now;
+      this.lastGrabMoveSentPos = targetPos.clone();
     } else if (target.type === 'monster') {
       target.model.position.copy(targetPos);
       target.model.userData.rb?.setTranslation(targetPos, true);
@@ -3386,6 +3411,8 @@ export class PlayerControls {
       this.multiplayer.send({ type: 'grab', from: this.multiplayer.getId(), target: this.grabbedTarget.id, active: false });
     }
     this.grabbedTarget = null;
+    this.lastGrabMoveSentAt = 0;
+    this.lastGrabMoveSentPos = null;
   }
 
   setGrabbed(active, grabberId = null) {


### PR DESCRIPTION
### Motivation

- Reduce network load and improve behavior on low-end or high-latency connections by increasing baseline send intervals and avoiding redundant sends.
- Prevent spamming peers with tiny or unchanged movement updates and enable coalescing of high-frequency messages to keep only the newest payload.
- Provide runtime counters and profile tuning (including measured RTT) for easier runtime observation and tuning.

### Description

- Increased baseline presence cadence and made entity/control intervals runtime-adjustable (`presenceSendIntervalMs`, `entityBroadcastIntervalMs`, `controlSendIntervalMs`) and introduced deadband thresholds (`POSITION_DEADBAND_SQ`, `ROTATION_DEADBAND_RAD`) in `app/bootstrapGameApp.js`.
- Added coalescing queue (`netSendQueue`) and helper functions `queueNetMessage`, `flushNetSendQueue`, and `tickNetStats` that keep only the newest unsent payload per coalesce key and exposed convenience accessors on `multiplayer` (`queueCoalesced`, `sendHighFrequency`, `getNetRuntimeStats`).
- Implemented deadband checks so unchanged `presence` and non-host `entityControl` payloads are skipped (and counted) instead of sent, and switched those sends to use the coalescing queue keys like `presence:self` and `entityControl:<id>`.
- Throttled and delta-checked grab movement sends in `controls/controls.js:updateGrabbedTarget` by adding `GRAB_MOVE_SEND_INTERVAL_MS` and `GRAB_MOVE_MIN_DELTA_SQ`, skipping very small moves and using the coalesced high-frequency send path when available; reset grab send tracking on release.
- Added runtime network counters and diagnostics (`window.netRuntimeStats` and `multiplayer.getNetRuntimeStats()`) that report `msgsPerSecond`, `coalesced`, `dropped`, queue depth, and the active interval values.
- Added runtime profile gating that factors measured RTT/packet lag (via `multiplayer.lastPingMs`/`lastPingAt`) together with device profile to choose low/mid/high networking profiles.

### Testing

- Performed static syntax checks with `node --check app/bootstrapGameApp.js` and `node --check controls/controls.js`, both succeeded.
- Verified the new coalescing/throttle paths are wired into existing send sites (presence, entity control, host entity broadcast, and grabMove) and that runtime stats are populated on `window.netRuntimeStats` during execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fc35eeb08325a38f47e634f088bb)