### PR TITLE
Add destructible low-poly bushes with drops and green leaf poof

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -5851,6 +5851,70 @@ async function initCore(runtimeContext) {
     });
   }
 
+  function getRandomBushDropPositions(origin, count, radius = 0.72) {
+    const positions = [];
+    if (!origin || count <= 0) return positions;
+    for (let i = 0; i < count; i += 1) {
+      const angle = (Math.PI * 2 * i) / count + Math.random() * 0.45;
+      const distance = radius * (0.55 + Math.random() * 0.45);
+      const dropPosition = origin.clone();
+      dropPosition.x += Math.cos(angle) * distance;
+      dropPosition.z += Math.sin(angle) * distance;
+      positions.push(dropPosition);
+    }
+    return positions;
+  }
+
+  function spawnBushRandomDrop(origin) {
+    if (!origin) return;
+    const roll = Math.random();
+    if (roll < 0.26) {
+      const count = 1 + Math.floor(Math.random() * 10);
+      getRandomBushDropPositions(origin, count, 0.95).forEach((dropPosition) => spawnCoinPickup(dropPosition));
+      return;
+    }
+    if (roll < 0.46) {
+      const count = 1 + Math.floor(Math.random() * 2);
+      getRandomBushDropPositions(origin, count).forEach((dropPosition) => spawnApplePickup(dropPosition));
+      return;
+    }
+    if (roll < 0.66) {
+      const count = 1 + Math.floor(Math.random() * 2);
+      getRandomBushDropPositions(origin, count).forEach((dropPosition) => {
+        const entry = MUSHROOM_ENTRIES[Math.floor(Math.random() * MUSHROOM_ENTRIES.length)];
+        if (entry?.id) spawnMushroomPickup(entry.id, dropPosition);
+      });
+      return;
+    }
+    if (roll < 0.82) {
+      spawnWoodPickup(origin.clone());
+    }
+  }
+
+  function destroyBush(bush) {
+    if (!bush) return false;
+    const position = natureController?.removeBush?.(bush);
+    if (!position) return false;
+    position.y = getTerrainHeight?.(position.x, position.z) ?? position.y ?? 0;
+    spawnImpactBurst(scene, position);
+    spawnGreenLeafStreaks(scene, position);
+    spawnBushRandomDrop(position);
+    return true;
+  }
+
+  function destroyBushesAtPositions(positions) {
+    if (!Array.isArray(positions) || positions.length === 0) return false;
+    positions.forEach((position) => {
+      const dropOrigin = position.clone?.() ?? asVec3(position);
+      if (!dropOrigin) return;
+      dropOrigin.y = getTerrainHeight?.(dropOrigin.x, dropOrigin.z) ?? dropOrigin.y ?? 0;
+      spawnImpactBurst(scene, dropOrigin);
+      spawnGreenLeafStreaks(scene, dropOrigin);
+      spawnBushRandomDrop(dropOrigin);
+    });
+    return true;
+  }
+
   function handleSwordTreeHit({ attacker, range }) {
     if (!attacker?.model?.position) return;
     const effectiveRange = (Number.isFinite(range) ? range : 0) + TREE_HIT_RANGE_BOOST;
@@ -7302,6 +7366,9 @@ async function initCore(runtimeContext) {
       }
     });
 
