### PR TITLE
Only auto-equip pickup when target hand is free

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -5812,7 +5812,13 @@ async function initCore(runtimeContext) {
         } else {
           addToInventory(itemId, pickup.quantity);
         }
-        equipInventoryItem(itemId);
+        const pickupHand = getInventoryItemHand(itemId);
+        const equippedInPickupHand = pickupHand
+          ? getEquippedInventoryItemIdForHand(pickupHand)
+          : null;
+        if (!equippedInPickupHand) {
+          equipInventoryItem(itemId);
+        }
         const index = droppedWeaponPickups.indexOf(pickup);
         if (index !== -1) {
           droppedWeaponPickups.splice(index, 1);


### PR DESCRIPTION
### Motivation
- Prevent involuntary swapping of a player's equipped item when picking up an item that uses the same hand by only auto-equipping pickups when that hand is currently free.

### Description
- Update the pickup collection logic in `app/bootstrapGameApp.js` to check `getInventoryItemHand(itemId)` and `getEquippedInventoryItemIdForHand(...)` and only call `equipInventoryItem(itemId)` if the target hand has no equipped item.

### Testing
- Ran `node --check app/bootstrapGameApp.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f254493d5c83319d2433e0d910c1fd)