### PR TITLE
Track GPS walking miles and show post-login walking summary

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -115,6 +115,7 @@ import {
   saveQuestState,
   saveAchievementState,
   saveSleepTimestamp,
+  saveWalkingStats,
   saveStatsImmediate,
   saveStatsThrottled,
   initMonsterPersistence,
@@ -299,6 +300,37 @@ const PERFORMANCE_PROFILE_CAPS = {
 
 function metersPerDegreeLon(latDeg) {
   return 111_412.84 * Math.cos((latDeg * Math.PI) / 180);
+}
+
+function getUtcDateString(timestampMs) {
+  return new Date(timestampMs).toISOString().slice(0, 10);
+}
+
+function toMiles(meters) {
+  return meters / 1609.344;
+}
+
+function getStartOfUtcWeek(timestampMs) {
+  const d = new Date(timestampMs);
+  const day = d.getUTCDay();
+  const diff = (day + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - diff);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function mergeWalkingStats(walkingStats) {
+  const totalMilesRaw = Number(walkingStats?.totalMiles);
+  const totalMiles = Number.isFinite(totalMilesRaw) && totalMilesRaw >= 0 ? totalMilesRaw : 0;
+  const sourceDaily = walkingStats?.dailyMiles && typeof walkingStats.dailyMiles === 'object' ? walkingStats.dailyMiles : {};
+  const dailyMiles = {};
+  for (const [date, miles] of Object.entries(sourceDaily)) {
+    const parsed = Number(miles);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    if (!Number.isFinite(parsed) || parsed <= 0) continue;
+    dailyMiles[date] = parsed;
+  }
+  return { totalMiles, dailyMiles, updatedAt: Number.isFinite(walkingStats?.updatedAt) ? walkingStats.updatedAt : null };
 }
 
 function distanceMeters(lat1, lon1, lat2, lon2) {
@@ -4102,6 +4134,60 @@ async function initCore(runtimeContext) {
   const offlineDecay = applyOfflineHungerDecay(playerProfile);
   playerProfile.stats = offlineDecay.stats;
   let lastStatUpdateAt = offlineDecay.lastStatUpdateAt;
+
+  const walkingState = mergeWalkingStats(playerProfile.walkingStats);
+
+  function showWalkingSummaryOverlay() {
+    const today = Date.now();
+    const startWeek = getStartOfUtcWeek(today);
+    let milesThisWeek = 0;
+    let firstDayTs = null;
+    for (const [date, miles] of Object.entries(walkingState.dailyMiles)) {
+      const ts = Date.parse(`${date}T00:00:00.000Z`);
+      if (!Number.isFinite(ts)) continue;
+      if (firstDayTs == null || ts < firstDayTs) firstDayTs = ts;
+      if (ts >= startWeek) milesThisWeek += miles;
+    }
+    const todayMiles = walkingState.dailyMiles[getUtcDateString(today)] || 0;
+    const weeks = firstDayTs == null ? 1 : Math.max(1, Math.ceil((today - firstDayTs + 1) / (7 * 24 * 60 * 60 * 1000)));
+    const avgWeekly = walkingState.totalMiles / weeks;
+
+    const overlay = document.createElement('div');
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.62);z-index:12000;display:flex;align-items:center;justify-content:center;padding:20px;';
+    const panel = document.createElement('div');
+    panel.style.cssText = 'position:relative;width:min(460px,100%);background:#111;color:#fff;border:2px solid #39f;border-radius:12px;padding:20px 18px 18px;font-family:Arial,sans-serif;';
+    const exitBtn = document.createElement('button');
+    exitBtn.textContent = '✕';
+    exitBtn.setAttribute('aria-label', 'Exit summary');
+    exitBtn.style.cssText = 'position:absolute;right:10px;top:8px;background:transparent;border:0;color:#fff;font-size:22px;cursor:pointer;';
+    const title = document.createElement('h2');
+    title.textContent = 'Walking Summary';
+    title.style.margin = '0 0 14px 0';
+    const metrics = [
+      ['Total miles walked', walkingState.totalMiles],
+      ['Average miles walked per week', avgWeekly],
+      ['Miles walked this week', milesThisWeek],
+      ['Miles walked today', todayMiles]
+    ];
+    const list = document.createElement('div');
+    metrics.forEach(([label, value]) => {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;justify-content:space-between;gap:12px;padding:7px 0;border-bottom:1px solid rgba(255,255,255,.16);';
+      row.innerHTML = `<span>${label}</span><strong>${Number(value).toFixed(2)}</strong>`;
+      list.appendChild(row);
+    });
+    const okBtn = document.createElement('button');
+    okBtn.textContent = 'Ok';
+    okBtn.style.cssText = 'margin-top:16px;width:100%;padding:10px;border-radius:8px;border:1px solid #39f;background:#1f3cff;color:#fff;font-weight:700;cursor:pointer;';
+    const close = () => overlay.remove();
+    okBtn.addEventListener('click', close);
+    exitBtn.addEventListener('click', close);
+    panel.append(exitBtn, title, list, okBtn);
+    overlay.appendChild(panel);
+    document.body.appendChild(overlay);
+  }
+
+  showWalkingSummaryOverlay();
 
   const statsState = {
     health: playerProfile.stats.health,
@@ -9732,6 +9818,25 @@ async function initCore(runtimeContext) {
   const locationProvider = createLocationProvider({
     onUpdate: (location) => {
       window.latestLocation = location;
+      const prevLat = locationState.lat;
+      const prevLon = locationState.lon;
+      const prevTs = Number.isFinite(locationState.timestamp) ? locationState.timestamp : null;
+      if (Number.isFinite(prevLat) && Number.isFinite(prevLon) && prevTs != null) {
+        const elapsedMs = Math.max(0, location.timestamp - prevTs);
+        const movedMeters = distanceMeters(prevLat, prevLon, location.lat, location.lon);
+        const maxReasonableMeters = Math.max(30, elapsedMs * (3.2 / 1000));
+        if (Number.isFinite(movedMeters) && movedMeters > 1 && movedMeters <= maxReasonableMeters) {
+          const miles = toMiles(movedMeters);
+          walkingState.totalMiles += miles;
+          const dayKey = getUtcDateString(location.timestamp);
+          walkingState.dailyMiles[dayKey] = (walkingState.dailyMiles[dayKey] || 0) + miles;
+          walkingState.updatedAt = Date.now();
+          if (profileNameKey) {
+            void saveWalkingStats(profileNameKey, walkingState);
+          }
+        }
+      }
+
       friendlyNpcManager?.recordGpsTravel?.({
         lat: location.lat,
         lon: location.lon,

--- a/features/persistenceFeature.js
+++ b/features/persistenceFeature.js
@@ -10,6 +10,7 @@ export {
   saveQuestState,
   saveAchievementState,
   saveSleepTimestamp,
+  saveWalkingStats,
   saveStatsImmediate,
   saveStatsThrottled
 } from '../playerProfile.js';

--- a/playerProfile.js
+++ b/playerProfile.js
@@ -50,6 +50,11 @@ const DEFAULT_ACHIEVEMENTS = {
   trackers: {},
   achievements: {}
 };
+const DEFAULT_WALKING_STATS = {
+  totalMiles: 0,
+  dailyMiles: {},
+  updatedAt: null
+};
 
 const lastWriteByName = new Map();
 const pendingStatsByName = new Map();
@@ -95,6 +100,7 @@ function buildProfile(name) {
     spells: { ...DEFAULT_SPELLS },
     quests: mergeQuests(DEFAULT_QUESTS),
     achievements: mergeAchievements(DEFAULT_ACHIEVEMENTS),
+    walkingStats: { ...DEFAULT_WALKING_STATS },
     characterModel: null,
     sleepStartedAt: null,
     lastStatUpdateAt: now,
@@ -116,6 +122,21 @@ function mergeQuests(quests) {
   };
 }
 
+
+function mergeWalkingStats(walkingStats) {
+  const totalMilesRaw = Number(walkingStats?.totalMiles);
+  const totalMiles = Number.isFinite(totalMilesRaw) && totalMilesRaw >= 0 ? totalMilesRaw : 0;
+  const sourceDaily = walkingStats?.dailyMiles && typeof walkingStats.dailyMiles === 'object' ? walkingStats.dailyMiles : {};
+  const dailyMiles = {};
+  for (const [date, miles] of Object.entries(sourceDaily)) {
+    const parsed = Number(miles);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) continue;
+    if (!Number.isFinite(parsed) || parsed <= 0) continue;
+    dailyMiles[date] = parsed;
+  }
+  const updatedAt = Number.isFinite(walkingStats?.updatedAt) ? walkingStats.updatedAt : null;
+  return { totalMiles, dailyMiles, updatedAt };
+}
 
 function mergeAchievements(achievements) {
   const trackers = achievements?.trackers && typeof achievements.trackers === 'object'
@@ -200,6 +221,7 @@ async function loadProfileForName(profileRef, trimmedName) {
   const mergedQuests = mergeQuests(profile.quests);
   const mergedAchievements = mergeAchievements(profile.achievements);
   const mergedCharacterModel = typeof profile.characterModel === 'string' ? profile.characterModel : null;
+  const mergedWalkingStats = mergeWalkingStats(profile.walkingStats);
   const statsMissing = Object.keys(DEFAULT_STATS).some(key => profile.stats?.[key] == null);
   const hasLastStatUpdateAt = Number.isFinite(profile.lastStatUpdateAt);
   const inventoryMissing = profile.inventory == null;
@@ -211,7 +233,8 @@ async function loadProfileForName(profileRef, trimmedName) {
   const questsMissing = profile.quests == null;
   const achievementsMissing = profile.achievements == null;
   const characterModelMissing = profile.characterModel !== mergedCharacterModel;
-  if (statsMissing || !hasLastStatUpdateAt || inventoryMissing || homeStorageMissing || customizationMissing || spellsMissing || questsMissing || achievementsMissing || characterModelMissing) {
+  const walkingStatsMissing = profile.walkingStats == null;
+  if (statsMissing || !hasLastStatUpdateAt || inventoryMissing || homeStorageMissing || customizationMissing || spellsMissing || questsMissing || achievementsMissing || characterModelMissing || walkingStatsMissing) {
     const updatePayload = { updatedAt: Date.now() };
     if (statsMissing) {
       updatePayload.stats = mergedStats;
@@ -261,6 +284,12 @@ async function loadProfileForName(profileRef, trimmedName) {
     } else {
       profile.characterModel = mergedCharacterModel;
     }
+    if (walkingStatsMissing) {
+      updatePayload.walkingStats = mergedWalkingStats;
+      profile.walkingStats = mergedWalkingStats;
+    } else {
+      profile.walkingStats = mergedWalkingStats;
+    }
     if (!hasLastStatUpdateAt) {
       updatePayload.lastStatUpdateAt = Date.now();
       profile.lastStatUpdateAt = updatePayload.lastStatUpdateAt;
@@ -275,6 +304,7 @@ async function loadProfileForName(profileRef, trimmedName) {
     profile.quests = mergedQuests;
     profile.achievements = mergedAchievements;
     profile.characterModel = mergedCharacterModel;
+    profile.walkingStats = mergedWalkingStats;
   }
 
   console.log('✅ Loaded profile for', trimmedName);
@@ -636,6 +666,18 @@ export async function saveAchievementState(nameKey, achievementState) {
     });
   } catch (error) {
     console.error('Failed to save achievement state for', nameKey, error);
+  }
+}
+
+export async function saveWalkingStats(nameKey, walkingStats) {
+  if (!nameKey) return;
+  try {
+    await update(ref(db, `profiles/${nameKey}`), {
+      walkingStats: mergeWalkingStats(walkingStats),
+      updatedAt: Date.now()
+    });
+  } catch (error) {
+    console.error('Failed to save walking stats for', nameKey, error);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide persistent tracking of real-world distance walked using GPS fixes (not in-world movement) so players can see their walking history. 
- Surface a simple summary to players when the game starts showing total/weekly/daily miles to encourage engagement. 
- Ensure data is sanitized and persisted on player profiles to survive sessions and migrations.

### Description
- Added persistent `walkingStats` to player profiles with a default shape and a `mergeWalkingStats` sanitizer/merge helper in `playerProfile.js` so old profiles are backfilled safely. 
- Implemented `saveWalkingStats(nameKey, walkingStats)` in `playerProfile.js` and re-exported it from `features/persistenceFeature.js` for runtime persistence. 
- Track GPS distance deltas in `app/bootstrapGameApp.js` by comparing consecutive location fixes, filtering unreasonable jumps, converting meters to miles, updating `walkingState.totalMiles` and per-day buckets (`dailyMiles`), and calling `saveWalkingStats` when a profile key exists. 
- Added a post-login “Walking Summary” overlay (displayed at game start) that shows total miles, average miles per week, miles this week, and miles today, with a top-right Exit button and a bottom Ok button that both dismiss the modal.

### Testing
- Ran the production build with `npm run -s build`, which completed successfully (vite build output produced). 
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3795d82348333b6573c29cef3b09a)