### PR TITLE
Add distance unit preference toggle and shared distance formatting

### DIFF
--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
+import { formatDistanceForDisplay, getDistanceUnitPreference } from '../distanceUnits.js';
 
 const TAB_KEY = 'settings:lastTab';
 
@@ -63,11 +64,7 @@ function formatTimestamp(ts) {
   return date.toLocaleString();
 }
 
-function formatDistance(distance) {
-  if (typeof distance !== 'number' || Number.isNaN(distance)) return '—';
-  if (distance < 1000) return `${distance.toFixed(0)} m`;
-  return `${(distance / 1000).toFixed(2)} km`;
-}
+function formatDistance(distance) { return formatDistanceForDisplay(distance); }
 
 function formatCoordinate(value) {
   if (typeof value !== 'number' || Number.isNaN(value)) return '—';
@@ -619,6 +616,18 @@ function buildDisplayPanel() {
     performanceSelect.appendChild(option);
   });
   performanceGroup.append(performanceLabel, performanceSelect);
+  const unitsGroup = createElement('div', 'settings-field');
+  const unitsLabel = createElement('label', 'settings-label', 'Distance Units');
+  unitsLabel.setAttribute('for', 'settings-distance-units');
+  const unitsSelect = createElement('select', 'settings-select');
+  unitsSelect.id = 'settings-distance-units';
+  [{ value: 'km', label: 'Kilometers / meters' }, { value: 'miles', label: 'Miles / feet' }].forEach(({ value, label }) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    unitsSelect.appendChild(option);
+  });
+  unitsGroup.append(unitsLabel, unitsSelect);
 
   const createRangeField = ({ id, label, min, max, step }) => {
     const field = createElement('div', 'settings-field');
@@ -680,6 +689,7 @@ function buildDisplayPanel() {
   panelEl.append(
     modeGroup,
     performanceGroup,
+    unitsGroup,
     ambientField.field,
     directionalField.field,
     groundField.field,
@@ -691,6 +701,7 @@ function buildDisplayPanel() {
   elements.displayFields = {
     modeSelect,
     performanceSelect,
+    unitsSelect,
     sliders: {
       ambientIntensity: ambientField.input,
       directionalIntensity: directionalField.input,
@@ -1433,6 +1444,13 @@ function bindEvents() {
       context.appState?.setDisplaySetting?.('performanceMode', value);
     });
   }
+  if (elements.displayFields?.unitsSelect) {
+    elements.displayFields.unitsSelect.addEventListener('change', (event) => {
+      context.appState?.setDistanceUnitPreference?.(event.target.value);
+      window.dispatchEvent(new Event('distance-unit-changed'));
+      update();
+    });
+  }
 
   if (elements.displayFields?.sliders) {
     Object.entries(elements.displayFields.sliders).forEach(([key, slider]) => {
@@ -1832,6 +1850,9 @@ export function updateUI() {
       if (elements.displayFields.performanceSelect.value !== displaySettings.performanceMode) {
         elements.displayFields.performanceSelect.value = displaySettings.performanceMode;
       }
+    }
+    if (elements.displayFields.unitsSelect) {
+      elements.displayFields.unitsSelect.value = getDistanceUnitPreference();
     }
     Object.entries(elements.displayFields.sliders || {}).forEach(([key, slider]) => {
       const value = displaySettings?.[key];

--- a/distanceUnits.js
+++ b/distanceUnits.js
@@ -1,0 +1,34 @@
+export const DISTANCE_UNITS_KEY = 'display:distanceUnit';
+
+export function getDistanceUnitPreference() {
+  const value = localStorage.getItem(DISTANCE_UNITS_KEY);
+  return value === 'miles' ? 'miles' : 'km';
+}
+
+export function setDistanceUnitPreference(unit) {
+  const normalized = unit === 'miles' ? 'miles' : 'km';
+  localStorage.setItem(DISTANCE_UNITS_KEY, normalized);
+  return normalized;
+}
+
+export function formatDistanceForDisplay(distanceMeters) {
+  if (typeof distanceMeters !== 'number' || Number.isNaN(distanceMeters)) return '—';
+  const unit = getDistanceUnitPreference();
+  if (unit === 'miles') {
+    const miles = distanceMeters / 1609.344;
+    if (miles >= 0.1) return `${miles.toFixed(2)} mi`;
+    const feet = distanceMeters * 3.28084;
+    return `${feet.toFixed(0)} ft`;
+  }
+  if (distanceMeters < 1000) return `${distanceMeters.toFixed(0)} m`;
+  return `${(distanceMeters / 1000).toFixed(2)} km`;
+}
+
+export function formatLongDistance(distanceMeters) {
+  if (typeof distanceMeters !== 'number' || Number.isNaN(distanceMeters)) return '—';
+  const unit = getDistanceUnitPreference();
+  if (unit === 'miles') {
+    return `${(distanceMeters / 1609.344).toFixed(2)} miles`;
+  }
+  return `${(distanceMeters / 1000).toFixed(2)} km`;
+}


### PR DESCRIPTION
### Motivation
- Provide a single, persistent user preference for distance units (kilometers/meters or miles/feet) so displayed distances across the UI are consistent.
- Centralize display-only formatting so backend code can continue using meters for calculations while the UI shows the preferred units.

### Description
- Added a new utility module `distanceUnits.js` which exposes `getDistanceUnitPreference`, `setDistanceUnitPreference`, `formatDistanceForDisplay`, and `formatLongDistance`, and persists the preference in `localStorage` under `display:distanceUnit`.
- Updated `controls/settingsPanel.js` to import the new formatter and replaced the local `formatDistance` with a wrapper that calls `formatDistanceForDisplay`.
- Added a new "Distance Units" selector to `Settings → Display` (`unitsSelect`) with options for `Kilometers / meters` and `Miles / feet`, and wired its `change` handler to persist the preference via `context.appState?.setDistanceUnitPreference` and emit a `distance-unit-changed` event.
- Initialized the selector value from the preference when the settings UI updates and exposed the select element in `elements.displayFields` so the UI reflects the saved choice.

### Testing
- Verified the new module can be imported by Node with `node -e "import('./distanceUnits.js').then(()=>console.log('ok'))"`, which printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f377713cc083339260e48795e238c4)