### PR TITLE
Fix auto-aim camera lock when firing bow/bomb projectiles

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3208,6 +3208,10 @@ export class PlayerControls {
     const equippedWeapon = this.getEquippedWeapon(hand);
     if (equippedWeapon?.itemId === 'bomb' && typeof this.throwBomb === 'function') {
       const direction = this.getAutoAimDirection(equippedWeapon) ?? this.getAimDirection(true);
+      if (direction) {
+        this.alignPlayerToDirection(direction);
+        this.applyAutoAimCameraDirection(direction);
+      }
       const position = this.getProjectileSpawnPosition(direction);
       const fired = this.throwBomb(position, direction);
       if (fired) {
@@ -3222,6 +3226,12 @@ export class PlayerControls {
     const usesArrow = gun?.itemId === 'bow' && typeof this.spawnArrowProjectile === 'function';
     const autoAimDirection = this.getAutoAimDirection(gun);
     const direction = autoAimDirection ?? (usesIceMist ? this.getPlayerFacingDirection() : this.getAimDirection(usesArrow));
+    if (direction) {
+      this.alignPlayerToDirection(direction);
+      if (autoAimDirection) {
+        this.applyAutoAimCameraDirection(autoAimDirection);
+      }
+    }
     const position = this.getProjectileSpawnPosition(direction);
 
     this.consumeAmmo();


### PR DESCRIPTION
### Motivation
- Tap-to-fire bow and bomb actions could leave the camera facing the previous heading (only doing shoulder zoom) so arrows fired on click did not snap toward nearby monsters. 
- The change ensures the player and camera immediately align to the computed auto-aim direction at the moment of fire so single-click shots feel locked-on when a nearby target exists.

### Description
- Updated `attemptFireProjectileForHand` in `controls/controls.js` to align the player to the resolved shot direction by calling `alignPlayerToDirection(direction)` before spawning/sending a projectile. 
- When auto-aim resolved a target, the code now also updates camera angles immediately by calling `applyAutoAimCameraDirection(...)` so yaw/pitch reflect the auto-aimed vector at fire time. 
- Applied the same alignment/camera update for bomb throws to keep projectile behavior consistent across weapon types. 
- Only `controls/controls.js` was modified to perform the alignment prior to calling `getProjectileSpawnPosition` and sending the projectile payload.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ef3a0e58832b82d3c391dd716042)