### PR TITLE
Revamp building flow and note post interfaces

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -10480,6 +10480,21 @@ async function initCore(runtimeContext) {
     selectedNoteId: null,
     cameraOffset: new THREE.Vector3(0, 4, 8)
   };
+  const createNoteMesh = () => {
+    const group = new THREE.Group();
+    const pole = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.07, 0.09, 1.0, 10),
+      new THREE.MeshStandardMaterial({ color: 0x6b4423 })
+    );
+    pole.position.y = 0.5;
+    const signTop = new THREE.Mesh(
+      new THREE.BoxGeometry(0.82, 0.54, 0.12),
+      new THREE.MeshStandardMaterial({ color: 0xa17242 })
+    );
+    signTop.position.y = 1.04;
+    group.add(pole, signTop);
+    return group;
+  };
   const buildInteractionBtn = document.createElement('button');
   buildInteractionBtn.type = 'button';
   buildInteractionBtn.textContent = 'Read Note';
@@ -10487,8 +10502,8 @@ async function initCore(runtimeContext) {
   document.body.appendChild(buildInteractionBtn);
   const BUILD_BUCKET_PRECISION = 4;
   const buildUi = document.createElement('div');
-  buildUi.style.cssText = 'position:fixed;left:50%;bottom:20%;transform:translateX(-50%);z-index:1200;display:none;gap:8px;flex-direction:column;align-items:center;';
-  buildUi.innerHTML = '<button id="build-confirm-btn" style="padding:10px 14px;">Build</button><div style="display:flex;gap:6px;"><button id="build-up-btn">⬆</button><button id="build-down-btn">⬇</button></div>';
+  buildUi.className = 'build-action-ui';
+  buildUi.innerHTML = '<button id="build-confirm-btn" class="retro-build-btn">Build</button><div class="build-vertical-controls"><button id="build-up-btn" class="retro-build-btn" aria-label="Move build up">▲ Up</button><button id="build-down-btn" class="retro-build-btn" aria-label="Move build down">▼ Down</button></div>';
   document.body.appendChild(buildUi);
   const buildConfirmBtn = buildUi.querySelector('#build-confirm-btn');
   const buildUpBtn = buildUi.querySelector('#build-up-btn');
@@ -10524,7 +10539,7 @@ async function initCore(runtimeContext) {
       Object.entries(value).forEach(([id, record]) => {
         if (buildState.records.has(id) || !record) return;
         const mesh = record.type === 'note'
-          ? new THREE.Mesh(new THREE.BoxGeometry(0.6, 1.3, 0.15), new THREE.MeshStandardMaterial({ color: 0x8b5a2b }))
+          ? createNoteMesh()
           : new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshStandardMaterial({ color: 0x6b4423 }));
         mesh.position.set(record.x || 0, record.y || 0, record.z || 0);
         mesh.userData.buildRecordId = id;
@@ -10654,17 +10669,16 @@ async function initCore(runtimeContext) {
     useInventoryItem: (itemId) => useInventoryItem(itemId),
     startBuildFlow: async (itemId) => {
       if (itemId !== 'wood') return;
-      const choice = window.prompt('Type "block" to build a block or "note" for Note Post', 'block');
-      if (!choice) return;
+      const type = await openBuildTypePicker();
+      if (!type) return;
       let noteText = '';
-      const type = choice.toLowerCase().includes('note') ? 'note' : 'block';
       if (type === 'note') {
-        noteText = window.prompt('Enter note text') || '';
-        if (!noteText.trim()) return;
+        noteText = await openNoteEntryModal();
+        if (!noteText?.trim()) return;
       }
       const pos = playerModel?.position?.clone?.() || new THREE.Vector3();
       const mesh = type === 'note'
-        ? new THREE.Mesh(new THREE.BoxGeometry(0.6, 1.3, 0.15), new THREE.MeshStandardMaterial({ color: 0x8b5a2b }))
+        ? createNoteMesh()
         : new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1), new THREE.MeshStandardMaterial({ color: 0x6b4423 }));
       mesh.position.copy(pos).add(new THREE.Vector3(0, 1.2, 1.2));
       scene.add(mesh);
@@ -10800,23 +10814,33 @@ async function initCore(runtimeContext) {
     const record = buildState.records.get(buildState.selectedNoteId);
     if (!record) return;
     const isOwner = record.ownerId === (multiplayer?.peer?.id || 'local');
-    window.alert(`Note: ${record.noteText || '(empty)'}`);
-    if (!isOwner) return;
-    const action = window.prompt('Type edit or delete to manage your post');
-    if (action === 'delete') {
-      const fix = getLatestLocationFix?.();
-      if (fix) await remove(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`));
-      scene.remove(record.mesh);
-      removeStaticBoxCollider(record.colliderEntry || record.mesh?.userData?.staticColliderEntry);
-      buildState.records.delete(buildState.selectedNoteId);
-    } else if (action === 'edit') {
-      const text = window.prompt('Edit note', record.noteText || '');
-      if (text != null) {
-        const fix = getLatestLocationFix?.();
-        if (fix) await update(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`), { noteText: text });
-        record.noteText = text;
+    noteViewModal.innerHTML = `<div class="build-modal"><h3>Note Post</h3><div class="note-view-text">${record.noteText || '(empty)'}</div><div class="build-modal-actions">${isOwner ? '<button type="button" class="build-cancel-btn" data-note-delete="1">Delete</button><button type="button" class="retro-build-btn" data-note-edit="1">Edit</button>' : ''}<button type="button" class="retro-build-btn" data-note-ok="1">Ok</button></div></div>`;
+    noteViewModal.classList.remove('hidden');
+    noteViewModal.addEventListener('click', async (event) => {
+      const ok = event.target.closest('[data-note-ok]');
+      const edit = event.target.closest('[data-note-edit]');
+      const del = event.target.closest('[data-note-delete]');
+      if (event.target === noteViewModal || ok) {
+        noteViewModal.classList.add('hidden');
+        return;
       }
-    }
+      if (del) {
+        const fix = getLatestLocationFix?.();
+        if (fix) await remove(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`));
+        scene.remove(record.mesh);
+        removeStaticBoxCollider(record.colliderEntry || record.mesh?.userData?.staticColliderEntry);
+        buildState.records.delete(buildState.selectedNoteId);
+        noteViewModal.classList.add('hidden');
+      } else if (edit) {
+        const text = await openNoteEntryModal(record.noteText || '');
+        if (text != null) {
+          const fix = getLatestLocationFix?.();
+          if (fix) await update(ref(db, `${onBuildLatLonPath(fix.lat, fix.lon)}/${buildState.selectedNoteId}`), { noteText: text });
+          record.noteText = text;
+        }
+        noteViewModal.classList.add('hidden');
+      }
+    }, { once: true });
   };
   buildInteractionBtn.addEventListener('click', () => { void showNoteInteraction(); });
 
@@ -12225,3 +12249,44 @@ export async function bootstrapGameApp() {
 
   return appContext;
 }
+  const buildModal = document.createElement('div');
+  buildModal.className = 'build-modal-overlay hidden';
+  const noteEntryModal = document.createElement('div');
+  noteEntryModal.className = 'build-modal-overlay hidden';
+  const noteViewModal = document.createElement('div');
+  noteViewModal.className = 'build-modal-overlay hidden';
+  document.body.append(buildModal, noteEntryModal, noteViewModal);
+  const openBuildTypePicker = () => new Promise((resolve) => {
+    buildModal.innerHTML = `<div class="build-modal"><h3>Choose Build Type</h3><div class="build-options-list"><button type="button" class="build-option-btn" data-build-type="block"><span>🧱</span>Block</button><button type="button" class="build-option-btn" data-build-type="note"><span>🪧</span>Note Post</button></div><button type="button" class="build-cancel-btn" data-build-cancel="1">Cancel</button></div>`;
+    buildModal.classList.remove('hidden');
+    const close = (value) => {
+      buildModal.classList.add('hidden');
+      buildModal.innerHTML = '';
+      resolve(value);
+    };
+    buildModal.addEventListener('click', (event) => {
+      const target = event.target.closest('button');
+      if (event.target === buildModal || target?.dataset.buildCancel) return close(null);
+      const type = target?.dataset.buildType;
+      if (type) close(type);
+    }, { once: true });
+  });
+  const openNoteEntryModal = (initialText = '') => new Promise((resolve) => {
+    noteEntryModal.innerHTML = `<div class="build-modal"><h3>Write Your Note</h3><textarea class="note-input" maxlength="280" placeholder="Leave a helpful message...">${initialText}</textarea><div class="build-modal-actions"><button type="button" class="build-cancel-btn" data-note-cancel="1">Cancel</button><button type="button" class="retro-build-btn" data-note-save="1">Save</button></div></div>`;
+    noteEntryModal.classList.remove('hidden');
+    const close = (value) => {
+      noteEntryModal.classList.add('hidden');
+      noteEntryModal.innerHTML = '';
+      resolve(value);
+    };
+    noteEntryModal.addEventListener('click', (event) => {
+      const saveBtn = event.target.closest('[data-note-save]');
+      const cancelBtn = event.target.closest('[data-note-cancel]');
+      if (event.target === noteEntryModal || cancelBtn) return close(null);
+      if (saveBtn) {
+        const text = noteEntryModal.querySelector('.note-input')?.value || '';
+        close(text.trim() || null);
+      }
+    }, { once: true });
+    noteEntryModal.querySelector('.note-input')?.focus();
+  });

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1366,6 +1366,7 @@ function bindEvents() {
         context.appState?.eatInventoryItem?.(selectedInventoryId);
       } else if (action === 'build') {
         context.appState?.startBuildFlow?.(selectedInventoryId);
+        closeInventoryOverlay();
       } else if (action === 'info') {
         if (selectedInventoryId === 'zombie_brains' && elements.inventoryInfoModal && elements.inventoryInfoText) {
           elements.inventoryInfoText.textContent = 'Zombie Brains are unstable remains from undead creatures. They pulse with strange energy. Maybe you can craft them into something useful at your home crafting table.';

--- a/styles.css
+++ b/styles.css
@@ -2468,3 +2468,47 @@ body.settings-open #inventory-button {
   background: #3cb85a;
   border-color: #3cb85a;
 }
+
+.build-action-ui {
+  position: fixed;
+  left: 50%;
+  bottom: 20%;
+  transform: translateX(-50%);
+  z-index: 1200;
+  display: none;
+  gap: 10px;
+  flex-direction: column;
+  align-items: center;
+}
+.retro-build-btn,
+.build-cancel-btn {
+  border: 2px solid #26180a;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #f5cb74 0%, #cb8b36 100%);
+  color: #2e1b08;
+  font-weight: 800;
+  padding: 10px 14px;
+  box-shadow: 0 4px 0 #5f3b14;
+}
+.retro-build-btn:active,
+.build-cancel-btn:active { transform: translateY(2px); box-shadow: 0 2px 0 #5f3b14; }
+.build-vertical-controls { display: flex; gap: 8px; }
+.build-modal-overlay {
+  position: fixed; inset: 0; z-index: 1600; display: grid; place-items: center; background: rgba(0,0,0,.5);
+}
+.build-modal-overlay.hidden { display: none; }
+.build-modal {
+  width: min(92vw, 420px); max-height: 70vh; overflow: auto; border: 2px solid #3a220b; border-radius: 10px;
+  background: linear-gradient(180deg, #fff5de 0%, #f0d4a2 100%); padding: 16px;
+}
+.build-options-list { display: grid; gap: 10px; max-height: 40vh; overflow: auto; margin: 12px 0; }
+.build-option-btn {
+  font: inherit; border: 2px solid #3a220b; border-radius: 8px; background: #fff9ea; padding: 12px; display: flex; gap: 8px; align-items: center;
+}
+.note-input {
+  width: 100%; min-height: 140px; margin: 10px 0; border: 2px solid #5f3b14; border-radius: 8px; padding: 10px; font: inherit; resize: vertical;
+}
+.note-view-text {
+  white-space: pre-wrap; max-height: 36vh; overflow: auto; border: 1px solid #8d6430; border-radius: 8px; background: #fff8ea; padding: 10px; margin: 10px 0;
+}
+.build-modal-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }


### PR DESCRIPTION
### Motivation
- Hide the inventory when the player chooses to build (wood) and move from blocking `prompt`/`alert` flows to proper UI for build selection and note entry.
- Provide a scrollable GUI for choosing what to place (block vs note post) instead of text prompts.
- Make note post creation and interaction feel polished with a textarea editor and a view modal that supports `Ok`, `Edit`, and `Delete` (owner-only).
- Improve placement controls with retro-styled buttons and give the note post a slimmer pole + wider sign top geometry for a clearer visual.

### Description
- Close the inventory overlay when the inventory `Build` action is used by calling `closeInventoryOverlay()` from `controls/settingsPanel.js`.
- Add a scrollable build-type picker modal and a note-entry modal in `app/bootstrapGameApp.js` via new helpers `openBuildTypePicker` and `openNoteEntryModal`, and wire them into `appState.startBuildFlow` to replace `window.prompt` usage.
- Replace the old `alert`/`prompt` note interaction with a `noteViewModal` that displays note text and shows `Ok` for all players and `Edit`/`Delete` only when the viewer is the owner; editing uses the same `openNoteEntryModal` flow.
- Replace in-world build UI markup with a styled `build-action-ui` and retro buttons (`.retro-build-btn`) and vertical controls (`▲ Up` / `▼ Down`) in `app/bootstrapGameApp.js` and add supporting styles in `styles.css`.
- Introduce `createNoteMesh()` in `app/bootstrapGameApp.js` to construct a slimmer pole with a wider sign top for note posts, and use it when loading persisted notes and when placing new notes.
- Files changed: `app/bootstrapGameApp.js`, `controls/settingsPanel.js`, and `styles.css`.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1853621c832b89bc75a4d4dad74e)