### PR TITLE
Improve Overpass retry behavior and service worker offline fallback handling

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -187,10 +187,12 @@ self.addEventListener('fetch', (event) => {
           return cachedResponse;
         }
 
-        return fetch(request).then(async (networkResponse) => {
-          await putWithLimits(CORE_CACHE, request, networkResponse, MAX_STATIC_ENTRIES);
-          return networkResponse;
-        });
+        return fetch(request)
+          .then(async (networkResponse) => {
+            await putWithLimits(CORE_CACHE, request, networkResponse, MAX_STATIC_ENTRIES);
+            return networkResponse;
+          })
+          .catch(() => caches.match('/index.html'));
       })
     );
     return;
@@ -225,7 +227,7 @@ self.addEventListener('fetch', (event) => {
         return cachedResponse;
       }
 
-      return staticUpdatePromise;
+      return staticUpdatePromise.then((networkResponse) => networkResponse || Response.error());
     })
   );
 

--- a/requestQueue.js
+++ b/requestQueue.js
@@ -1,6 +1,6 @@
-const DEFAULT_RATE_LIMIT_MS = 2000;
-const DEFAULT_BACKOFF_MS = 500;
-const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RATE_LIMIT_MS = 3500;
+const DEFAULT_BACKOFF_MS = 1250;
+const DEFAULT_MAX_RETRIES = 5;
 const RETRYABLE_STATUS = new Set([429, 504]);
 
 class StaleRequestError extends Error {
@@ -12,6 +12,21 @@ class StaleRequestError extends Error {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseRetryAfterMs(retryAfterHeader) {
+  if (!retryAfterHeader) {
+    return null;
+  }
+  const seconds = Number.parseFloat(retryAfterHeader);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const at = Date.parse(retryAfterHeader);
+  if (Number.isFinite(at)) {
+    return Math.max(0, at - Date.now());
+  }
+  return null;
 }
 
 function haversineMeters(a, b) {
@@ -132,7 +147,10 @@ class RequestQueue {
           if (attempt >= this.maxRetries) {
             break;
           }
-          await sleep(this.backoffMs * 2 ** (attempt - 1));
+          const retryAfterMs = parseRetryAfterMs(response.headers?.get("retry-after"));
+          const expBackoffMs = this.backoffMs * 2 ** (attempt - 1);
+          const jitterMs = Math.floor(Math.random() * 350);
+          await sleep(Math.max(retryAfterMs ?? 0, expBackoffMs) + jitterMs);
           continue;
         }
         throw new Error(`Overpass request failed: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
### Motivation
- Overpass upstream responses were returning `429` under burst traffic and the client retry/rate limits were too aggressive, causing repeated failures; the intent is to reduce pressure on Overpass and be more respectful of upstream retry guidance.
- The service worker sometimes rejected fetch events without returning a valid `Response`, producing uncaught promise rejections in the SW and failing navigation/static fetches, so the intent is to provide safe fallbacks.

### Description
- Increased defaults in `requestQueue.js` to `rateLimitMs = 3500`, `backoffMs = 1250`, and `maxRetries = 5` to throttle client request bursts.
- Added `parseRetryAfterMs` in `requestQueue.js` to respect `Retry-After` headers and used exponential backoff plus a small jitter when retrying failed upstream requests.
- Hardened `public/service-worker.js` so app-shell fetches fallback to a cached `/index.html` when the network fetch fails and static-asset misses resolve to a safe `Response.error()` when neither cache nor network yields a response.
- Kept existing stale-request behavior and exponential backoff on thrown errors while making retry delays more conservative and upstream-aware in `requestQueue.js`.

### Testing
- Ran `npm run build` which completed successfully and produced the production build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24ef150a4833195f7217da5e8c9bb)