### PR TITLE
Add Build flow for wood (blocks and note posts) with Firebase persistence

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -103,6 +103,8 @@ import { getAttackTypes } from '../items/melee.js';
 import { exposeDebugGlobals } from '../src/runtime/exposeDebugGlobals.js';
 import { claimAchievement, getAchievementView, mergeAchievementState, recordAchievementProgress } from '../achievements.js';
 import { getDistanceUnitPreference, setDistanceUnitPreference } from '../distanceUnits.js';
+import { db } from '../firebase-init.js';
+import { onValue, push, ref, remove, set, update } from 'firebase/database';
 
 import {
   clearStoredPin,
@@ -4787,6 +4789,7 @@ async function initCore(runtimeContext) {
     || isSaltItem(itemId)
     || isSauteedMushroomsItem(itemId);
   const isPotionItem = (itemId) => potionItemIds.has(itemId);
+  const buildableItemIds = new Set(['wood']);
   const getInventoryItemActions = (itemId) => {
     if (isFoodItem(itemId)) {
       return ['drop', 'eat'];
@@ -4799,6 +4802,9 @@ async function initCore(runtimeContext) {
     }
     if (isZombieBrainsItem(itemId)) {
       return ['drop', 'info'];
+    }
+    if (buildableItemIds.has(itemId)) {
+      return ['drop', 'build'];
     }
     return ['drop'];
   };
@@ -10465,6 +10471,71 @@ async function initCore(runtimeContext) {
     debugState.lastError = error;
   };
 
+  const buildState = {
+    mode: null,
+    placing: null,
+    records: new Map(),
+    selectedNoteId: null
+  };
+  const BUILD_BUCKET_PRECISION = 4;
+  const buildUi = document.createElement('div');
+  buildUi.style.cssText = 'position:fixed;bottom:88px;right:12px;z-index:1200;display:none;gap:8px;flex-direction:column;';
+  buildUi.innerHTML = '<button id="build-confirm-btn" style="padding:10px 14px;">Build</button><div style="display:flex;gap:6px;"><button id="build-up-btn">⬆</button><button id="build-down-btn">⬇</button></div>';
+  document.body.appendChild(buildUi);
+  const buildConfirmBtn = buildUi.querySelector('#build-confirm-btn');
+  const buildUpBtn = buildUi.querySelector('#build-up-btn');
+  const buildDownBtn = buildUi.querySelector('#build-down-btn');
+  let buildVerticalInput = 0;
+  window.addEventListener('keydown', (event) => {
+    if (!buildState.placing) return;
+    if (event.key === 'ArrowUp') buildVerticalInput = 1;
+    if (event.key === 'ArrowDown') buildVerticalInput = -1;
+  });
+  window.addEventListener('keyup', (event) => {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') buildVerticalInput = 0;
+  });
+  const onBuildLatLonPath = (lat, lon) => `worldBuilds/${lat.toFixed(BUILD_BUCKET_PRECISION)}_${lon.toFixed(BUILD_BUCKET_PRECISION)}`;
+  const subscribeBuildsForCurrentLocation = () => {
+    const fix = getLatestLocationFix?.();
+    if (!fix || !Number.isFinite(fix.lat) || !Number.isFinite(fix.lon)) return;
+    onValue(ref(db, onBuildLatLonPath(fix.lat, fix.lon)), (snapshot) => {
+      const value = snapshot.val() || {};
+      Object.entries(value).forEach(([id, record]) => {
+        if (buildState.records.has(id) || !record) return;
+        const mesh = record.type === 'note'
+          ? new THREE.Mesh(new THREE.BoxGeometry(0.6, 1.3, 0.15), new THREE.MeshStandardMaterial({ color: 0x8b5a2b }))
+          : new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshStandardMaterial({ color: 0x6b4423 }));
+        mesh.position.set(record.x || 0, record.y || 0, record.z || 0);
+        mesh.userData.buildRecordId = id;
+        mesh.userData.buildHealth = Number.isFinite(record.health) ? record.health : 100;
+        mesh.userData.buildOwner = record.ownerId || null;
+        mesh.userData.buildType = record.type || 'block';
+        mesh.userData.noteText = record.noteText || '';
+        scene.add(mesh);
+        buildState.records.set(id, { mesh, ...record });
+      });
+    });
+  };
+  buildUpBtn?.addEventListener('pointerdown', () => { buildVerticalInput = 1; });
+  buildDownBtn?.addEventListener('pointerdown', () => { buildVerticalInput = -1; });
+  const resetVertical = () => { buildVerticalInput = 0; };
+  buildUpBtn?.addEventListener('pointerup', resetVertical);
+  buildDownBtn?.addEventListener('pointerup', resetVertical);
+  buildConfirmBtn?.addEventListener('click', async () => {
+    if (!buildState.placing) return;
+    const fix = getLatestLocationFix?.();
+    if (!fix || !Number.isFinite(fix.lat) || !Number.isFinite(fix.lon)) return;
+    const idRef = push(ref(db, onBuildLatLonPath(fix.lat, fix.lon)));
+    const p = buildState.placing.mesh.position;
+    const record = { type: buildState.placing.type, x: p.x, y: p.y, z: p.z, health: 100, noteText: buildState.placing.noteText || '', ownerId: multiplayer?.peer?.id || 'local' };
+    await set(idRef, record);
+    buildState.records.set(idRef.key, { ...record, mesh: buildState.placing.mesh });
+    buildState.placing.mesh.userData.buildRecordId = idRef.key;
+    buildState.placing.mesh.userData.noteText = record.noteText;
+    buildState.placing = null;
+    buildUi.style.display = 'none';
+    removeFromInventory('wood', 1);
+  });
   const appState = {
     getPlayerName: () => playerName,
     setPlayerName: (name) => {
@@ -10555,6 +10626,25 @@ async function initCore(runtimeContext) {
     dropInventoryItem: (itemId) => dropInventoryItem(itemId),
     eatInventoryItem: (itemId) => eatInventoryItem(itemId),
     useInventoryItem: (itemId) => useInventoryItem(itemId),
+    startBuildFlow: async (itemId) => {
+      if (itemId !== 'wood') return;
+      const choice = window.prompt('Type "block" to build a block or "note" for Note Post', 'block');
+      if (!choice) return;
+      let noteText = '';
+      const type = choice.toLowerCase().includes('note') ? 'note' : 'block';
+      if (type === 'note') {
+        noteText = window.prompt('Enter note text') || '';
+        if (!noteText.trim()) return;
+      }
+      const pos = playerModel?.position?.clone?.() || new THREE.Vector3();
+      const mesh = type === 'note'
+        ? new THREE.Mesh(new THREE.BoxGeometry(0.6, 1.3, 0.15), new THREE.MeshStandardMaterial({ color: 0x8b5a2b }))
+        : new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshStandardMaterial({ color: 0x6b4423 }));
+      mesh.position.copy(pos).add(new THREE.Vector3(0, 1.2, 1.2));
+      scene.add(mesh);
+      buildState.placing = { mesh, type, noteText };
+      buildUi.style.display = 'flex';
+    },
     addToInventory: (itemId, amount) => addToInventory(itemId, amount),
     removeFromInventory: (itemId, amount) => removeFromInventory(itemId, amount),
     storeHomeStorageItem: (itemId) => storeHomeStorageItem(itemId),
@@ -10972,6 +11062,27 @@ async function initCore(runtimeContext) {
       }
       if (!playerControls?.isClimbing) {
         climbedSinceGrounded = false;
+      }
+    }
+    if (buildState.placing) {
+      const moveSpeed = 3 * frameDelta;
+      const keys = playerControls?.keysPressed || new Set();
+      if (keys.has('w')) buildState.placing.mesh.position.z += moveSpeed;
+      if (keys.has('s')) buildState.placing.mesh.position.z -= moveSpeed;
+      if (keys.has('a')) buildState.placing.mesh.position.x += moveSpeed;
+      if (keys.has('d')) buildState.placing.mesh.position.x -= moveSpeed;
+      if (buildVerticalInput !== 0) buildState.placing.mesh.position.y += buildVerticalInput * moveSpeed;
+    } else {
+      const playerPos = playerModel?.position;
+      if (playerPos) {
+        buildState.selectedNoteId = null;
+        buildState.records.forEach((record, id) => {
+          if (record.type !== 'note' || !record.mesh) return;
+          const distance = record.mesh.position.distanceTo(playerPos);
+          if (distance < 3) {
+            buildState.selectedNoteId = id;
+          }
+        });
       }
     }
     if (craftState.swirl?.line) {
@@ -11997,6 +12108,32 @@ async function initCore(runtimeContext) {
   canProcessIncomingPeerData = true;
   processIncomingPeerDataQueue();
 
+  subscribeBuildsForCurrentLocation();
+  window.addEventListener('keydown', async (event) => {
+    if (event.key.toLowerCase() !== 'e' || !buildState.selectedNoteId) return;
+    const record = buildState.records.get(buildState.selectedNoteId);
+    if (!record) return;
+    const isOwner = record.ownerId === (multiplayer?.peer?.id || 'local');
+    window.alert(`Note: ${record.noteText || '(empty)'}`);
+    if (isOwner) {
+      const action = window.prompt('Type edit or delete to manage your post');
+      if (action === 'delete') {
+        const fix = getLatestLocationFix?.();
+        if (fix) {
+          await remove(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`));
+        }
+        scene.remove(record.mesh);
+        buildState.records.delete(buildState.selectedNoteId);
+      } else if (action === 'edit') {
+        const text = window.prompt('Edit note', record.noteText || '');
+        if (text != null) {
+          const fix = getLatestLocationFix?.();
+          if (fix) await update(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`), { noteText: text });
+          record.noteText = text;
+        }
+      }
+    }
+  });
   animate();
 
   return runtimeContext;

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -6630,9 +6630,10 @@ async function initCore(runtimeContext) {
 
   let mapViewEnabled = false;
   let playerDead = false;
+  let isBuildPlacementActive = false;
   const updateControlAvailability = () => {
     if (!playerControls) return;
-    playerControls.enabled = !mapViewEnabled && !playerDead && !levelUpSelectionActive;
+    playerControls.enabled = !mapViewEnabled && !playerDead && !levelUpSelectionActive && !isBuildPlacementActive;
   };
   const updateEnergyEffects = () => {
     if (!playerControls) return;
@@ -10475,11 +10476,12 @@ async function initCore(runtimeContext) {
     mode: null,
     placing: null,
     records: new Map(),
-    selectedNoteId: null
+    selectedNoteId: null,
+    cameraOffset: new THREE.Vector3(0, 4, 8)
   };
   const BUILD_BUCKET_PRECISION = 4;
   const buildUi = document.createElement('div');
-  buildUi.style.cssText = 'position:fixed;bottom:88px;right:12px;z-index:1200;display:none;gap:8px;flex-direction:column;';
+  buildUi.style.cssText = 'position:fixed;left:50%;bottom:20%;transform:translateX(-50%);z-index:1200;display:none;gap:8px;flex-direction:column;align-items:center;';
   buildUi.innerHTML = '<button id="build-confirm-btn" style="padding:10px 14px;">Build</button><div style="display:flex;gap:6px;"><button id="build-up-btn">⬆</button><button id="build-down-btn">⬇</button></div>';
   document.body.appendChild(buildUi);
   const buildConfirmBtn = buildUi.querySelector('#build-confirm-btn');
@@ -10494,7 +10496,11 @@ async function initCore(runtimeContext) {
   window.addEventListener('keyup', (event) => {
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') buildVerticalInput = 0;
   });
-  const onBuildLatLonPath = (lat, lon) => `worldBuilds/${lat.toFixed(BUILD_BUCKET_PRECISION)}_${lon.toFixed(BUILD_BUCKET_PRECISION)}`;
+  const toBucketKey = (value) => {
+    const scaled = Math.round(value * (10 ** BUILD_BUCKET_PRECISION));
+    return scaled < 0 ? `m${Math.abs(scaled)}` : `p${scaled}`;
+  };
+  const onBuildLatLonPath = (lat, lon) => `worldBuilds/${toBucketKey(lat)}_${toBucketKey(lon)}`;
   const subscribeBuildsForCurrentLocation = () => {
     const fix = getLatestLocationFix?.();
     if (!fix || !Number.isFinite(fix.lat) || !Number.isFinite(fix.lon)) return;
@@ -10533,7 +10539,9 @@ async function initCore(runtimeContext) {
     buildState.placing.mesh.userData.buildRecordId = idRef.key;
     buildState.placing.mesh.userData.noteText = record.noteText;
     buildState.placing = null;
+    isBuildPlacementActive = false;
     buildUi.style.display = 'none';
+    updateControlAvailability();
     removeFromInventory('wood', 1);
   });
   const appState = {
@@ -10643,7 +10651,9 @@ async function initCore(runtimeContext) {
       mesh.position.copy(pos).add(new THREE.Vector3(0, 1.2, 1.2));
       scene.add(mesh);
       buildState.placing = { mesh, type, noteText };
+      isBuildPlacementActive = true;
       buildUi.style.display = 'flex';
+      updateControlAvailability();
     },
     addToInventory: (itemId, amount) => addToInventory(itemId, amount),
     removeFromInventory: (itemId, amount) => removeFromInventory(itemId, amount),
@@ -11054,7 +11064,7 @@ async function initCore(runtimeContext) {
       updatePickupTiles(playerPosition);
     }
 
-    if (!mapViewEnabled) {
+    if (!mapViewEnabled && !buildState.placing) {
       playerControls.update();
       if (playerControls?.isClimbing && !climbedSinceGrounded) {
         climbedSinceGrounded = true;
@@ -11072,6 +11082,10 @@ async function initCore(runtimeContext) {
       if (keys.has('a')) buildState.placing.mesh.position.x += moveSpeed;
       if (keys.has('d')) buildState.placing.mesh.position.x -= moveSpeed;
       if (buildVerticalInput !== 0) buildState.placing.mesh.position.y += buildVerticalInput * moveSpeed;
+      const followTarget = buildState.placing.mesh.position;
+      const desiredCameraPos = followTarget.clone().add(buildState.cameraOffset);
+      camera.position.lerp(desiredCameraPos, 0.15);
+      camera.lookAt(followTarget);
     } else {
       const playerPos = playerModel?.position;
       if (playerPos) {

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -286,7 +286,10 @@ function buildInventoryPanel() {
   const eatButton = createElement('button', 'settings-button', 'Eat');
   eatButton.type = 'button';
   eatButton.dataset.inventoryAction = 'eat';
-  actions.append(dropButton, infoButton, useButton, equipButton, eatButton);
+  const buildButton = createElement('button', 'settings-button', 'Build');
+  buildButton.type = 'button';
+  buildButton.dataset.inventoryAction = 'build';
+  actions.append(dropButton, infoButton, useButton, equipButton, eatButton, buildButton);
   details.append(detailsText, actions);
   panelEl.append(grid, emptyState, details);
 
@@ -317,6 +320,7 @@ function buildInventoryPanel() {
   elements.inventoryUseButton = useButton;
   elements.inventoryEquipButton = equipButton;
   elements.inventoryEatButton = eatButton;
+  elements.inventoryBuildButton = buildButton;
   elements.inventoryInfoModal = infoModal;
   elements.inventoryInfoText = infoText;
 
@@ -1318,6 +1322,10 @@ function renderInventory() {
       const canEat = itemActions.includes('eat');
       elements.inventoryEatButton.style.display = canEat ? 'inline-flex' : 'none';
     }
+    if (elements.inventoryBuildButton) {
+      const canBuild = itemActions.includes('build');
+      elements.inventoryBuildButton.style.display = canBuild ? 'inline-flex' : 'none';
+    }
     if (elements.inventoryDetailsContainer) {
       if (selectedTile && selectedTile.parentElement === elements.inventoryGrid) {
         selectedTile.insertAdjacentElement('afterend', elements.inventoryDetailsContainer);
@@ -1356,6 +1364,8 @@ function bindEvents() {
         context.appState?.unequipInventoryItem?.(selectedInventoryId);
       } else if (action === 'eat') {
         context.appState?.eatInventoryItem?.(selectedInventoryId);
+      } else if (action === 'build') {
+        context.appState?.startBuildFlow?.(selectedInventoryId);
       } else if (action === 'info') {
         if (selectedInventoryId === 'zombie_brains' && elements.inventoryInfoModal && elements.inventoryInfoText) {
           elements.inventoryInfoText.textContent = 'Zombie Brains are unstable remains from undead creatures. They pulse with strange energy. Maybe you can craft them into something useful at your home crafting table.';


### PR DESCRIPTION
### Motivation
- Provide a way for players to use `wood` from inventory to place world objects (blocks or note posts) and share them with nearby players. 
- Let players position a placement object directly (WASD / joystick for horizontal, arrow keys / on-screen buttons for vertical) before confirming placement. 
- Persist placed builds to Firebase so other players see them at the same GPS bucket, and allow simple note-post interactions including owner edit/delete. 

### Description
- Added an inventory `Build` action button and wired it to `appState.startBuildFlow(...)` in `controls/settingsPanel.js`. 
- Added `wood` to the set of buildable items and exposed the `build` action via `getInventoryItemActions` in `app/bootstrapGameApp.js`. 
- Implemented a placement mode (`buildState`) and small on-screen build UI (confirm, up/down) that appears during placement, and created `startBuildFlow` to spawn a temporary mesh to place (block or note post) and collect optional note text. 
- Placement controls: WASD / joystick adjust horizontal position each frame while placing, ArrowUp/ArrowDown and on-screen `⬆`/`⬇` buttons adjust vertical position, and `Build` confirm button saves the placement. 
- Firebase persistence: placed records are written under a GPS-bucketed path `worldBuilds/<lat_lon>` using `push`/`set`, and the client subscribes with `onValue` to load builds in the current GPS bucket; note-post records include `noteText`, `ownerId` and `health` and are mirrored to a scene mesh with `userData` for later interactions. 
- Note-post read/edit/delete: pressing `E` when near a note posts shows the note text via `alert`, and if the local player is the owner a prompt allows `edit` or `delete`, which updates/removes the Firebase record and scene mesh. 

### Testing
- Ran a production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb871868832bb58bc52795aadeed)