### PR TITLE
Trigger tree cutting for all sword attacks

### DIFF
--- a/items/melee.js
+++ b/items/melee.js
@@ -127,7 +127,10 @@ export function updateMeleeAttacks({
             : attackName,
         ['melee']
       );
-      if (attackName === 'swordSlash' && attacker.id === 'local') {
+      if (attacker.id === 'local'
+        && attacker.model.userData?.equippedWeaponType === 'sword'
+        && Array.isArray(cfg.types)
+        && cfg.types.includes('cut')) {
         onSwordHit?.({ attacker, range: cfg.range });
       }
       if (attackName === 'mutantPunch'


### PR DESCRIPTION
### Motivation
- Tree cutting only fired for the `swordSlash` animation even though multiple sword attacks are tagged with the `cut` type, so other sword animations could not cut trees.

### Description
- Change `updateMeleeAttacks` in `items/melee.js` to call `onSwordHit` for any local attacker with `equippedWeaponType === 'sword'` when the attack config `types` includes `'cut'`, instead of only when `attackName === 'swordSlash'`.

### Testing
- Ran a production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f374c9f0c083338321470800d29dbd)