### PR TITLE
Fix TDZ error for monster spawn helpers

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3582,7 +3582,7 @@ async function initCore(runtimeContext) {
   }
 
 
-  const getMonsterGroundOffset = (monsterLikeOrLevel = null) => {
+  function getMonsterGroundOffset(monsterLikeOrLevel = null) {
     if (monsterLikeOrLevel && Number.isFinite(monsterLikeOrLevel.sizeScale)) {
       return MONSTER_SPAWN_GROUND_OFFSET * Math.max(0.75, monsterLikeOrLevel.sizeScale);
     }
@@ -3592,9 +3592,9 @@ async function initCore(runtimeContext) {
       return MONSTER_SPAWN_GROUND_OFFSET * Math.max(0.75, estimatedScale);
     }
     return MONSTER_SPAWN_GROUND_OFFSET;
-  };
+  }
 
-  const getMonsterSpawnPosition = (monsterLikeOrLevel = null) => {
+  function getMonsterSpawnPosition(monsterLikeOrLevel = null) {
     const groundOffset = getMonsterGroundOffset(monsterLikeOrLevel);
     for (let attempt = 0; attempt < MONSTER_SPAWN_ATTEMPTS; attempt += 1) {
       const angle = Math.random() * Math.PI * 2;
@@ -3616,7 +3616,7 @@ async function initCore(runtimeContext) {
     const fallbackY = getSpawnY(fallback.x, fallback.z, groundOffset, { allowOnBuildings: true });
     fallback.y = Number.isFinite(fallbackY) ? fallbackY : fallback.y;
     return fallback;
-  };
+  }
 
   const disposeWeaponMesh = (mesh) => {
     if (!mesh) return;


### PR DESCRIPTION
### Motivation
- Avoid a runtime `ReferenceError: Cannot access 'Gl' before initialization` caused by temporal-dead-zone ordering when helpers are referenced from minified bundles.

### Description
- Convert `getMonsterGroundOffset` from a `const` arrow function to a hoisted `function` declaration in `app/bootstrapGameApp.js`.
- Convert `getMonsterSpawnPosition` from a `const` arrow function to a hoisted `function` declaration in `app/bootstrapGameApp.js`.
- These changes ensure the helpers are hoisted and cannot be referenced before initialization in bundled/minified output.

### Testing
- Ran `npm run build` and the build completed successfully.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f256274bd08331bb078c8c8ae13b47)