### PR TITLE
Add bomb monster impact explosions

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -7353,6 +7353,25 @@ async function initCore(runtimeContext) {
     }
   });
 
+  function getBombExplosionGroundPosition(hitPosition, monster) {
+    const sourcePosition = monster?.model?.position ?? hitPosition;
+    const explosionPosition = sourcePosition?.clone?.() ?? new THREE.Vector3();
+    const groundY = getTerrainHeight(explosionPosition.x, explosionPosition.z);
+    if (Number.isFinite(groundY)) {
+      explosionPosition.y = groundY;
+    } else if (hitPosition?.isVector3 && Number.isFinite(hitPosition.y)) {
+      explosionPosition.y = Math.min(explosionPosition.y, hitPosition.y);
+    }
+    return explosionPosition;
+  }
+
+  function handleBombMonsterImpact({ hitPosition, monster } = {}, shooterId) {
+    const explosionPosition = getBombExplosionGroundPosition(hitPosition, monster);
+    spawnBombMist(scene, bombMists, explosionPosition);
+    applyBombImpactDamage(explosionPosition, shooterId);
+    return true;
+  }
+
   function spawnBombProjectileWithPerfFlags(scene, list, position, direction, shooterId) {
     if (!bomb?.mesh) return;
 
@@ -7368,10 +7387,14 @@ async function initCore(runtimeContext) {
       lifetime: BOMB_THROW_LIFETIME,
       colliderDesc: RAPIER.ColliderDesc.ball(0.18).setRestitution(0.3).setFriction(0.8),
       groundContactOffset: 0.18,
+      damage: getBombDamage(shooterId),
+      attackLabel: 'bombExplosion',
+      attackTypes: ['explosive'],
       onGroundHit: (hitPosition) => {
         spawnBombMist(scene, bombMists, hitPosition);
         applyBombImpactDamage(hitPosition, shooterId);
-      }
+      },
+      onMonsterImpact: (impact) => handleBombMonsterImpact(impact, shooterId)
     });
 
     const latest = list[list.length - 1];

--- a/items/projectiles.js
+++ b/items/projectiles.js
@@ -99,6 +99,9 @@ export function spawnProjectile(scene, projectiles, position, direction, shooter
   mesh.userData.isArrow = options.isArrow ?? false;
   mesh.userData.releaseMesh = options.releaseMesh ?? null;
   mesh.userData.onGroundHit = options.onGroundHit ?? null;
+  mesh.userData.onMonsterImpact = typeof options.onMonsterImpact === 'function'
+    ? options.onMonsterImpact
+    : null;
   mesh.userData.damage = Number.isFinite(options.damage) ? options.damage : 1;
   mesh.userData.attackLabel = typeof options.attackLabel === 'string' && options.attackLabel
     ? options.attackLabel
@@ -312,6 +315,18 @@ export function updateProjectiles({
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {
+          if (typeof proj.userData.onMonsterImpact === 'function') {
+            const handled = proj.userData.onMonsterImpact({
+              projectile: proj,
+              monster,
+              hitPosition: proj.position.clone()
+            });
+            if (handled) {
+              removeProjectile(i);
+              removed = true;
+              break;
+            }
+          }
           console.log(`💥 Monster was hit`);
           const baseDamage = Number.isFinite(proj.userData.damage) ? proj.userData.damage : 1;
           const damage = proj.userData.shooterId === localId ? getStrengthDamage(baseDamage) : baseDamage;
@@ -340,6 +355,18 @@ export function updateProjectiles({
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {
+          if (typeof proj.userData.onMonsterImpact === 'function') {
+            const handled = proj.userData.onMonsterImpact({
+              projectile: proj,
+              monster,
+              hitPosition: proj.position.clone()
+            });
+            if (handled) {
+              removeProjectile(i);
+              removed = true;
+              break;
+            }
+          }
           const baseDamage = Number.isFinite(proj.userData.damage) ? proj.userData.damage : 1;
           const damage = proj.userData.shooterId === localId ? getStrengthDamage(baseDamage) : baseDamage;
           const attackTypes = getAttackTypes(


### PR DESCRIPTION
### Motivation
- Thrown bombs currently remove monsters on direct hit without spawning the ground explosion visual or marking the hit as an explosive attack. The change makes direct-hit bombs behave like ground detonations visually and as an explosive damage type.

### Description
- Add a projectile-level hook `mesh.userData.onMonsterImpact` and call it from `updateProjectiles` before the default monster-hit handling so special projectiles can override direct-hit behavior (`items/projectiles.js`).
- Add `getBombExplosionGroundPosition` and `handleBombMonsterImpact` helpers and wire a bomb-specific `onMonsterImpact` handler so bombs spawn the same ground `spawnBombMist` at the monster’s ground position and call `applyBombImpactDamage` (`app/bootstrapGameApp.js`).
- Configure thrown bomb projectile metadata to include `damage: getBombDamage(shooterId)`, `attackLabel: 'bombExplosion'`, and `attackTypes: ['explosive']` so damage is treated as explosive when bombs hit directly (`app/bootstrapGameApp.js`).

### Testing
- Ran `npm run build`, which completed successfully and produced the production bundles.
- Verified the dev build includes the updated modules without build errors (no automated unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb716a1c448325b4478048b6918bfe)