+    const removedBushPositions = natureController?.removeBushesInRadius?.(hitPosition, BOMB_DAMAGE_RADIUS) ?? [];
+    destroyBushesAtPositions(removedBushPositions);
+
     if (natureController?.removeRocksInRadius) {
       const removedRockPositions = natureController.removeRocksInRadius(hitPosition, BOMB_DAMAGE_RADIUS);
       if (removedRockPositions.length > 0) {
@@ -7951,11 +8018,11 @@ async function initCore(runtimeContext) {
     attackVisualState.impacts.push({ sprite, material, spawnTime: performance.now(), lifetimeMs: ATTACK_IMPACT_LIFETIME_MS });
   }
 
-  function spawnRedImpactStreaks(scene, position) {
+  function spawnImpactStreaks(scene, position, { color = 0xff3344, count = ATTACK_RED_STREAK_COUNT, lifetimeMs = ATTACK_RED_STREAK_LIFETIME_MS } = {}) {
     if (!scene || !position) return;
     const group = new THREE.Group();
     const material = new THREE.MeshBasicMaterial({
-      color: 0xff3344,
+      color,
       transparent: true,
       opacity: 0.95,
       depthWrite: false,
@@ -7963,10 +8030,10 @@ async function initCore(runtimeContext) {
       side: THREE.DoubleSide
     });
     const streaks = [];
-    for (let i = 0; i < ATTACK_RED_STREAK_COUNT; i += 1) {
+    for (let i = 0; i < count; i += 1) {
       const geometry = new THREE.PlaneGeometry(0.08, THREE.MathUtils.lerp(0.48, 0.95, Math.random()));
       const mesh = new THREE.Mesh(geometry, material);
-      const angle = (Math.PI * 2 * i) / ATTACK_RED_STREAK_COUNT + (Math.random() - 0.5) * 0.5;
+      const angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.5;
       mesh.position.set(0, THREE.MathUtils.lerp(0.18, 0.55, Math.random()), 0);
       mesh.rotation.x = -Math.PI / 2;
       mesh.rotation.z = angle;
@@ -7986,7 +8053,19 @@ async function initCore(runtimeContext) {
       material,
       streaks,
       spawnTime: performance.now(),
-      lifetimeMs: ATTACK_RED_STREAK_LIFETIME_MS
+      lifetimeMs
+    });
+  }
+
+  function spawnRedImpactStreaks(scene, position) {
+    spawnImpactStreaks(scene, position);
+  }
+
+  function spawnGreenLeafStreaks(scene, position) {
+    spawnImpactStreaks(scene, position, {
+      color: 0x68ff63,
+      count: 14,
+      lifetimeMs: ATTACK_RED_STREAK_LIFETIME_MS * 1.35
     });
   }
 
@@ -10908,6 +10987,11 @@ async function initCore(runtimeContext) {
     const attackerPosition = attacker?.model?.position;
     if (!attackerPosition) return false;
     const effectiveRange = Math.max(0.8, Number.isFinite(range) ? range : 1.5);
+    const bush = natureController?.getClosestBush?.(attackerPosition, effectiveRange, {
+      attackerModel: attacker?.model,
+      region: region || 'around'
+    });
+    if (bush && destroyBush(bush)) return true;
     let closest = null;
     let closestDistance = Number.POSITIVE_INFINITY;
     buildState.records.forEach((record, id) => {
@@ -10943,6 +11027,8 @@ async function initCore(runtimeContext) {
 
   const handleBuildProjectileHit = ({ projectileBox, damage } = {}) => {
     if (!projectileBox) return false;
+    const removedBushPositions = natureController?.removeBushesIntersectingBox?.(projectileBox) ?? [];
+    if (destroyBushesAtPositions(removedBushPositions)) return true;
     for (const [id, record] of buildState.records.entries()) {
       if (!record?.mesh) continue;
       buildHealthBarState.tempBox.setFromObject(record.mesh);
@@ -10956,7 +11042,9 @@ async function initCore(runtimeContext) {
 
   const handleBuildAreaHit = ({ position, radius, damage } = {}) => {
     if (!position || !Number.isFinite(radius)) return false;
-    let didHit = false;
+    const removedBushPositions = natureController?.removeBushesInRadius?.(position, radius) ?? [];
+    let didHit = destroyBushesAtPositions(removedBushPositions);
+
     buildState.records.forEach((record, id) => {
       if (!record?.mesh?.position) return;
       if (position.distanceTo(record.mesh.position) <= radius) {

--- a/environment/nature.js
+++ b/environment/nature.js
@@ -34,6 +34,10 @@ const TREE_TILE_BUFFER = 5;
 const NEAR_TILE_DISTANCE = 1;
 const ROCK_GRID_SPACING = 24;
 const ROCK_SPAWN_CHANCE = 0.28;
+const BUSH_GRID_SPACING = 18;
+const BUSH_SPAWN_CHANCE = 0.22;
+const BUSH_MIN_RADIUS = 0.55;
+const BUSH_MAX_RADIUS = 1.25;
 const ROCK_MIN_RADIUS = 0.45;
 const ROCK_MAX_RADIUS = 1.4;
 const ROCK_COLLIDER_HEIGHT_RATIO = 0.7;
@@ -253,6 +257,13 @@ export async function createNature({
   const rockGeometries = [
     new THREE.DodecahedronGeometry(1, 0),
     new THREE.IcosahedronGeometry(1, 0)
+  ];
+  const bushCoreGeometry = new THREE.DodecahedronGeometry(1, 0);
+  const bushLobeGeometry = new THREE.IcosahedronGeometry(1, 0);
+  const bushMaterials = [
+    new THREE.MeshStandardMaterial({ color: 0x2f7d32, roughness: 0.92, metalness: 0.01, flatShading: true }),
+    new THREE.MeshStandardMaterial({ color: 0x3f9a3e, roughness: 0.9, metalness: 0.01, flatShading: true }),
+    new THREE.MeshStandardMaterial({ color: 0x5da23b, roughness: 0.88, metalness: 0.01, flatShading: true })
   ];
   const treeImpostorTrunkGeometry = new THREE.CylinderGeometry(0.06, 0.08, 0.35, 5);
   const treeImpostorLeafGeometry = new THREE.ConeGeometry(0.28, 0.75, 6);
@@ -553,6 +564,46 @@ export async function createNature({
     return { rb, collider };
   };
 
+  const createBushImpostor = ({ worldX, worldZ, tileKey, radius, rotation, terrainY, variant }) => {
+    const bush = new THREE.Group();
+    bush.name = 'bush-impostor';
+    const material = bushMaterials[variant % bushMaterials.length];
+    const core = new THREE.Mesh(bushCoreGeometry, material);
+    core.castShadow = true;
+    core.receiveShadow = true;
+    core.position.y = radius * 0.42;
+    core.scale.set(radius * 0.95, radius * 0.58, radius * 0.85);
+    bush.add(core);
+
+    const lobeCount = 4 + (variant % 3);
+    for (let i = 0; i < lobeCount; i += 1) {
+      const lobeMaterial = bushMaterials[(variant + i + 1) % bushMaterials.length];
+      const lobe = new THREE.Mesh(bushLobeGeometry, lobeMaterial);
+      const angle = (Math.PI * 2 * i) / lobeCount;
+      const lobeRadius = radius * (0.46 + pseudoRandom2D(worldX + i, worldZ - i, 48.2) * 0.18);
+      lobe.castShadow = true;
+      lobe.receiveShadow = true;
+      lobe.position.set(Math.cos(angle) * radius * 0.44, radius * 0.36, Math.sin(angle) * radius * 0.44);
+      lobe.scale.set(lobeRadius, lobeRadius * 0.58, lobeRadius * 0.82);
+      lobe.rotation.set(
+        pseudoRandom2D(worldX, worldZ, 50 + i) * Math.PI,
+        angle + pseudoRandom2D(worldX, worldZ, 51 + i) * 0.8,
+        pseudoRandom2D(worldX, worldZ, 52 + i) * Math.PI
+      );
+      bush.add(lobe);
+    }
+
+    bush.position.set(worldX, terrainY, worldZ);
+    bush.rotation.y = rotation;
+    bush.userData = {
+      tileKey,
+      isBush: true,
+      interactable: true,
+      boundsRadius: radius * 1.35
+    };
+    return bush;
+  };
+
   const createTreeImpostor = ({
     worldX,
     worldZ,
@@ -624,6 +675,7 @@ export async function createNature({
     const baseZ = tile.y * tileSizeMeters;
     const trees = [];
     const rocks = [];
+    const bushes = [];
     const rockPhysics = [];
     const treePhysics = [];
     const tileClimbAreas = [];
@@ -721,6 +773,38 @@ export async function createNature({
       }
     }
 
+    for (let ix = 0; ix <= tileSizeMeters; ix += BUSH_GRID_SPACING) {
+      for (let iz = 0; iz <= tileSizeMeters; iz += BUSH_GRID_SPACING) {
+        const worldX = baseX + ix + (pseudoRandom2D(baseX + ix, baseZ + iz, 41.1) - 0.5) * BUSH_GRID_SPACING * 0.45;
+        const worldZ = baseZ + iz + (pseudoRandom2D(baseX + ix, baseZ + iz, 41.7) - 0.5) * BUSH_GRID_SPACING * 0.45;
+        if (pseudoRandom2D(worldX, worldZ, 42.3) > BUSH_SPAWN_CHANCE) continue;
+
+        const radius = BUSH_MIN_RADIUS
+          + pseudoRandom2D(worldX, worldZ, 43.9) * (BUSH_MAX_RADIUS - BUSH_MIN_RADIUS);
+        tempPosition.set(worldX, 0, worldZ);
+        const bushBlockerProbe = {
+          position: tempPosition,
+          userData: { boundsRadius: radius * 1.45 }
+        };
+        if (tileBlockers && isTreeBlocked(bushBlockerProbe, tileBlockers)) {
+          continue;
+        }
+
+        const terrainY = getTerrainHeight?.(worldX, worldZ) ?? 0;
+        const bush = createBushImpostor({
+          worldX,
+          worldZ,
+          tileKey,
+          radius,
+          rotation: pseudoRandom2D(worldX, worldZ, 45.1) * Math.PI * 2,
+          terrainY,
+          variant: Math.floor(pseudoRandom2D(worldX, worldZ, 46.8) * 1000)
+        });
+        tileGroup.add(bush);
+        bushes.push(bush);
+      }
+    }
+
     for (let ix = 0; ix <= tileSizeMeters; ix += ROCK_GRID_SPACING) {
       for (let iz = 0; iz <= tileSizeMeters; iz += ROCK_GRID_SPACING) {
         const worldX = baseX + ix;
@@ -776,6 +860,7 @@ export async function createNature({
       group: tileGroup,
       trees,
       rocks,
+      bushes,
       rockPhysics,
       treePhysics
     };
@@ -967,6 +1052,99 @@ export async function createNature({
     return true;
   };
 
+  const getClosestBush = (position, range, { attackerModel, region = 'around' } = {}) => {
+    if (!position || !Number.isFinite(range)) return null;
+    const maxDistance = Math.max(0, range);
+    let closest = null;
+    let closestDistance = Infinity;
+    const forward = new THREE.Vector3();
+    const toBush = new THREE.Vector3();
+    const right = new THREE.Vector3();
+    if (region === 'forward' && attackerModel?.getWorldDirection) {
+      attackerModel.getWorldDirection(forward);
+      forward.y = 0;
+      if (forward.lengthSq() < 0.0001) forward.set(0, 0, 1);
+      else forward.normalize();
+      right.set(forward.z, 0, -forward.x);
+    }
+    for (const entry of treeTiles.values()) {
+      for (const bush of entry.bushes ?? []) {
+        if (!bush?.position || bush.userData?.isRemoved) continue;
+        toBush.subVectors(bush.position, position);
+        toBush.y = 0;
+        const distance = toBush.length();
+        const paddedRange = maxDistance + (bush.userData?.boundsRadius ?? 0.6);
+        if (distance > paddedRange) continue;
+        if (region === 'forward' && forward.lengthSq() > 0) {
+          const forwardDistance = toBush.dot(forward);
+          const lateralDistance = Math.abs(toBush.dot(right));
+          if (forwardDistance < -0.2 || forwardDistance > paddedRange || lateralDistance > paddedRange) continue;
+        }
+        if (distance < closestDistance) {
+          closestDistance = distance;
+          closest = bush;
+        }
+      }
+    }
+    return closest;
+  };
+
+  const removeBush = (bush) => {
+    if (!bush) return null;
+    const tileKey = bush.userData?.tileKey;
+    const entry = tileKey ? treeTiles.get(tileKey) : null;
+    if (!entry) return null;
+    const index = (entry.bushes ?? []).indexOf(bush);
+    if (index === -1) return null;
+    entry.bushes.splice(index, 1);
+    bush.userData.isRemoved = true;
+    const position = bush.position?.clone?.() ?? null;
+    entry.group.remove(bush);
+    return position;
+  };
+
+  const removeBushesInRadius = (position, radius = 0) => {
+    if (!position || !Number.isFinite(radius) || radius <= 0) return [];
+    const removed = [];
+    const radiusSq = radius * radius;
+    for (const entry of treeTiles.values()) {
+      if (!Array.isArray(entry?.bushes) || !entry.bushes.length) continue;
+      for (let i = entry.bushes.length - 1; i >= 0; i -= 1) {
+        const bush = entry.bushes[i];
+        if (!bush?.position) continue;
+        const dx = bush.position.x - position.x;
+        const dz = bush.position.z - position.z;
+        const paddedRadius = radius + (bush.userData?.boundsRadius ?? 0.6);
+        if ((dx * dx) + (dz * dz) > Math.max(radiusSq, paddedRadius * paddedRadius)) continue;
+        removed.push(bush.position.clone());
+        bush.userData.isRemoved = true;
+        entry.bushes.splice(i, 1);
+        entry.group.remove(bush);
+      }
+    }
+    return removed;
+  };
+
+  const removeBushesIntersectingBox = (box) => {
+    if (!box) return [];
+    const removed = [];
+    const bushBox = new THREE.Box3();
+    for (const entry of treeTiles.values()) {
+      if (!Array.isArray(entry?.bushes) || !entry.bushes.length) continue;
+      for (let i = entry.bushes.length - 1; i >= 0; i -= 1) {
+        const bush = entry.bushes[i];
+        if (!bush) continue;
+        bushBox.setFromObject(bush);
+        if (!box.intersectsBox(bushBox)) continue;
+        removed.push(bush.position.clone());
+        bush.userData.isRemoved = true;
+        entry.bushes.splice(i, 1);
+        entry.group.remove(bush);
+      }
+    }
+    return removed;
+  };
+
   const removeRocksInRadius = (position, radius = 0) => {
     if (!position || !Number.isFinite(radius) || radius <= 0) return [];
     const removed = [];
@@ -1081,6 +1259,9 @@ export async function createNature({
     refreshClimbableAreas();
     rockGeometries.forEach((geometry) => geometry.dispose());
     rockMaterial.dispose();
+    bushCoreGeometry.dispose();
+    bushLobeGeometry.dispose();
+    bushMaterials.forEach((material) => material.dispose());
     treeImpostorTrunkGeometry.dispose();
     treeImpostorLeafGeometry.dispose();
     treeImpostorTrunkMaterial.dispose();
@@ -1108,7 +1289,11 @@ export async function createNature({
     refreshAll,
     setTileCache,
     getClosestTree,
+    getClosestBush,
     removeTree,
+    removeBush,
+    removeBushesInRadius,
+    removeBushesIntersectingBox,
     removeRocksInRadius,
     spawnQuestRock,
     setTreeColliderEnabled,


### PR DESCRIPTION
### Motivation
- Add low-poly bushes to the procedural nature system so they spawn like rocks/trees and provide interactive world content. 
- Allow melee, kick/punch, projectile/arrow and area/bomb hits to destroy bushes and produce satisfying visual and loot feedback. 

### Description
- Add bush spawn configuration and geometry to `environment/nature.js` with constants `BUSH_GRID_SPACING`, `BUSH_SPAWN_CHANCE`, `BUSH_MIN_RADIUS`, `BUSH_MAX_RADIUS` and new `createBushImpostor` that composes a low-poly core + lobes and `bushMaterials`. 
- Integrate bush spawning into `createTileTrees` and track `bushes` per tile, plus new APIs: `getClosestBush`, `removeBush`, `removeBushesInRadius`, and `removeBushesIntersectingBox`, and ensure disposal of bush geometries/materials in `dispose`. 
- Add helper visuals and drop behavior in `app/bootstrapGameApp.js`: refactor `spawnImpactStreaks`, add `spawnGreenLeafStreaks`, add `getRandomBushDropPositions`, `spawnBushRandomDrop` (randomized drops: 1-10 coins, 1-2 apples, 1-2 mushrooms, 1 wood, or nothing), and functions `destroyBush` / `destroyBushesAtPositions` that play impact + green leaf streaks and spawn drops. 
- Wire bush destruction into combat and world-impact flows by calling new nature APIs from build/attack/projectile/area handlers so hits (sword/punch/kick/arrow/bomb/projectile) remove bushes and spawn effects/drops. 

### Testing
- Ran `npm run build` to validate code compiles and bundles for production; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca45220c08325bf6dcbd12069b6a9)