### PR TITLE
Allow applying monster rigid-body transforms on non-host clients

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3870,7 +3870,11 @@ async function initCore(runtimeContext) {
 
 
   function canApplyMonsterBodyTransform() {
-    return !multiplayer || multiplayer.isHost;
+    // Monster transforms always come from the host-authoritative state stream.
+    // Even on non-host peers we must keep the Rapier body in sync with the
+    // received transform, otherwise the physics->mesh sync loop will keep
+    // snapping the visual mesh back to stale body poses.
+    return true;
   }
 
   function setMonsterForSlot(slotId, monster) {


### PR DESCRIPTION
### Motivation
- Non-host peers received correct host-authoritative monster states but visual jitter occurred because the Rapier rigid bodies on clients were not being updated, allowing the physics->mesh sync loop to snap meshes back to stale poses.

### Description
- Update `canApplyMonsterBodyTransform()` in `app/bootstrapGameApp.js` to always return `true` and add an explanatory comment so non-host clients also call `body.setTranslation`/`body.setRotation` when applying networked monster transforms.

### Testing
- Ran the production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4abd864708333a6dba27f6e83bbed)