### PR TITLE
Use full 3D distance for apple pickup so vertical separation matters

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -5370,11 +5370,8 @@ async function initCore(runtimeContext) {
       const applePosition = pickup.mesh.getWorldPosition
         ? pickup.mesh.getWorldPosition(tempTreePosition)
         : pickup.mesh.position;
-      const horizontalDistance = Math.hypot(
-        playerPosition.x - applePosition.x,
-        playerPosition.z - applePosition.z
-      );
-      if (horizontalDistance > APPLE_PICKUP_RADIUS) return false;
+      const appleDistance = playerPosition.distanceTo(applePosition);
+      if (appleDistance > APPLE_PICKUP_RADIUS) return false;
     }
     addToInventory(pickup.id, 1);
     disposeApplePickup(pickup);


### PR DESCRIPTION
### Motivation
- Apple pickups were being collected when the player was horizontally near the trunk even if they were far below the apples, so collection should require closeness in height as well as horizontal distance.

### Description
- Changed the `pickupApple` distance check in `app/bootstrapGameApp.js` to use the full 3D distance (`playerPosition.distanceTo(applePosition)`) instead of a horizontal-only `Math.hypot` calculation, preserving the existing pickup radius constant and behavior otherwise.

### Testing
- No automated tests were run; the change was validated by inspecting the updated `pickupApple` logic and verifying the diff to ensure only the distance computation was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3746f595c833386e75bb09c74f49e)