### PR TITLE
Recognize mesh-based monsters for engaged camera lock

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3489,6 +3489,13 @@ export class PlayerControls {
     const resolveMonsterActor = (monster) => {
       if (!monster || typeof monster !== 'object') return null;
       if (monster.model?.position) return monster;
+      if (monster.mesh?.position) {
+        return {
+          ...monster,
+          model: monster.mesh,
+          isDead: monster.isDead ?? monster.dead ?? monster.model?.userData?.mode === 'dead'
+        };
+      }
       if (monster.character?.model?.position) return monster.character;
       if (monster.monster?.model?.position) return monster.monster;
       if (monster.entity?.model?.position) return monster.entity;


### PR DESCRIPTION
### Motivation
- The engaged camera lock could ignore some monsters when they expose `mesh.position` instead of `model.position`, causing the first encountered monster to not become the lock-on target. 
- Normalize heterogeneous monster shapes so the existing distance and dead-state checks used by the camera can operate consistently.

### Description
- Update `PlayerControls.updateEngagedMode()` in `controls/controls.js` to detect monsters that expose `mesh.position` and normalize them into the expected actor shape. 
- For mesh-based monsters return a synthetic actor with `model` set to `monster.mesh` and `isDead` resolved via `monster.isDead ?? monster.dead ?? monster.model?.userData?.mode === 'dead'`. 
- This keeps the rest of the engaged-target selection, distance calculation, and dead filtering unchanged while ensuring mesh-backed monsters are considered.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2681671e48331b94ff4b4a0fb09f2)