### PR TITLE
Fix distance unit preference persistence and unit displays

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -102,6 +102,7 @@ import { appContext } from '../src/runtime/appContext.js';
 import { getAttackTypes } from '../items/melee.js';
 import { exposeDebugGlobals } from '../src/runtime/exposeDebugGlobals.js';
 import { claimAchievement, getAchievementView, mergeAchievementState, recordAchievementProgress } from '../achievements.js';
+import { getDistanceUnitPreference, setDistanceUnitPreference } from '../distanceUnits.js';
 
 import {
   clearStoredPin,
@@ -4163,11 +4164,14 @@ async function initCore(runtimeContext) {
     const title = document.createElement('h2');
     title.textContent = 'Walking Summary';
     title.style.margin = '0 0 14px 0';
+    const distanceUnit = getDistanceUnitPreference();
+    const convertMilesToDisplay = (miles) => (distanceUnit === 'miles' ? miles : miles * 1.609344);
+    const unitLabel = distanceUnit === 'miles' ? 'miles' : 'km';
     const metrics = [
-      ['Total miles walked', walkingState.totalMiles],
-      ['Average miles walked per week', avgWeekly],
-      ['Miles walked this week', milesThisWeek],
-      ['Miles walked today', todayMiles]
+      [`Total ${unitLabel} walked`, convertMilesToDisplay(walkingState.totalMiles)],
+      [`Average ${unitLabel} walked per week`, convertMilesToDisplay(avgWeekly)],
+      [`${distanceUnit === 'miles' ? 'Miles' : 'Km'} walked this week`, convertMilesToDisplay(milesThisWeek)],
+      [`${distanceUnit === 'miles' ? 'Miles' : 'Km'} walked today`, convertMilesToDisplay(todayMiles)]
     ];
     const list = document.createElement('div');
     metrics.forEach(([label, value]) => {
@@ -10559,6 +10563,8 @@ async function initCore(runtimeContext) {
     getDisplaySettings: () => ({ ...displaySettings }),
     setDisplayMode: (mode) => setDisplayMode(mode),
     setDisplaySetting: (key, value) => setDisplaySetting(key, value),
+    getDistanceUnitPreference: () => getDistanceUnitPreference(),
+    setDistanceUnitPreference: (unit) => setDistanceUnitPreference(unit),
     resetWorldOrigin: () => {
       resetWorldOrigin();
       locationState.originLat = null;

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
-import { formatDistanceForDisplay, getDistanceUnitPreference } from '../distanceUnits.js';
+import { formatDistanceForDisplay, getDistanceUnitPreference, setDistanceUnitPreference } from '../distanceUnits.js';
 
 const TAB_KEY = 'settings:lastTab';
 
@@ -73,7 +73,10 @@ function formatCoordinate(value) {
 
 function formatMeters(value) {
   if (typeof value !== 'number' || Number.isNaN(value)) return '—';
-  return value.toFixed(2);
+  if (getDistanceUnitPreference() === 'miles') {
+    return `${(value * 3.28084).toFixed(2)} ft`;
+  }
+  return `${value.toFixed(2)} m`;
 }
 
 function formatStatValue(key, value) {
@@ -1446,7 +1449,11 @@ function bindEvents() {
   }
   if (elements.displayFields?.unitsSelect) {
     elements.displayFields.unitsSelect.addEventListener('change', (event) => {
-      context.appState?.setDistanceUnitPreference?.(event.target.value);
+      const selectedUnit = event.target.value;
+      const appliedUnit = context.appState?.setDistanceUnitPreference?.(selectedUnit) ?? setDistanceUnitPreference(selectedUnit);
+      if (elements.displayFields?.unitsSelect) {
+        elements.displayFields.unitsSelect.value = appliedUnit;
+      }
       window.dispatchEvent(new Event('distance-unit-changed'));
       update();
     });


### PR DESCRIPTION
### Motivation
- The Display tab's distance unit selector reverted to `km` after selecting `miles`, so the preference was not reliably persisted or reflected in the UI.
- Developer tab position readouts were always showing meters even when the display setting was miles, causing inconsistency.
- The Walking Summary overlay shown at login always labeled and showed miles rather than following the selected unit preference.

### Description
- Added `getDistanceUnitPreference` / `setDistanceUnitPreference` accessors into the shared `appState` so UI and other systems can read/write the same preference (`app/bootstrapGameApp.js`).
- Updated the Display settings UI to call `context.appState?.setDistanceUnitPreference` and fall back to `setDistanceUnitPreference` locally, then reapply the normalized value to the select control and dispatch the existing `distance-unit-changed` event (`controls/settingsPanel.js`).
- Updated developer position formatting by changing `formatMeters` to render `m` in metric mode and `ft` in miles mode (`controls/settingsPanel.js`).
- Updated the login `Walking Summary` overlay to convert labels and values to the active unit (miles or kilometers) using `getDistanceUnitPreference` and appropriate conversion logic (`app/bootstrapGameApp.js`).

### Testing
- Built the production bundle with `npm run build`, which completed successfully.
- No automated unit tests were modified or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37c25f31c83338ddf633e6df11cb9)