### PR TITLE
Fix auto-aim camera tracking

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -1015,7 +1015,6 @@ export class PlayerControls {
       this.isFireHeld = false;
       this.autoAimBreakUntilRelease = false;
       this.autoAimCurrentPitch = 0;
-      this.autoAimCameraDirection = null;
       this.setAiming(false);
       const hand = this.getInventoryItemHand?.(throwItemId) || 'right';
       const autoAimDirection = this.getAutoAimDirection({ itemId: throwItemId, type: 'throw' });
@@ -3320,6 +3319,9 @@ export class PlayerControls {
       this.autoAimBreakUntilRelease = false;
       this.autoAimCameraDirection = null;
     } else {
+      if (this.autoAimCameraDirection) {
+        this.syncCameraOrbitToAutoAimDirection(this.autoAimCameraDirection);
+      }
       this.aimReleaseHoldUntil = performance.now() + this.aimReleaseDelayMs;
       this.autoAimBreakUntilRelease = false;
       this.autoAimCurrentPitch = 0;
@@ -3364,7 +3366,23 @@ export class PlayerControls {
     if (!direction) return;
     const d = direction.clone().normalize();
     this.autoAimCameraDirection = d;
-    this.yaw = Math.atan2(d.x, d.z);
+    this.syncCameraOrbitToAutoAimDirection(d);
+  }
+
+  syncCameraOrbitToAutoAimDirection(direction) {
+    if (!direction) return;
+    const d = direction.clone().normalize();
+    this.yaw = Math.atan2(-d.x, -d.z);
+
+    const horizontalAim = Math.max(0.001, Math.hypot(d.x, d.z));
+    const cameraOffset = this.cameraOffset || this.aimCameraOffset || this.baseCameraOffset;
+    const horizontalOffset = Math.max(0.001, Math.hypot(cameraOffset?.x ?? 0, cameraOffset?.z ?? 1));
+    const cameraOffsetY = cameraOffset?.y ?? 0;
+    const desiredVerticalOffset = -horizontalOffset * (d.y / horizontalAim);
+    const pitchRatio = THREE.MathUtils.clamp((desiredVerticalOffset - cameraOffsetY) / 5, -1, 1);
+    const maxPitch = Math.PI / 3;
+    const minPitch = -Math.PI / 8;
+    this.pitch = THREE.MathUtils.clamp(Math.asin(pitchRatio), minPitch, maxPitch);
   }
 
   breakAutoAimFromManualCamera() {

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -316,6 +316,7 @@ export class PlayerControls {
     this.isFireHeld = false;
     this.autoAimBreakUntilRelease = false;
     this.autoAimCurrentPitch = 0;
+    this.autoAimCameraDirection = null;
     this.baseCameraOffset = this.cameraOffset.clone();
     this.aimCameraOffset = this.baseCameraOffset.clone().add(new THREE.Vector3(0, 0, -3.2));
     this.weaponCameraOffset = this.baseCameraOffset.clone().add(WEAPON_CAMERA_OFFSET);
@@ -1014,6 +1015,7 @@ export class PlayerControls {
       this.isFireHeld = false;
       this.autoAimBreakUntilRelease = false;
       this.autoAimCurrentPitch = 0;
+      this.autoAimCameraDirection = null;
       this.setAiming(false);
       const hand = this.getInventoryItemHand?.(throwItemId) || 'right';
       const autoAimDirection = this.getAutoAimDirection({ itemId: throwItemId, type: 'throw' });
@@ -2582,7 +2584,7 @@ export class PlayerControls {
         // this.playerModel.rotation.y = yawAngle;
       }
       if (this.isFireHeld && this.shouldHoldToFire() && !slideMomentumActive) {
-        const aimDirection = this.getAimDirection(true);
+        const aimDirection = this.autoAimCameraDirection ?? this.getAimDirection(true);
         yawAngle = Math.atan2(aimDirection.x, aimDirection.z);
       }
       if (this.engagedDirection) {
@@ -2816,6 +2818,9 @@ export class PlayerControls {
     }
 
     this.camera.position.copy(resolvedCameraPosition);
+    if (this.shouldUseAutoAimCameraDirection()) {
+      cameraLookTarget = resolvedCameraPosition.clone().add(this.autoAimCameraDirection);
+    }
     this.camera.lookAt(cameraLookTarget);
 
     if (this.playerModel && this.playerModel.userData.mixer) {
@@ -3313,10 +3318,12 @@ export class PlayerControls {
     if (active) {
       this.aimReleaseHoldUntil = null;
       this.autoAimBreakUntilRelease = false;
+      this.autoAimCameraDirection = null;
     } else {
       this.aimReleaseHoldUntil = performance.now() + this.aimReleaseDelayMs;
       this.autoAimBreakUntilRelease = false;
       this.autoAimCurrentPitch = 0;
+      this.autoAimCameraDirection = null;
     }
   }
 
@@ -3338,21 +3345,26 @@ export class PlayerControls {
     const weapon = this.mobileThrowAimItemId
       ? { itemId: this.mobileThrowAimItemId, type: 'throw' }
       : this.getEquippedWeapon();
-    if (!this.isFireHeld || (!this.mobileThrowAimItemId && !this.shouldHoldToFire()) || this.isWeaponShoulderCameraActive()) return;
+    if (!this.isFireHeld || (!this.mobileThrowAimItemId && !this.shouldHoldToFire())) {
+      this.autoAimCameraDirection = null;
+      return;
+    }
     const invertForBow = weapon?.itemId === 'bow';
     const autoAimDirection = this.getAutoAimDirection(weapon);
     const direction = autoAimDirection ?? this.getAimDirection(invertForBow);
     this.alignPlayerToDirection(direction);
     if (autoAimDirection) {
       this.applyAutoAimCameraDirection(autoAimDirection);
+    } else {
+      this.autoAimCameraDirection = null;
     }
   }
 
   applyAutoAimCameraDirection(direction) {
     if (!direction) return;
     const d = direction.clone().normalize();
+    this.autoAimCameraDirection = d;
     this.yaw = Math.atan2(d.x, d.z);
-    this.pitch = Math.asin(THREE.MathUtils.clamp(d.y, -0.95, 0.95));
   }
 
   breakAutoAimFromManualCamera() {
@@ -3485,6 +3497,12 @@ export class PlayerControls {
     return !this.isEngaged && !this.isAiming;
   }
 
+  shouldUseAutoAimCameraDirection() {
+    return !!this.autoAimCameraDirection
+      && this.isFireHeld
+      && !this.autoAimBreakUntilRelease
+      && !this.isEngaged;
+  }
 
   alignPlayerToDirection(direction) {
     if (!this.playerModel) return;


### PR DESCRIPTION
### Motivation
- Players reported the bow/bomb auto-aim fires projectiles toward targets but the third-person/shoulder camera does not track the locked target, making aim feel incorrect while holding fire.
- The shoulder/zoom camera logic needs to observe the locked auto-aim direction independently from projectile spawn logic so the camera visually aligns with the lock while holding aim.

### Description
- Added a cached `autoAimCameraDirection` property on `PlayerControls` to store the active auto-aim direction while fire is held.
- Populated and cleared `autoAimCameraDirection` from `updateAimingRotation`, `applyAutoAimCameraDirection`, `setAiming`, and mobile throw handlers so the cached state is cleared when aiming stops or the lock is lost.
- Made camera tracking use the cached direction by adding `shouldUseAutoAimCameraDirection()` and, when true, adjusting `camera.lookAt()` to point along `autoAimCameraDirection`.  
- When holding fire, player facing (yaw) now prefers the cached `autoAimCameraDirection` if present so the character and shoulder camera remain aligned with the locked target.

### Testing
- Ran the production build with `npm run build` and the build completed successfully (vite build completed and `dist` assets were generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9187315c832586cb1b8b0713a037)