### PR TITLE
Fix sword spin charge hit timing and attack indicator sync

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -7678,10 +7678,11 @@ async function initCore(runtimeContext) {
       : activeAttack.name;
     const cfg = ATTACKS[attackName];
     if (!cfg) return;
+    const attackCfg = activeAttack.overrides ? { ...cfg, ...activeAttack.overrides } : cfg;
 
     const elapsed = Date.now() - activeAttack.start;
-    const visualWindowMs = Math.max(cfg.hitWindow * ATTACK_WINDOW_VISUAL_MULTIPLIER, 220);
-    const inHitWindow = elapsed >= cfg.hitTime && elapsed <= cfg.hitTime + visualWindowMs;
+    const visualWindowMs = Math.max(attackCfg.hitWindow * ATTACK_WINDOW_VISUAL_MULTIPLIER, 220);
+    const inHitWindow = elapsed >= attackCfg.hitTime && elapsed <= attackCfg.hitTime + visualWindowMs;
 
     if (!inHitWindow) {
       if (attackWindowMists.length) {
@@ -7696,7 +7697,7 @@ async function initCore(runtimeContext) {
       return;
     }
 
-    const attackRegion = cfg.region || 'around';
+    const attackRegion = attackCfg.region || 'around';
     const expectedShape = attackRegion === 'forward' ? 'box' : 'circle';
 
     if (!attackWindowMists.length || attackWindowMists[0]?.shape !== expectedShape) {
@@ -7730,7 +7731,7 @@ async function initCore(runtimeContext) {
 
     const entry = attackWindowMists[0];
     const mesh = entry.mesh;
-    const range = Math.max(0.4, cfg.range);
+    const range = Math.max(0.4, attackCfg.range);
     mesh.position.copy(playerModel.position);
     mesh.position.y += ATTACK_WINDOW_MIST_HEIGHT * 0.5;
 

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -744,13 +744,16 @@ export class PlayerControls {
     if (!this.swordSpinChargeActive) return false;
     this.swordSpinChargeActive = false;
     const heldForMs = Math.max(0, performance.now() - this.swordSpinChargeStartAt);
-    const chargeRatio = Math.max(0, Math.min(1, Math.min(SWORD_SPIN_CHARGE_MAX_HOLD_MS, heldForMs) / SWORD_SPIN_CHARGE_MAX_HOLD_MS));
+    const clampedHeldForMs = Math.min(SWORD_SPIN_CHARGE_MAX_HOLD_MS, heldForMs);
+    const chargeRatio = Math.max(0, Math.min(1, clampedHeldForMs / SWORD_SPIN_CHARGE_MAX_HOLD_MS));
     const spinAction = this.playerModel?.userData?.actions?.swordSpin;
     if (spinAction) spinAction.timeScale = 1;
+    const swordSpinBaseHitTimeMs = 800;
+    const swordSpinChargeHitDelayMs = clampedHeldForMs * (1 - SWORD_SPIN_WINDUP_SPEED);
     if (this.playerModel?.userData?.attack?.name === 'swordSpin') {
       this.playerModel.userData.attack.overrides = {
         ...(this.playerModel.userData.attack.overrides || {}),
-        hitTime: 800,
+        hitTime: swordSpinBaseHitTimeMs + swordSpinChargeHitDelayMs,
         hitWindow: 300,
         damage: 3 + (3 * chargeRatio),
         range: 3 + (3 * chargeRatio)


### PR DESCRIPTION
### Motivation
- When winding up `swordSpin` the animation is slowed by `SWORD_SPIN_WINDUP_SPEED`, so the attack `hitTime` must be delayed to match the slowed visual timing.
- The attack area visual (yellow circle / mist) was driven by the base `ATTACKS` values and therefore could appear out of sync when `attack.overrides` were applied for charged attacks. 
- The delay applied should be `heldForMs * (1 - timeScale)`, so with `timeScale = 0.25` the hit is delayed by `0.75 * heldForMs`.

### Description
- In `controls/controls.js` `releaseSwordSpinCharge` now clamps the held duration, computes `swordSpinChargeHitDelayMs = clampedHeldForMs * (1 - SWORD_SPIN_WINDUP_SPEED)`, and sets `hitTime` to `800 + swordSpinChargeHitDelayMs` while preserving charge-based `damage` and `range` scaling.
- The code also uses a `clampedHeldForMs` for both the `chargeRatio` and the hit delay computation to keep behavior consistent and avoid exceeding `SWORD_SPIN_CHARGE_MAX_HOLD_MS`.
- In `app/bootstrapGameApp.js` `updateAttackWindowMist` now merges `activeAttack.overrides` into the base config as `attackCfg` and references `attackCfg.hitTime`, `attackCfg.hitWindow`, `attackCfg.region`, and `attackCfg.range` so the visual attack indicator appears exactly when the computed hit window opens.
- The spin action `timeScale` is reset to `1` on release so the animation returns to normal playback when the hit timing is applied.

### Testing
- Ran `npm run build`, which completed successfully.
- Ran `npm test -- --runInBand`, which could not run because there is no `test` script defined in `package.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4aaff03bc83338aa2ec6a1bdf20fe)