### PR TITLE
Fix bow tap shots to still use nearest-target auto-aim

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3351,7 +3351,9 @@ export class PlayerControls {
   }
 
   getAutoAimDirection(weapon) {
-    if (!weapon || this.autoAimBreakUntilRelease || !this.playerModel) return null;
+    if (!weapon || !this.playerModel) return null;
+    const shouldRespectManualBreak = this.isAiming || this.isFireHeld;
+    if (shouldRespectManualBreak && this.autoAimBreakUntilRelease) return null;
     if (!(weapon.itemId === 'bow' || weapon.itemId === 'iceGun' || weapon.itemId === 'bomb')) return null;
 
     const maxRange = weapon.itemId === 'iceGun' ? AUTO_AIM_ICE_RANGE_M : AUTO_AIM_RANGE_M;


### PR DESCRIPTION
### Motivation
- Prevent a prior manual camera break from permanently disabling auto-aim for quick tap-to-fire bow shots so tapping the bow button can retarget the nearest monster.

### Description
- Update `getAutoAimDirection` in `controls/controls.js` to only honor `autoAimBreakUntilRelease` when the player is actively aiming or holding fire by introducing `shouldRespectManualBreak = this.isAiming || this.isFireHeld` and gating the break check behind it.

### Testing
- Applied the patch with the included `python` edit and verified changes were staged and committed using `git status --short`, `git diff -- controls/controls.js`, and `git add`/`git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ecd90f48833395115a6ea3652cee)