### PR TITLE
Add friendly NPC combat assistance

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3472,7 +3472,9 @@ async function initCore(runtimeContext) {
     debug: window.DEBUG_FRIENDLY_PERSIST,
     onSpawnEvent: handleCharacterSpawnEvent,
     onBeforeSpawn: (...args) => trimTravelSpawnPopulationIfNeeded(...args),
-    onRemoteSpawnRequest: requestHostSpawnEvent
+    onRemoteSpawnRequest: requestHostSpawnEvent,
+    getMonsters: () => monsters,
+    onMonsterHit: handleMonsterDamage
   });
   if (multiplayer?.roomId) {
     friendlyNpcManager.onRoomReady({ roomId: multiplayer.roomId, isHost: multiplayer.isHost });
@@ -12057,6 +12059,11 @@ async function initCore(runtimeContext) {
           friendlyAvoidanceZones.push(merchantFriendly.model.position.clone());
         }
         const roomFriendlies = friendlyNpcManager?.friendlies || [];
+        const combatFriendlies = [...roomFriendlies];
+        const questFriend = questManager?.getQuestFriend?.();
+        if (questFriend?.model && !questFriend.isDead) {
+          combatFriendlies.push(questFriend);
+        }
         roomFriendlies.forEach((friendly) => {
           if (friendly?.isDead || !friendly?.model?.position) return;
           friendlyAvoidanceZones.push(friendly.model.position.clone());
@@ -12104,7 +12111,8 @@ async function initCore(runtimeContext) {
             friendlyAvoidanceZones,
             resolveGroundY,
             walkableSlopeDegrees: 42,
-            groundOffset: 0.9 * (Number.isFinite(monster.sizeScale) ? monster.sizeScale : 1)
+            groundOffset: 0.9 * (Number.isFinite(monster.sizeScale) ? monster.sizeScale : 1),
+            friendlyTargets: combatFriendlies
           };
           const MAX_AI_DELTA_SECONDS = 0.5;
 

--- a/characters/FriendlyCharacter.js
+++ b/characters/FriendlyCharacter.js
@@ -7,6 +7,8 @@ const DEFAULT_HEALTH = BASE_HEALTH_SEGMENTS;
 const WANDER_CHANGE_MS = 2400;
 const MOVE_FADE = 0.2;
 const IDLE_SPEED_MULTIPLIER = 1.0;
+const FRIENDLY_MONSTER_HELP_RADIUS = 12;
+const FRIENDLY_MONSTER_DAMAGE = 1;
 const DANCE_MIN_INTERVAL_MS = 3200;
 const DANCE_MAX_INTERVAL_MS = 7200;
 const DANCE_MIN_DURATION_MS = 1800;
@@ -29,10 +31,17 @@ export class FriendlyCharacter extends MonsterCharacter {
     this.followTargetModel = null;
     this.followDistance = 3;
     this.followStartDistance = 4.5;
+    this.helpingPlayerFight = false;
+    this.monsterHelpRadius = FRIENDLY_MONSTER_HELP_RADIUS;
+    this.alwaysShowHealthBar = true;
     this.model.userData.mode = "friendly";
+    this.model.userData.helpingPlayerFight = false;
     this.speedMultiplier = 1;
     this.sizeScale = 1;
-    this.attackDamage = 0;
+    this.attackDamage = FRIENDLY_MONSTER_DAMAGE;
+    if (this.healthBar) {
+      this.healthBar.visible = true;
+    }
     this.setLevel(1, { preserveHealth: false });
   }
 
@@ -72,8 +81,12 @@ export class FriendlyCharacter extends MonsterCharacter {
     this.nextDanceAt = now + interval;
   }
 
-  setFollowTarget(model, { followDistance = 3, followStartDistance = 4.5 } = {}) {
+  setFollowTarget(model, { followDistance = 3, followStartDistance = 4.5, helpingPlayerFight = null } = {}) {
     this.followTargetModel = model || null;
+    if (helpingPlayerFight != null) {
+      this.helpingPlayerFight = !!helpingPlayerFight;
+      this.model.userData.helpingPlayerFight = this.helpingPlayerFight;
+    }
     if (Number.isFinite(followDistance)) {
       this.followDistance = Math.max(0, followDistance);
     }
@@ -88,7 +101,7 @@ export class FriendlyCharacter extends MonsterCharacter {
     this.model.userData.level = nextLevel;
     this.sizeScale = 1;
     this.speedMultiplier = 1;
-    this.attackDamage = 0;
+    this.attackDamage = FRIENDLY_MONSTER_DAMAGE;
     this.maxHealth = getMaxHealthSegments(nextLevel);
     this.model.userData.maxHealth = this.maxHealth;
     if (!preserveHealth) {
@@ -106,7 +119,27 @@ export class FriendlyCharacter extends MonsterCharacter {
     super.updateHealthBarScale();
   }
 
-  updateAI(deltaTime, playerModel, otherPlayers) {
+  updateHealthBarVisibility() {
+    if (!this.healthBar) return;
+    this.healthBar.visible = !this.isDead && this.model.userData.npcRole !== 'merchant';
+  }
+
+  findClosestMonster(monsters = []) {
+    if (!this.model?.position || !Array.isArray(monsters)) return null;
+    let closest = null;
+    let closestDistance = Infinity;
+    monsters.forEach((monster) => {
+      if (!monster?.model?.position || monster.isDead) return;
+      const distance = this.model.position.distanceTo(monster.model.position);
+      if (distance <= this.monsterHelpRadius && distance < closestDistance) {
+        closest = monster;
+        closestDistance = distance;
+      }
+    });
+    return closest ? { id: closest.id, model: closest.model, entity: closest, distance: closestDistance } : null;
+  }
+
+  updateAI(deltaTime, playerModel, otherPlayers = {}, monsters = [], context = {}) {
     if (!this.model) return;
     const body = this.body;
     if (!body) return;
@@ -155,6 +188,38 @@ export class FriendlyCharacter extends MonsterCharacter {
     if (this.forceEngaged) {
       this.isEngaged = true;
       this.model.userData.mode = "engaged";
+    }
+
+    const canHelpFightMonsters = this.helpingPlayerFight || this.model.userData.isQuestFriend === true;
+    const closestMonster = canHelpFightMonsters ? this.findClosestMonster(monsters) : null;
+    if (closestMonster) {
+      this.isEngaged = true;
+      this.model.userData.mode = "engaged";
+      this.danceUntil = 0;
+      this.updateCombatAI(delta, closestMonster, [closestMonster], (monsterTarget, hitContext = {}) => {
+        const monster = monsterTarget?.entity;
+        if (!monster?.model || monster.isDead) return;
+        const damage = Number.isFinite(hitContext.damage)
+          ? Math.max(1, Math.round(hitContext.damage))
+          : this.attackDamage;
+        const killed = monster.applyDamage?.(damage, { attackTypes: hitContext.attackTypes || ['friendly', 'melee'] });
+        if (!killed) {
+          monster.applyKnockback?.({
+            direction: monster.model.position.clone().sub(this.model.position).normalize(),
+            strength: hitContext.strength
+          });
+        }
+        context.onMonsterHit?.(monster, {
+          damage,
+          killed: !!killed,
+          sourceId: this.id,
+          attackTypes: hitContext.attackTypes || ['friendly', 'melee']
+        });
+        if (killed) {
+          window.onMonsterKill?.(monster, { withFriend: true });
+        }
+      }, context);
+      return;
     }
 
     if (this.followTargetModel?.position && !this.forceEngaged) {

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -496,11 +496,22 @@ export class MonsterCharacter extends CharacterBase {
       { id: 'local', model: playerModel },
       ...Object.entries(otherPlayers).map(([id, p]) => ({ id, model: p.model }))
     ].filter(entry => entry.model);
+    const friendlyTargets = Array.isArray(context.friendlyTargets)
+      ? context.friendlyTargets
+        .filter((friendly) => friendly?.model && !friendly.isDead)
+        .map((friendly) => ({
+          id: friendly.id || 'friendly',
+          model: friendly.model,
+          entity: friendly,
+          targetType: 'friendly'
+        }))
+      : [];
+    const combatTargets = allPlayers.concat(friendlyTargets);
 
     let closestPlayer = null;
     let closestDistance = Infinity;
 
-    for (const player of allPlayers) {
+    for (const player of combatTargets) {
       const dist = this.model.position.distanceTo(player.model.position);
       if (dist < closestDistance) {
         closestDistance = dist;
@@ -565,7 +576,7 @@ export class MonsterCharacter extends CharacterBase {
       return;
     }
 
-    this.updateCombatAI(delta, closestPlayer, allPlayers, (player, hitContext = {}) => {
+    this.updateCombatAI(delta, closestPlayer, combatTargets, (player, hitContext = {}) => {
       const damage = Number.isFinite(hitContext.damage)
         ? Math.max(1, Math.round(hitContext.damage))
         : this.attackDamage;
@@ -576,7 +587,18 @@ export class MonsterCharacter extends CharacterBase {
       }
       const isInvincible = localControls?.isInvincible && Date.now() < (localControls.invincibleUntil || 0);
       const attackTypes = getAttackTypes(null, hitContext.attackTypes || ['melee']);
-      if (player.id === 'local' && !localControls?.isKnocked && !isInvincible) {
+      if (player.targetType === 'friendly') {
+        const friendly = player.entity;
+        if (!friendly?.model || friendly.isDead) return;
+        const killed = friendly.applyDamage?.(damage, { attackTypes });
+        if (!killed) {
+          friendly.applyKnockback?.({
+            direction: this.model.userData.direction.clone(),
+            strength: MONSTER_ATTACK.knockbackStrength
+          });
+        }
+        context.onFriendlyHit?.(friendly, { damage, killed: !!killed, sourceId: this.id, attackTypes });
+      } else if (player.id === 'local' && !localControls?.isKnocked && !isInvincible) {
         window.localHealth = Math.max(0, window.localHealth - damage);
         window.lastHitAttackTypes = attackTypes;
         if (localControls) {

--- a/characters/merchant.js
+++ b/characters/merchant.js
@@ -259,6 +259,9 @@ const loadMerchantFriendly = ({
     friendly.setLevel(1, { preserveHealth: false });
     friendly.resetHealth();
     friendly.model.userData.npcRole = 'merchant';
+    if (friendly.healthBar) {
+      friendly.healthBar.visible = false;
+    }
     friendly.model.userData.mode = 'engaged';
     const basePosition = merchantSpawnBasePosition.clone().add(MERCHANT_OFFSET);
     const terrainHeight = getTerrainHeight?.(basePosition.x, basePosition.z);

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -48,7 +48,9 @@ export function createFriendlyNpcManager({
   debug = false,
   onSpawnEvent,
   onBeforeSpawn,
-  onRemoteSpawnRequest
+  onRemoteSpawnRequest,
+  getMonsters,
+  onMonsterHit
 } = {}) {
   const friendlies = [];
   const records = new Map();
@@ -515,6 +517,8 @@ const getHealthForLevel = (level) => {
       maybeRequestSpawnFromDistance();
     }
     updateActiveFriendlies(!isHostNow);
+    const monsters = typeof getMonsters === 'function' ? (getMonsters() || []) : [];
+    const aiContext = { onMonsterHit };
     friendlies.forEach((friendly) => {
       if (!friendly?.model) return;
       const lastUpdate = friendly.lastAIUpdateMs ?? 0;
@@ -526,7 +530,7 @@ const getHealthForLevel = (level) => {
             lastUpdate > 0 ? elapsedSeconds : (Number.isFinite(delta) ? delta : 0)
           );
           friendly.lastAIUpdateMs = nowMs;
-          friendly.updateAI(aiDeltaSeconds, playerModel, otherPlayers);
+          friendly.updateAI(aiDeltaSeconds, playerModel, otherPlayers, monsters, aiContext);
         }
         persistFriendlyState(friendly);
       } else {

--- a/quest.js
+++ b/quest.js
@@ -16,6 +16,7 @@ const QUEST_FRIEND_DISENGAGE_RADIUS = 8;
 const QUEST_FRIEND_FOLLOW_DISTANCE = 3;
 const QUEST_FRIEND_FOLLOW_START_DISTANCE = 4.5;
 const QUEST_GENERIC_XP = 60;
+const QUEST_FRIEND_RESPAWN_DELAY_MS = 20000;
 
 const TUTORIAL_QUESTS = [
   {
@@ -91,8 +92,9 @@ export class QuestManager {
     this.state = {
       friend: null,
       pendingSpawn: false,
+      respawnAt: 0,
       deltaSeconds: 0,
-      shouldFollowPlayer: false,
+      shouldFollowPlayer: true,
       acceptedQuestIds: [],
       completedQuestIds: [],
       gpsQuestStartFix: null,
@@ -154,19 +156,36 @@ export class QuestManager {
     return this.isQuestFriend(friendly);
   }
 
+  cleanupQuestFriend() {
+    const friend = this.state.friend;
+    if (!friend) return;
+    this.detachPhysics?.(friend);
+    if (friend.model?.parent) {
+      friend.model.parent.remove(friend.model);
+    }
+    friend.model = null;
+    this.state.friend = null;
+  }
+
   ensureQuestFriendSpawned() {
-    if (this.state.friend?.isDead || !this.state.friend?.model) {
-      this.detachPhysics?.(this.state.friend);
-      this.state.friend = null;
+    const now = Date.now();
+    if (this.state.friend?.isDead || (this.state.friend && !this.state.friend.model)) {
+      this.cleanupQuestFriend();
+      this.state.respawnAt = now + QUEST_FRIEND_RESPAWN_DELAY_MS;
     }
     if (this.state.friend || this.state.pendingSpawn) return;
+    if (this.state.respawnAt && now < this.state.respawnAt) return;
     this.state.pendingSpawn = true;
+    this.state.respawnAt = 0;
 
+    const playerPosition = this.getPlayerModel?.()?.position;
     const angle = Math.random() * Math.PI * 2;
     const radius = QUEST_FRIEND_SPAWN_RADIUS_MIN
       + Math.random() * (QUEST_FRIEND_SPAWN_RADIUS_MAX - QUEST_FRIEND_SPAWN_RADIUS_MIN);
-    const spawnX = Math.cos(angle) * radius;
-    const spawnZ = Math.sin(angle) * radius;
+    const originX = Number.isFinite(playerPosition?.x) ? playerPosition.x : 0;
+    const originZ = Number.isFinite(playerPosition?.z) ? playerPosition.z : 0;
+    const spawnX = originX + Math.cos(angle) * radius;
+    const spawnZ = originZ + Math.sin(angle) * radius;
     const terrainHeight = getTerrainHeight(spawnX, spawnZ);
     const spawnY = Number.isFinite(terrainHeight) ? terrainHeight + 0.5 : 0.5;
 
@@ -183,7 +202,11 @@ export class QuestManager {
         questFriend.setWanderRadius(QUEST_FRIEND_WANDER_RADIUS);
         questFriend.setEngageRadius(QUEST_FRIEND_ENGAGE_RADIUS);
         questFriend.setDisengageRadius(QUEST_FRIEND_DISENGAGE_RADIUS);
-        questFriend.setFollowTarget(null);
+        questFriend.setFollowTarget(this.state.shouldFollowPlayer ? this.getPlayerModel?.() : null, {
+          followDistance: QUEST_FRIEND_FOLLOW_DISTANCE,
+          followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE,
+          helpingPlayerFight: this.state.shouldFollowPlayer
+        });
         questFriend.setLevel(1, { preserveHealth: false });
         questFriend.resetHealth();
         questFriend.setPosition(spawnX, spawnY, spawnZ);
@@ -209,10 +232,30 @@ export class QuestManager {
 
   getDialogueForFriendly(friendly, dialoguePool) {
     if (!this.isQuestFriend(friendly)) {
-      if (!Array.isArray(dialoguePool) || dialoguePool.length === 0) {
-        return null;
-      }
-      return dialoguePool[Math.floor(Math.random() * dialoguePool.length)];
+      const baseDialogue = Array.isArray(dialoguePool) && dialoguePool.length > 0
+        ? dialoguePool[Math.floor(Math.random() * dialoguePool.length)]
+        : { blocks: ["Hello, traveler."], responses: [] };
+      const isHelping = !!friendly?.helpingPlayerFight;
+      return {
+        blocks: [
+          ...(Array.isArray(baseDialogue.blocks) ? baseDialogue.blocks : []),
+          isHelping
+            ? "I’m helping you fight monsters. Want me to stop following you?"
+            : "Do you want help fighting monsters?"
+        ],
+        responses: [
+          ...(Array.isArray(baseDialogue.responses) ? baseDialogue.responses : []),
+          {
+            label: isHelping ? "stop helping" : "yes, help fight",
+            reply: isHelping ? "Okay, I’ll stop following you." : "You got it. I’ll follow you and fight nearby monsters.",
+            onSelect: isHelping ? "stopFriendlyMonsterHelp" : "startFriendlyMonsterHelp"
+          },
+          ...(!isHelping ? [{
+            label: "no thanks",
+            reply: "No problem. Stay safe out there."
+          }] : [])
+        ]
+      };
     }
 
     const quest = this.getCurrentSuggestedQuest();
@@ -223,6 +266,11 @@ export class QuestManager {
           "Nice work, adventurer. Keep exploring Street Quest!"
         ],
         responses: [
+          {
+            label: this.state.shouldFollowPlayer ? "stop following me" : "follow me",
+            reply: this.state.shouldFollowPlayer ? "Okay, I’ll stay here and keep watch." : "I’ll stick close and help fight monsters.",
+            onSelect: this.state.shouldFollowPlayer ? "stopFollowingQuestFriend" : "startFollowingQuestFriend"
+          },
           {
             label: "No thanks, see you later.",
             reply: "See you out there."
@@ -266,12 +314,18 @@ export class QuestManager {
             reply: "Okay, I’ll stay here and keep watch.",
             onSelect: "stopFollowingQuestFriend"
           }
-        ] : [])
+        ] : [
+          {
+            label: "follow me",
+            reply: "I’ll stick close and help fight monsters.",
+            onSelect: "startFollowingQuestFriend"
+          }
+        ])
       ]
     };
   }
 
-  handleDialogueOption(option) {
+  handleDialogueOption(option, activeFriendly = null) {
     if (!option?.onSelect) return;
     if (option.onSelect === "acceptTutorialQuest") {
       this.acceptSuggestedQuest();
@@ -279,7 +333,28 @@ export class QuestManager {
     }
     if (option.onSelect === "stopFollowingQuestFriend") {
       this.state.shouldFollowPlayer = false;
-      this.state.friend?.setFollowTarget(null);
+      this.state.friend?.setFollowTarget(null, { helpingPlayerFight: false });
+      return;
+    }
+    if (option.onSelect === "startFollowingQuestFriend") {
+      this.state.shouldFollowPlayer = true;
+      this.state.friend?.setFollowTarget(this.getPlayerModel?.(), {
+        followDistance: QUEST_FRIEND_FOLLOW_DISTANCE,
+        followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE,
+        helpingPlayerFight: true
+      });
+      return;
+    }
+    if (option.onSelect === "startFriendlyMonsterHelp" && activeFriendly?.setFollowTarget) {
+      activeFriendly.setFollowTarget(this.getPlayerModel?.(), {
+        followDistance: QUEST_FRIEND_FOLLOW_DISTANCE,
+        followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE,
+        helpingPlayerFight: true
+      });
+      return;
+    }
+    if (option.onSelect === "stopFriendlyMonsterHelp" && activeFriendly?.setFollowTarget) {
+      activeFriendly.setFollowTarget(null, { helpingPlayerFight: false });
     }
   }
 
@@ -293,7 +368,8 @@ export class QuestManager {
     this.state.shouldFollowPlayer = true;
     this.state.friend?.setFollowTarget(this.getPlayerModel?.(), {
       followDistance: QUEST_FRIEND_FOLLOW_DISTANCE,
-      followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE
+      followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE,
+      helpingPlayerFight: true
     });
     if (quest.id === "gps-walk-30m") {
       const latestFix = window.latestLocation;
@@ -446,12 +522,14 @@ export class QuestManager {
       if (this.state.shouldFollowPlayer) {
         friend.setFollowTarget(playerModel, {
           followDistance: QUEST_FRIEND_FOLLOW_DISTANCE,
-          followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE
+          followStartDistance: QUEST_FRIEND_FOLLOW_START_DISTANCE,
+          helpingPlayerFight: true
         });
       } else {
-        friend.setFollowTarget(null);
+        friend.setFollowTarget(null, { helpingPlayerFight: false });
       }
-      friend.updateAI(this.state.deltaSeconds, playerModel, {});
+      const monsters = Array.isArray(window.monsters) ? window.monsters : [];
+      friend.updateAI(this.state.deltaSeconds, playerModel, {}, monsters);
     }
     this.updateGpsQuestProgress();
     this.updateClimbQuestProgress();


### PR DESCRIPTION
### Motivation
- Let the quest-giving NPC and other non-merchant friendlies be recruitable followers that assist the player in combat and can take damage and die. 
- Reuse existing combat logic so friendlies fight monsters and monsters can attack friendlies, improving emergent combat interactions. 
- Ensure quest friend behavior is convenient (follows by default, can be told to stop) and robust (respawns after death). 

### Description
- Add helper state, visible health bars, melee damage, monster-targeting and a `findClosestMonster` helper to `characters/FriendlyCharacter.js`, and integrate friendly attacks via the existing `updateCombatAI` flow. 
- Allow monsters to consider friendlies as valid targets by extending `characters/MonsterCharacter.js` to accept `context.friendlyTargets` and to apply damage/knockback to friendly entities. 
- Wire the friendly manager and main app to supply monsters and monster-hit callbacks by updating `friendlyNpcManager.js` and `app/bootstrapGameApp.js` so host-side AI receives `friendlyTargets` and the quest friend is included in combat-aware friendly lists. 
- Update quest logic in `quest.js` so the quest friend follows by default (with dialogue options to `follow`/`stop following`), can be toggled to `helpingPlayerFight`, and respawns near the player after `20s` if killed; also add dialogue for recruiting regular friendlies to help fight. 
- Keep merchants out of combat helper flow by hiding merchant health bars in `characters/merchant.js`. 

### Testing
- Ran `npm run build` to verify the bundle builds successfully and the changes integrate with the game loop; the build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6fa6dc8483259e9b5ac81864e5a9)