### PR TITLE
Reduce Overpass 429s with request dedupe and shared cooldown

### DIFF
--- a/osmClient.js
+++ b/osmClient.js
@@ -24,6 +24,12 @@ const HIGHWAY_TAGS = [
 
 const highwayRegex = HIGHWAY_TAGS.join("|");
 
+function buildDedupeKey(lat, lon, radiusMeters) {
+  const latBucket = lat.toFixed(4);
+  const lonBucket = lon.toFixed(4);
+  return `${latBucket}:${lonBucket}:${Math.round(radiusMeters)}`;
+}
+
 function buildOverpassQuery(lat, lon, radiusMeters) {
   return [
     "[out:json][timeout:10];",
@@ -69,6 +75,7 @@ export async function fetchOSMData(lat, lon, radiusMeters, options = {}) {
     lat,
     lon,
     staleDistanceMeters,
+    dedupeKey: buildDedupeKey(lat, lon, radiusMeters),
     requestFn: () => performOverpassRequest(new URLSearchParams({ data: query })),
   });
 

--- a/requestQueue.js
+++ b/requestQueue.js
@@ -1,4 +1,4 @@
-const DEFAULT_RATE_LIMIT_MS = 3500;
+const DEFAULT_RATE_LIMIT_MS = 5000;
 const DEFAULT_BACKOFF_MS = 1250;
 const DEFAULT_MAX_RETRIES = 5;
 const RETRYABLE_STATUS = new Set([429, 504]);
@@ -55,10 +55,12 @@ class RequestQueue {
     this.queue = [];
     this.processing = false;
     this.lastRequestStartedAt = 0;
+    this.globalNextAllowedAt = 0;
     this.latestLocation = null;
+    this.pendingByKey = new Map();
   }
 
-  enqueue({ lat, lon, staleDistanceMeters, requestFn }) {
+  enqueue({ lat, lon, staleDistanceMeters, requestFn, dedupeKey = null }) {
     if (typeof requestFn !== "function") {
       return Promise.reject(new TypeError("requestFn must be a function."));
     }
@@ -67,17 +69,33 @@ class RequestQueue {
       ? { lat, lon }
       : this.latestLocation;
 
-    return new Promise((resolve, reject) => {
+    if (dedupeKey && this.pendingByKey.has(dedupeKey)) {
+      return this.pendingByKey.get(dedupeKey);
+    }
+
+    const promise = new Promise((resolve, reject) => {
       this.queue.push({
         lat,
         lon,
         staleDistanceMeters,
         requestFn,
+        dedupeKey,
         resolve,
         reject,
       });
       this.processQueue();
     });
+
+    if (dedupeKey) {
+      this.pendingByKey.set(dedupeKey, promise);
+      promise.finally(() => {
+        if (this.pendingByKey.get(dedupeKey) === promise) {
+          this.pendingByKey.delete(dedupeKey);
+        }
+      });
+    }
+
+    return promise;
   }
 
   async processQueue() {
@@ -118,7 +136,9 @@ class RequestQueue {
 
   async waitForRateLimit() {
     const elapsed = Date.now() - this.lastRequestStartedAt;
-    const waitMs = Math.max(0, this.rateLimitMs - elapsed);
+    const baseWaitMs = Math.max(0, this.rateLimitMs - elapsed);
+    const globalWaitMs = Math.max(0, this.globalNextAllowedAt - Date.now());
+    const waitMs = Math.max(baseWaitMs, globalWaitMs);
     if (waitMs > 0) {
       await sleep(waitMs);
     }
@@ -150,7 +170,9 @@ class RequestQueue {
           const retryAfterMs = parseRetryAfterMs(response.headers?.get("retry-after"));
           const expBackoffMs = this.backoffMs * 2 ** (attempt - 1);
           const jitterMs = Math.floor(Math.random() * 350);
-          await sleep(Math.max(retryAfterMs ?? 0, expBackoffMs) + jitterMs);
+          const cooldownMs = Math.max(retryAfterMs ?? 0, expBackoffMs) + jitterMs;
+          this.globalNextAllowedAt = Math.max(this.globalNextAllowedAt, Date.now() + cooldownMs);
+          await sleep(cooldownMs);
           continue;
         }
         throw new Error(`Overpass request failed: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
### Motivation
- Reduce sustained/duplicate Overpass requests that cause `429 Too Many Requests` responses from upstream services.
- Prevent identical in-flight map queries from issuing duplicate POSTs and wasting rate-limited capacity.
- Ensure retry/backoff signals (including `Retry-After`) apply to the whole queue so subsequent requests back off as well.

### Description
- Increased the default per-request spacing from `3500`ms to `5000`ms in `requestQueue.js` to lower steady request pressure.
- Added optional `dedupeKey` to `RequestQueue.enqueue(...)` and a `pendingByKey` map so in-flight requests with the same key return the same promise instead of issuing another request.
- Introduced `globalNextAllowedAt` and updated `waitForRateLimit()` to respect a shared cooldown, and set `globalNextAllowedAt` when retryable responses occur using `Retry-After`, exponential backoff, and jitter.
- Added `buildDedupeKey(...)` to `osmClient.js` (rounding lat/lon to 4 decimal places and rounding radius) and wired the dedupe key into `enqueue(...)` so nearby duplicate fetches collapse.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2532c8d1c8331aa1726e7cc122fd3)