### PR TITLE
Make monster and animal drops always home to player

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11140,7 +11140,7 @@ async function initCore(runtimeContext) {
           meatPickups.splice(i, 1);
           continue;
         }
-        if (!playerDead && playerModel.position.distanceTo(pickup.mesh.position) <= getPickupAttractRadius()) {
+        if (!playerDead) {
           attractPickupToPlayer(pickup.mesh, playerModel, PICKUP_ATTRACT_SPEED, frameDelta);
         }
         if (shouldCheckPickups && pickupMeat(pickup)) continue;
@@ -11154,10 +11154,7 @@ async function initCore(runtimeContext) {
         pickup.mesh.rotation.y += 0.02;
         const targetModel = pickup.homeTargetModel || playerModel;
         if (targetModel && !playerDead) {
-          const shouldHome = pickup.homeTargetModel || playerModel.position.distanceTo(pickup.mesh.position) <= getPickupAttractRadius();
-          if (shouldHome) {
-            attractPickupToPlayer(pickup.mesh, targetModel, pickup.homeTargetModel ? MONSTER_DROP_ATTRACT_SPEED : PICKUP_ATTRACT_SPEED, frameDelta);
-          }
+          attractPickupToPlayer(pickup.mesh, targetModel, pickup.homeTargetModel ? MONSTER_DROP_ATTRACT_SPEED : PICKUP_ATTRACT_SPEED, frameDelta);
         }
         if (shouldCheckPickups && pickupZombieBrains(pickup)) continue;
       }
@@ -11175,10 +11172,7 @@ async function initCore(runtimeContext) {
         pickup.mesh.position.y = pickup.mesh.userData.baseY + Math.sin(pickupTime + phase) * 0.08;
         const targetModel = pickup.homeTargetModel || playerModel;
         if (targetModel && !playerDead) {
-          const shouldHome = pickup.homeTargetModel || playerModel.position.distanceTo(pickup.mesh.position) <= getPickupAttractRadius();
-          if (shouldHome) {
-            attractPickupToPlayer(pickup.mesh, targetModel, pickup.homeTargetModel ? MONSTER_DROP_ATTRACT_SPEED : PICKUP_ATTRACT_SPEED, frameDelta);
-          }
+          attractPickupToPlayer(pickup.mesh, targetModel, pickup.homeTargetModel ? MONSTER_DROP_ATTRACT_SPEED : PICKUP_ATTRACT_SPEED, frameDelta);
         }
         if (shouldCheckPickups && pickupSalt(pickup)) continue;
       }


### PR DESCRIPTION
### Motivation
- Ensure monster/animal drop pickups (meat, zombie brains, salt) always drift toward the player so they are collected regardless of distance.

### Description
- Remove the attract-radius gate for meat pickups so they are always attracted to the player when alive and present.
- Make zombie brains and salt pickups always call the homing logic toward their `homeTargetModel` (or player by default) instead of waiting for proximity.
- Leave other pickup categories (wood, apples, mushrooms, etc.) unchanged so the scope is limited to monster/animal drops.

### Testing
- Located and inspected pickup handling with `rg` and confirmed affected blocks in `app/bootstrapGameApp.js` were updated successfully.
- Applied the automated patch with a Python one-liner and verified modifications by printing the updated file region with `nl`/`sed`; the inspections succeeded.
- Ran a repository diff/inspection to confirm only the intended lines in `app/bootstrapGameApp.js` changed and found no other modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2512f8cfc83318eaca960c80e7b57)