### PR TITLE
Add craftable wooden shield (left-hand) with blocking and shield health

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -1743,6 +1743,7 @@ async function initCore(runtimeContext) {
         if (!Array.isArray(drop.rotation) || drop.rotation.length !== 4 || !drop.rotation.every(isFiniteNumber)) return false;
         if (drop.quantity != null && !isFiniteNumber(drop.quantity)) return false;
         if (drop.torchHealth != null && !isFiniteNumber(drop.torchHealth)) return false;
+        if (drop.shieldHealth != null && !isFiniteNumber(drop.shieldHealth)) return false;
         return true;
       });
     };
@@ -1760,7 +1761,8 @@ async function initCore(runtimeContext) {
       && typeof payload.dropId === 'string'
       && (payload.itemId == null || typeof payload.itemId === 'string')
       && (payload.quantity == null || isFiniteNumber(payload.quantity))
-      && (payload.torchHealth == null || isFiniteNumber(payload.torchHealth));
+      && (payload.torchHealth == null || isFiniteNumber(payload.torchHealth))
+      && (payload.shieldHealth == null || isFiniteNumber(payload.shieldHealth));
 
     const isGrabMessage = payload => isObject(payload)
       && payload.type === 'grab'
@@ -2288,7 +2290,7 @@ async function initCore(runtimeContext) {
 
     if (previousHostId !== newHostId) {
       clearAllRemoteHeldWeaponMeshes();
-      [iceGun, bow, bomb, autumnSword, lantern, torch].forEach((weapon) => {
+      [iceGun, bow, bomb, autumnSword, lantern, torch, shield].forEach((weapon) => {
         if (!weapon) return;
         weapon.remoteHolderId = null;
       });
@@ -2368,6 +2370,7 @@ async function initCore(runtimeContext) {
   let autumnSword;
   let lantern;
   let torch;
+  let shield;
   let bomb;
   let treasureChest;
   let bed;
@@ -2652,6 +2655,7 @@ async function initCore(runtimeContext) {
     const remoteEquipByType = {
       lantern,
       torch,
+      shield,
       iceGun: iceGun,
       bow,
       bomb,
@@ -2670,6 +2674,7 @@ async function initCore(runtimeContext) {
 
     setRemoteEquipState('lantern', nextLeft === 'lantern');
     setRemoteEquipState('torch', nextLeft === 'torch');
+    setRemoteEquipState('shield', nextLeft === 'shield');
     setRemoteEquipState('iceGun', nextRight === 'iceGun');
     setRemoteEquipState('bow', nextRight === 'bow');
     setRemoteEquipState('bomb', nextRight === 'bomb');
@@ -2682,7 +2687,7 @@ async function initCore(runtimeContext) {
     Array.from(remoteHeldWeaponMeshes.keys()).forEach(disposeRemoteHeldWeaponMesh);
   };
 
-  const { IceGun, Bow, Lantern, AutumnSword, Bomb } = await loadSpecialWeapons();
+  const { IceGun, Bow, Lantern, AutumnSword, Bomb, Shield, SHIELD_ITEM_ID, DEFAULT_SHIELD_HEALTH } = await loadSpecialWeapons();
 
   const updateWeaponMarker = (weapon, marker, rotationSpeed, offsetY = 1.2) => {
     if (!weapon?.mesh || !marker) return;
@@ -3253,8 +3258,78 @@ async function initCore(runtimeContext) {
     isLocallyControlled: () => torch?.holder === playerControls
   });
 
-  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch };
-  window.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch };
+  shield = new Shield(scene);
+  await shield.load(playerModel.position.clone().add(new THREE.Vector3(2, 0, 2.4)));
+  window.shield = shield;
+  const shieldMarker = createWeaponMarker(0x7a4a20);
+  shield.onPickup = (holder) => {
+    if (holder !== playerControls) return;
+    const heldMesh = ensureLocalHeldWeaponMesh(shield, SHIELD_ITEM_ID);
+    if (heldMesh) {
+      shield.useHeldMeshWhenHeld = true;
+      heldMesh.visible = true;
+    }
+    unequipOtherInventoryItems(SHIELD_ITEM_ID);
+    const pickupHealth = normalizeShieldHealth(shield.mesh?.userData?.shieldHealth);
+    addToInventory(SHIELD_ITEM_ID, 1);
+    inventoryState[SHIELD_ITEM_ID] = ensureCatalogEntry(SHIELD_ITEM_ID, normalizeShieldEntry({
+      ...inventoryState[SHIELD_ITEM_ID],
+      [SHIELD_HEALTH_KEY]: pickupHealth
+    }));
+    shield.localHoldOrigin = 'world';
+  };
+  shield.onDrop = (holder, { removeFromInventory: shouldRemoveFromInventory } = {}) => {
+    if (holder !== playerControls) return;
+    shield.localHoldOrigin = null;
+    if (shouldRemoveFromInventory) {
+      removeFromInventory(SHIELD_ITEM_ID, 1);
+    }
+  };
+  if (shield.mesh) {
+    shield.mesh.userData.hideInMapView = true;
+    shield.mesh.userData.shieldHealth = DEFAULT_SHIELD_HEALTH;
+    shield.mesh.userData.shieldMaxHealth = DEFAULT_SHIELD_HEALTH;
+    shield.mesh.visible = false;
+  }
+  registerNetworkedEntity('shield', {
+    getState: () => {
+      if (!shield?.mesh) return null;
+      const pos = shield.mesh.position;
+      const q = shield.mesh.quaternion;
+      return {
+        position: [pos.x, pos.y, pos.z],
+        rotation: [q.x, q.y, q.z, q.w],
+        holderId: (shield.holder === playerControls && shield.localHoldOrigin === 'world') ? multiplayer?.getId?.() : null,
+        shieldHealth: shield.mesh.userData.shieldHealth ?? DEFAULT_SHIELD_HEALTH
+      };
+    },
+    applyState: state => {
+      if (!shield?.mesh || !state) return;
+      const [px, py, pz] = state.position || [];
+      const [rx, ry, rz, rw] = state.rotation || [];
+      if (Number.isFinite(px) && Number.isFinite(py) && Number.isFinite(pz)) {
+        shield.mesh.position.set(px, py, pz);
+      }
+      if (Number.isFinite(rx) && Number.isFinite(ry) && Number.isFinite(rz) && Number.isFinite(rw)) {
+        shield.mesh.quaternion.set(rx, ry, rz, rw);
+      }
+      if (Number.isFinite(state.shieldHealth)) {
+        shield.mesh.userData.shieldHealth = normalizeShieldHealth(state.shieldHealth);
+      }
+      const previousHolderId = shield.remoteHolderId ?? null;
+      shield.remoteHolderId = state.holderId ?? getPresenceHolderForWeaponType(shield.type);
+      updateRemoteWeaponType(shield, shield.remoteHolderId, previousHolderId);
+      if (state.holderId !== multiplayer?.getId?.() && shield.holder === playerControls && shield.localHoldOrigin === 'world') {
+        shield.holder = null;
+        shield.localHoldOrigin = null;
+      }
+    },
+    isLocallyControlled: () => shield?.holder === playerControls
+  });
+
+
+  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch, shield };
+  window.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch, shield };
   treasureChest = new TreasureChest(scene);
   await treasureChest.load();
   window.treasureChest = treasureChest;
@@ -4631,6 +4706,25 @@ async function initCore(runtimeContext) {
   const getTorchHealths = (entry) => (
     Array.isArray(entry?.[TORCH_HEALTH_KEY]) ? [...entry[TORCH_HEALTH_KEY]] : []
   );
+  const SHIELD_HEALTH_KEY = 'shieldHealth';
+  const SHIELD_MAX_HEALTH_KEY = 'shieldMaxHealth';
+  const normalizeShieldHealth = (value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return DEFAULT_SHIELD_HEALTH;
+    }
+    return Math.max(0, Math.min(DEFAULT_SHIELD_HEALTH, numeric));
+  };
+  const normalizeShieldEntry = (entry = {}) => {
+    const countValue = Number.isFinite(entry.count) ? Math.max(0, Math.floor(entry.count)) : 0;
+    const health = normalizeShieldHealth(entry[SHIELD_HEALTH_KEY]);
+    return {
+      ...entry,
+      count: countValue > 0 && health > 0 ? countValue : 0,
+      [SHIELD_HEALTH_KEY]: health,
+      [SHIELD_MAX_HEALTH_KEY]: DEFAULT_SHIELD_HEALTH
+    };
+  };
   const inventoryCatalog = {
     iceGun: {
       name: 'Ice Gun',
@@ -4655,6 +4749,10 @@ async function initCore(runtimeContext) {
     torch: {
       name: 'Torch (Left Hand)',
       icon: '/assets/ui/items/torch.png'
+    },
+    [SHIELD_ITEM_ID]: {
+      name: 'Shield (Left Hand)',
+      icon: ''
     },
     [LIFE_POTION_ITEM_ID]: {
       name: 'Life Potion',
@@ -4711,10 +4809,15 @@ async function initCore(runtimeContext) {
     const catalogEntry = ensureCatalogEntry(itemId, entry);
     const nextEntry = itemId === TORCH_ITEM_ID
       ? normalizeTorchEntry(catalogEntry)
-      : catalogEntry;
+      : itemId === SHIELD_ITEM_ID
+        ? normalizeShieldEntry(catalogEntry)
+        : catalogEntry;
     const healthsChanged = itemId === TORCH_ITEM_ID
       && JSON.stringify(nextEntry[TORCH_HEALTH_KEY]) !== JSON.stringify(entry?.[TORCH_HEALTH_KEY]);
-    if (nextEntry.name !== entry?.name || nextEntry.icon !== entry?.icon || healthsChanged) {
+    const shieldHealthChanged = itemId === SHIELD_ITEM_ID
+      && (nextEntry[SHIELD_HEALTH_KEY] !== entry?.[SHIELD_HEALTH_KEY]
+        || nextEntry[SHIELD_MAX_HEALTH_KEY] !== entry?.[SHIELD_MAX_HEALTH_KEY]);
+    if (nextEntry.name !== entry?.name || nextEntry.icon !== entry?.icon || healthsChanged || shieldHealthChanged) {
       inventoryDirty = true;
     }
     inventoryState[itemId] = nextEntry;
@@ -4723,10 +4826,15 @@ async function initCore(runtimeContext) {
     const catalogEntry = ensureCatalogEntry(itemId, entry);
     const nextEntry = itemId === TORCH_ITEM_ID
       ? normalizeTorchEntry(catalogEntry)
-      : catalogEntry;
+      : itemId === SHIELD_ITEM_ID
+        ? normalizeShieldEntry(catalogEntry)
+        : catalogEntry;
     const healthsChanged = itemId === TORCH_ITEM_ID
       && JSON.stringify(nextEntry[TORCH_HEALTH_KEY]) !== JSON.stringify(entry?.[TORCH_HEALTH_KEY]);
-    if (nextEntry.name !== entry?.name || nextEntry.icon !== entry?.icon || healthsChanged) {
+    const shieldHealthChanged = itemId === SHIELD_ITEM_ID
+      && (nextEntry[SHIELD_HEALTH_KEY] !== entry?.[SHIELD_HEALTH_KEY]
+        || nextEntry[SHIELD_MAX_HEALTH_KEY] !== entry?.[SHIELD_MAX_HEALTH_KEY]);
+    if (nextEntry.name !== entry?.name || nextEntry.icon !== entry?.icon || healthsChanged || shieldHealthChanged) {
       homeStorageDirty = true;
     }
     homeStorageState[itemId] = nextEntry;
@@ -4765,6 +4873,13 @@ async function initCore(runtimeContext) {
     };
     inventoryDirty = true;
   }
+  if (inventoryState[SHIELD_ITEM_ID]?.name !== inventoryCatalog[SHIELD_ITEM_ID].name) {
+    inventoryState[SHIELD_ITEM_ID] = normalizeShieldEntry({
+      ...(inventoryState[SHIELD_ITEM_ID] || {}),
+      name: inventoryCatalog[SHIELD_ITEM_ID].name
+    });
+    inventoryDirty = true;
+  }
   if (homeStorageState.lantern?.name !== inventoryCatalog.lantern.name) {
     homeStorageState.lantern = {
       ...(homeStorageState.lantern || {}),
@@ -4783,10 +4898,11 @@ async function initCore(runtimeContext) {
     saveStatsThrottled(profileNameKey, statsState, lastStatUpdateAt, inventoryState, homeStorageState);
   }
 
-  const equippableItems = new Set(['lantern', 'torch', 'iceGun', 'bow', 'bomb', 'autumnSword']);
+  const equippableItems = new Set(['lantern', 'torch', SHIELD_ITEM_ID, 'iceGun', 'bow', 'bomb', 'autumnSword']);
   const inventoryHandSlots = {
     lantern: 'left',
     torch: 'left',
+    [SHIELD_ITEM_ID]: 'left',
     iceGun: 'right',
     bow: 'right',
     bomb: 'right',
@@ -4889,6 +5005,7 @@ async function initCore(runtimeContext) {
     if (itemId === 'coins') return '🪙';
     if (itemId === ICE_AMMO_KEY || itemId === 'iceGun') return '❄️';
     if (itemId === ARROW_AMMO_KEY || itemId === 'bow') return '🏹';
+    if (itemId === SHIELD_ITEM_ID) return '🛡️';
     if (itemId === APPLE_ITEM_ID) return '🍎';
     if (itemId?.startsWith?.('mushroom_')) return '🍄';
     return '🎒';
@@ -5145,6 +5262,9 @@ async function initCore(runtimeContext) {
     if (itemId === 'torch') {
       return torch?.holder === playerControls;
     }
+    if (itemId === SHIELD_ITEM_ID) {
+      return shield?.holder === playerControls;
+    }
     if (itemId === 'iceGun') {
       return iceGun?.holder === playerControls;
     }
@@ -5164,6 +5284,7 @@ async function initCore(runtimeContext) {
     if (hand === 'left') {
       if (isInventoryItemEquipped('torch')) return 'torch';
       if (isInventoryItemEquipped('lantern')) return 'lantern';
+      if (isInventoryItemEquipped(SHIELD_ITEM_ID)) return SHIELD_ITEM_ID;
       return null;
     }
     if (hand === 'right') {
@@ -5266,6 +5387,30 @@ async function initCore(runtimeContext) {
       updateSettingsUI();
       return;
     }
+    if (itemId === SHIELD_ITEM_ID) {
+      if (!shield?.mesh || !playerControls) return;
+      const entry = normalizeShieldEntry(inventoryState[SHIELD_ITEM_ID]);
+      if (!entry.count || entry[SHIELD_HEALTH_KEY] <= 0) {
+        delete inventoryState[SHIELD_ITEM_ID];
+        persistInventoryAndStorage();
+        return;
+      }
+      inventoryState[SHIELD_ITEM_ID] = ensureCatalogEntry(SHIELD_ITEM_ID, entry);
+      const heldMesh = ensureLocalHeldWeaponMesh(shield, SHIELD_ITEM_ID, { forceNew: true });
+      shield.useHeldMeshWhenHeld = true;
+      if (heldMesh) {
+        heldMesh.userData.shieldHealth = entry[SHIELD_HEALTH_KEY];
+        heldMesh.userData.shieldMaxHealth = entry[SHIELD_MAX_HEALTH_KEY];
+        heldMesh.visible = true;
+      }
+      shield.mesh.userData.shieldHealth = entry[SHIELD_HEALTH_KEY];
+      shield.mesh.userData.shieldMaxHealth = entry[SHIELD_MAX_HEALTH_KEY];
+      shield.mesh.visible = false;
+      shield.localHoldOrigin = 'inventory';
+      shield.holder = playerControls;
+      updateSettingsUI();
+      return;
+    }
     if (itemId === 'iceGun') {
       if (!iceGun?.mesh || !playerControls) return;
       const heldMesh = ensureLocalHeldWeaponMesh(iceGun, 'iceGun', { forceNew: true });
@@ -5364,6 +5509,19 @@ async function initCore(runtimeContext) {
       }
       clearPlayerWeaponType(playerControls, torch.type);
       audioManager?.stopLoopingSFX('torch-loop');
+      updateSettingsUI();
+      return;
+    }
+    if (itemId === SHIELD_ITEM_ID) {
+      if (shield?.holder !== playerControls) return;
+      shield.holder = null;
+      shield.localHoldOrigin = null;
+      if (shield.mesh) {
+        shield.mesh.visible = false;
+      }
+      if (shield.heldMesh) {
+        shield.heldMesh.visible = false;
+      }
       updateSettingsUI();
       return;
     }
@@ -6004,6 +6162,7 @@ async function initCore(runtimeContext) {
       quaternion,
       allowHidden = false,
       torchHealth,
+      shieldHealth,
       dropId,
       shouldBroadcastRemoval = true,
       onPickup
@@ -6026,6 +6185,9 @@ async function initCore(runtimeContext) {
     if (itemId === TORCH_ITEM_ID && Number.isFinite(torchHealth)) {
       pickupMesh.userData.torchHealth = normalizeTorchHealth(torchHealth);
     }
+    if (itemId === SHIELD_ITEM_ID && Number.isFinite(shieldHealth)) {
+      pickupMesh.userData.shieldHealth = normalizeShieldHealth(shieldHealth);
+    }
     scene.add(pickupMesh);
     const marker = createWeaponMarker(markerColor);
     const pickup = {
@@ -6036,6 +6198,7 @@ async function initCore(runtimeContext) {
       type: item?.type || itemId,
       holder: null,
       torchHealth: Number.isFinite(torchHealth) ? normalizeTorchHealth(torchHealth) : null,
+      shieldHealth: Number.isFinite(shieldHealth) ? normalizeShieldHealth(shieldHealth) : null,
       markerOffsetY,
       dropId: dropId || null,
       shouldBroadcastRemoval: !!shouldBroadcastRemoval,
@@ -6047,6 +6210,13 @@ async function initCore(runtimeContext) {
           addToInventory(itemId, pickup.quantity, {
             torchHealth: pickup.torchHealth ?? pickupMesh.userData.torchHealth ?? DEFAULT_TORCH_HEALTH
           });
+        } else if (itemId === SHIELD_ITEM_ID) {
+          addToInventory(itemId, pickup.quantity);
+          inventoryState[SHIELD_ITEM_ID] = ensureCatalogEntry(SHIELD_ITEM_ID, normalizeShieldEntry({
+            ...inventoryState[SHIELD_ITEM_ID],
+            [SHIELD_HEALTH_KEY]: pickup.shieldHealth ?? pickupMesh.userData.shieldHealth ?? DEFAULT_SHIELD_HEALTH
+          }));
+          persistInventoryAndStorage();
         } else {
           addToInventory(itemId, pickup.quantity);
         }
@@ -6062,7 +6232,7 @@ async function initCore(runtimeContext) {
           droppedWeaponPickups.splice(index, 1);
         }
         if (pickup.dropId && pickup.shouldBroadcastRemoval && multiplayer && !multiplayer.isHost) {
-          multiplayer.send({ type: 'dropWeaponPickup', dropId: pickup.dropId, itemId: pickup.itemId, quantity: pickup.quantity, torchHealth: pickup.torchHealth });
+          multiplayer.send({ type: 'dropWeaponPickup', dropId: pickup.dropId, itemId: pickup.itemId, quantity: pickup.quantity, torchHealth: pickup.torchHealth, shieldHealth: pickup.shieldHealth });
         }
         if (pickup.dropId) {
           networkDroppedWeaponPickups.delete(pickup.dropId);
@@ -6494,7 +6664,8 @@ async function initCore(runtimeContext) {
       bomb,
       autumnSword,
       lantern,
-      torch
+      torch,
+      shield
     };
     const item = itemMap[itemId];
     if (!item?.mesh) {
@@ -6509,11 +6680,16 @@ async function initCore(runtimeContext) {
         ? 0xffc26b
         : itemId === TORCH_ITEM_ID
           ? 0xffa54c
+          : itemId === SHIELD_ITEM_ID
+            ? 0x7a4a20
           : itemId === 'bomb'
             ? 0xff4d4d
             : 0xffd400;
       const torchPickupHealth = itemId === TORCH_ITEM_ID
         ? takeTorchHealth(inventoryState)?.health
+        : null;
+      const shieldPickupHealth = itemId === SHIELD_ITEM_ID
+        ? normalizeShieldHealth(inventoryState[SHIELD_ITEM_ID]?.[SHIELD_HEALTH_KEY] ?? item.mesh?.userData?.shieldHealth)
         : null;
       const dropId = createNetworkDropId('weapon');
       const q = playerControls?.playerModel?.quaternion || item.mesh?.quaternion;
@@ -6532,6 +6708,7 @@ async function initCore(runtimeContext) {
         position: dropPosition,
         quaternion: q,
         torchHealth: torchPickupHealth ?? undefined,
+        shieldHealth: shieldPickupHealth ?? undefined,
         dropId,
         allowHidden: true
       });
@@ -6545,7 +6722,8 @@ async function initCore(runtimeContext) {
             position: [pos.x, pos.y, pos.z],
             rotation: [q.x, q.y, q.z, q.w],
             quantity: 1,
-            torchHealth: torchPickupHealth ?? undefined
+            torchHealth: torchPickupHealth ?? undefined,
+            shieldHealth: shieldPickupHealth ?? undefined
           }]
         });
       }
@@ -6560,11 +6738,16 @@ async function initCore(runtimeContext) {
         ? 0xffc26b
         : itemId === TORCH_ITEM_ID
           ? 0xffa54c
+          : itemId === SHIELD_ITEM_ID
+            ? 0x7a4a20
           : itemId === 'bomb'
             ? 0xff4d4d
             : 0xffd400;
       const torchPickupHealth = itemId === TORCH_ITEM_ID
         ? takeTorchHealth(inventoryState)?.health
+        : null;
+      const shieldPickupHealth = itemId === SHIELD_ITEM_ID
+        ? normalizeShieldHealth(inventoryState[SHIELD_ITEM_ID]?.[SHIELD_HEALTH_KEY] ?? item.mesh?.userData?.shieldHealth)
         : null;
       const dropId = createNetworkDropId('weapon');
       createDroppedWeaponPickup(item, {
@@ -6574,6 +6757,7 @@ async function initCore(runtimeContext) {
         position: dropPosition,
         quaternion: playerControls?.playerModel?.quaternion,
         torchHealth: torchPickupHealth ?? undefined,
+        shieldHealth: shieldPickupHealth ?? undefined,
         dropId
       });
       if (multiplayer && !multiplayer.isHost) {
@@ -6587,7 +6771,8 @@ async function initCore(runtimeContext) {
             position: [pos.x, pos.y, pos.z],
             rotation: [q.x, q.y, q.z, q.w],
             quantity: 1,
-            torchHealth: torchPickupHealth ?? undefined
+            torchHealth: torchPickupHealth ?? undefined,
+            shieldHealth: shieldPickupHealth ?? undefined
           }]
         });
       }
@@ -6609,6 +6794,9 @@ async function initCore(runtimeContext) {
         item.mesh.userData.torchHealth = result.health;
       }
       persistInventoryAndStorage();
+    } else if (itemId === SHIELD_ITEM_ID) {
+      item.mesh.userData.shieldHealth = normalizeShieldHealth(inventoryState[SHIELD_ITEM_ID]?.[SHIELD_HEALTH_KEY]);
+      removeFromInventory(itemId, 1);
     } else {
       removeFromInventory(itemId, 1);
     }
@@ -7142,6 +7330,63 @@ async function initCore(runtimeContext) {
     get: () => statsState.health,
     set: value => setStat('health', value)
   });
+
+  const shieldBlockTempForward = new THREE.Vector3();
+  const shieldBlockTempToAttacker = new THREE.Vector3();
+  const isAttackerInShieldBlockArc = (attackerModel) => {
+    if (!attackerModel?.position || !playerModel?.position) return false;
+    shieldBlockTempToAttacker.subVectors(attackerModel.position, playerModel.position);
+    shieldBlockTempToAttacker.y = 0;
+    if (shieldBlockTempToAttacker.lengthSq() < 0.0001) return true;
+    shieldBlockTempToAttacker.normalize();
+    if (typeof playerModel.getWorldDirection === 'function') {
+      playerModel.getWorldDirection(shieldBlockTempForward);
+    } else {
+      shieldBlockTempForward.copy(playerModel.userData?.direction || new THREE.Vector3(0, 0, 1));
+    }
+    shieldBlockTempForward.y = 0;
+    if (shieldBlockTempForward.lengthSq() < 0.0001) {
+      shieldBlockTempForward.copy(playerModel.userData?.direction || new THREE.Vector3(0, 0, 1));
+      shieldBlockTempForward.y = 0;
+    }
+    if (shieldBlockTempForward.lengthSq() < 0.0001) shieldBlockTempForward.set(0, 0, 1);
+    shieldBlockTempForward.normalize();
+    return shieldBlockTempForward.dot(shieldBlockTempToAttacker) > 0.2;
+  };
+
+  const damageEquippedShield = (damage = 1) => {
+    const currentEntry = normalizeShieldEntry(inventoryState[SHIELD_ITEM_ID]);
+    if (!currentEntry.count || currentEntry[SHIELD_HEALTH_KEY] <= 0) return false;
+    const currentHealth = currentEntry[SHIELD_HEALTH_KEY];
+    const nextHealth = Math.max(0, currentHealth - Math.max(1, Math.round(damage)));
+    const nextEntry = normalizeShieldEntry({
+      ...currentEntry,
+      [SHIELD_HEALTH_KEY]: nextHealth
+    });
+    if (shield?.mesh) {
+      shield.mesh.userData.shieldHealth = nextHealth;
+      shield.mesh.userData.shieldMaxHealth = DEFAULT_SHIELD_HEALTH;
+    }
+    if (shield?.heldMesh) {
+      shield.heldMesh.userData.shieldHealth = nextHealth;
+      shield.heldMesh.userData.shieldMaxHealth = DEFAULT_SHIELD_HEALTH;
+    }
+    shield?.showHealthBar?.(nextHealth, DEFAULT_SHIELD_HEALTH);
+    if (nextHealth <= 0) {
+      delete inventoryState[SHIELD_ITEM_ID];
+      unequipInventoryItem(SHIELD_ITEM_ID);
+    } else {
+      inventoryState[SHIELD_ITEM_ID] = ensureCatalogEntry(SHIELD_ITEM_ID, nextEntry);
+    }
+    persistInventoryAndStorage();
+    return true;
+  };
+
+  window.tryBlockLocalPlayerHitWithShield = ({ attackerModel, damage } = {}) => {
+    if (shield?.holder !== playerControls || !inventoryState[SHIELD_ITEM_ID]?.count) return false;
+    if (!isAttackerInShieldBlockArc(attackerModel)) return false;
+    return damageEquippedShield(damage);
+  };
 
   Object.defineProperty(window, 'hunger', {
     configurable: true,
@@ -8708,7 +8953,8 @@ async function initCore(runtimeContext) {
       torch: { item: torch, markerColor: 0xffa54c },
       bomb: { item: bomb, markerColor: 0xff4d4d },
       autumnSword: { item: autumnSword, markerColor: 0xffd400 },
-      iceGun: { item: iceGun, markerColor: 0xffd400 }
+      iceGun: { item: iceGun, markerColor: 0xffd400 },
+      shield: { item: shield, markerColor: 0x7a4a20 }
     }[drop.itemId];
     if (!pickupConfig?.item?.mesh) return;
     const amount = Number.isFinite(drop.quantity) ? Math.max(1, Math.floor(drop.quantity)) : 1;
@@ -8725,6 +8971,7 @@ async function initCore(runtimeContext) {
       quaternion: quat,
       allowHidden: true,
       torchHealth: Number.isFinite(drop.torchHealth) ? drop.torchHealth : undefined,
+      shieldHealth: Number.isFinite(drop.shieldHealth) ? drop.shieldHealth : undefined,
       dropId,
       shouldBroadcastRemoval: false
     });
@@ -8747,6 +8994,13 @@ async function initCore(runtimeContext) {
           existing.torchHealth = normalizedHealth;
           if (existing.mesh) {
             existing.mesh.userData.torchHealth = normalizedHealth;
+          }
+        }
+        if (Number.isFinite(drop.shieldHealth)) {
+          const normalizedHealth = normalizeShieldHealth(drop.shieldHealth);
+          existing.shieldHealth = normalizedHealth;
+          if (existing.mesh) {
+            existing.mesh.userData.shieldHealth = normalizedHealth;
           }
         }
         return;
@@ -8779,7 +9033,8 @@ async function initCore(runtimeContext) {
             position: [pos.x, pos.y, pos.z],
             rotation: [q.x, q.y, q.z, q.w],
             quantity: pickup.quantity,
-            torchHealth: pickup.torchHealth
+            torchHealth: pickup.torchHealth,
+            shieldHealth: pickup.shieldHealth
           };
         })
         .filter(Boolean);
@@ -11187,6 +11442,18 @@ async function initCore(runtimeContext) {
       const type = await openBuildTypePicker();
       if (!type) return;
       let noteText = '';
+      if (type === SHIELD_ITEM_ID) {
+        addToInventory(SHIELD_ITEM_ID, 1);
+        inventoryState[SHIELD_ITEM_ID] = ensureCatalogEntry(SHIELD_ITEM_ID, normalizeShieldEntry({
+          ...inventoryState[SHIELD_ITEM_ID],
+          count: Math.max(1, inventoryState[SHIELD_ITEM_ID]?.count || 1),
+          [SHIELD_HEALTH_KEY]: DEFAULT_SHIELD_HEALTH
+        }));
+        removeFromInventory('wood', 1);
+        equipInventoryItem(SHIELD_ITEM_ID);
+        persistInventoryAndStorage();
+        return;
+      }
       if (type === 'note') {
         noteText = await openNoteEntryModal();
         if (!noteText?.trim()) return;
@@ -12157,12 +12424,14 @@ async function initCore(runtimeContext) {
     autumnSword?.update();
     lantern?.update();
     torch?.update();
+    shield?.update();
     syncRemoteHeldWeaponMesh(iceGun);
     syncRemoteHeldWeaponMesh(bow);
     syncRemoteHeldWeaponMesh(bomb);
     syncRemoteHeldWeaponMesh(autumnSword);
     syncRemoteHeldWeaponMesh(lantern);
     syncRemoteHeldWeaponMesh(torch);
+    syncRemoteHeldWeaponMesh(shield);
     if (bowHeldArrow) {
       const shouldShowArrow = bow?.holder === playerControls && playerControls?.isFireHeld;
       bowHeldArrow.visible = shouldShowArrow;
@@ -12173,7 +12442,8 @@ async function initCore(runtimeContext) {
     updateWeaponMarker(autumnSword, autumnSwordMarker, 0.03);
     updateWeaponMarker(lantern, lanternMarker, 0.03);
     updateWeaponMarker(torch, torchMarker, 0.03);
-    [iceGun, bow, bomb, autumnSword, lantern, torch].forEach((weapon) => {
+    updateWeaponMarker(shield, shieldMarker, 0.03);
+    [iceGun, bow, bomb, autumnSword, lantern, torch, shield].forEach((weapon) => {
       const mesh = weapon?.mesh;
       if (!mesh || weapon?.holder || playerDead) return;
       if (playerModel.position.distanceTo(mesh.position) <= getPickupAttractRadius()) {
@@ -12538,7 +12808,9 @@ async function initCore(runtimeContext) {
       }
       payload.equippedLeft = isInventoryItemEquipped('torch')
         ? 'torch'
-        : (isInventoryItemEquipped('lantern') ? 'lantern' : null);
+        : (isInventoryItemEquipped('lantern')
+          ? 'lantern'
+          : (isInventoryItemEquipped(SHIELD_ITEM_ID) ? SHIELD_ITEM_ID : null));
       payload.equippedRight = isInventoryItemEquipped('iceGun')
         ? 'iceGun'
         : (isInventoryItemEquipped('bow')
@@ -12790,7 +13062,7 @@ export async function bootstrapGameApp() {
   noteViewModal.className = 'build-modal-overlay hidden';
   document.body.append(buildModal, noteEntryModal, noteViewModal);
   const openBuildTypePicker = () => new Promise((resolve) => {
-    buildModal.innerHTML = `<div class="build-modal"><h3>Choose Build Type</h3><div class="build-options-list"><button type="button" class="build-option-btn" data-build-type="block"><span>🧱</span>Block</button><button type="button" class="build-option-btn" data-build-type="note"><span>🪧</span>Note Post</button></div><button type="button" class="build-cancel-btn" data-build-cancel="1">Cancel</button></div>`;
+    buildModal.innerHTML = `<div class="build-modal"><h3>Choose Build Type</h3><div class="build-options-list"><button type="button" class="build-option-btn" data-build-type="block"><span>🧱</span>Block</button><button type="button" class="build-option-btn" data-build-type="note"><span>🪧</span>Note Post</button><button type="button" class="build-option-btn" data-build-type="shield"><span>🛡️</span>Shield</button></div><button type="button" class="build-cancel-btn" data-build-cancel="1">Cancel</button></div>`;
     buildModal.classList.remove('hidden');
     const close = (value) => {
       buildModal.classList.add('hidden');

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -599,6 +599,12 @@ export class MonsterCharacter extends CharacterBase {
         }
         context.onFriendlyHit?.(friendly, { damage, killed: !!killed, sourceId: this.id, attackTypes });
       } else if (player.id === 'local' && !localControls?.isKnocked && !isInvincible) {
+        const blockedByShield = window.tryBlockLocalPlayerHitWithShield?.({
+          attackerModel: this.model,
+          damage,
+          attackTypes
+        });
+        if (blockedByShield) return;
         window.localHealth = Math.max(0, window.localHealth - damage);
         window.lastHitAttackTypes = attackTypes;
         if (localControls) {

--- a/controls/homeStoragePanel.js
+++ b/controls/homeStoragePanel.js
@@ -126,6 +126,7 @@ function getFallbackIcon(itemId) {
   if (itemId === 'bow') return '🏹';
   if (itemId === 'autumnSword') return '🗡️';
   if (itemId === 'lantern') return '🏮';
+  if (itemId === 'shield') return '🛡️';
   if (itemId === 'apple') return '🍎';
   if (itemId === 'wood') return '🪵';
   if (itemId.startsWith('mushroom_')) return '🍄';

--- a/controls/merchantPanel.js
+++ b/controls/merchantPanel.js
@@ -130,6 +130,7 @@ function getFallbackIcon(itemId) {
   if (itemId === 'arrow ammo') return '🏹';
   if (itemId === 'autumnSword') return '🗡️';
   if (itemId === 'lantern') return '🏮';
+  if (itemId === 'shield') return '🛡️';
   if (itemId === 'apple') return '🍎';
   if (itemId === 'wood') return '🪵';
   if (itemId.startsWith('mushroom_')) return '🍄';

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1205,6 +1205,7 @@ function renderInventory() {
     bow: '🏹',
     autumnSword: '🗡️',
     lantern: '🏮',
+    shield: '🛡️',
     apple: '🍎',
     wood: '🪵',
     meat: '🥩'
@@ -1294,7 +1295,10 @@ function renderInventory() {
       : selectedInventoryId === 'bow'
         ? ` • Arrows ${Number.isFinite(selectedItem?.['arrow ammo']) ? selectedItem['arrow ammo'] : 0}`
         : '';
-    elements.inventoryDetails.textContent = `${selectedItem.name || selectedInventoryId}${equippedText}${countText}${ammoText}`;
+    const shieldHealthText = selectedInventoryId === 'shield'
+      ? ` • Health ${Math.max(0, Math.round(Number.isFinite(selectedItem?.shieldHealth) ? selectedItem.shieldHealth : 0))}`
+      : '';
+    elements.inventoryDetails.textContent = `${selectedItem.name || selectedInventoryId}${equippedText}${countText}${ammoText}${shieldHealthText}`;
     if (elements.inventoryActions) {
       elements.inventoryActions.style.display = 'flex';
     }

--- a/features/combatFeature.js
+++ b/features/combatFeature.js
@@ -25,13 +25,17 @@ export async function loadSpecialWeapons() {
       import('../items/bow.js'),
       import('../items/lantern.js'),
       import('../items/autumnSword.js'),
-      import('../items/bomb.js')
-    ]).then(([iceGunModule, bowModule, lanternModule, autumnSwordModule, bombModule]) => ({
+      import('../items/bomb.js'),
+      import('../items/shield.js')
+    ]).then(([iceGunModule, bowModule, lanternModule, autumnSwordModule, bombModule, shieldModule]) => ({
       IceGun: iceGunModule.IceGun,
       Bow: bowModule.Bow,
       Lantern: lanternModule.Lantern,
       AutumnSword: autumnSwordModule.AutumnSword,
-      Bomb: bombModule.Bomb
+      Bomb: bombModule.Bomb,
+      Shield: shieldModule.Shield,
+      SHIELD_ITEM_ID: shieldModule.SHIELD_ITEM_ID,
+      DEFAULT_SHIELD_HEALTH: shieldModule.DEFAULT_SHIELD_HEALTH
     })).finally(() => {
       hideLoading();
     });

--- a/items/melee.js
+++ b/items/melee.js
@@ -161,6 +161,12 @@ export function updateMeleeAttacks({
             attackTypes
           });
           if (target.id === 'local') {
+            const blockedByShield = window.tryBlockLocalPlayerHitWithShield?.({
+              attackerModel: attacker.model,
+              damage: attackDamage,
+              attackTypes
+            });
+            if (blockedByShield) continue;
             window.localHealth = Math.max(0, window.localHealth - attackDamage);
             window.lastHitAttackTypes = attackTypes;
             const playerControls = appContext.systems.playerControls ?? window.playerControls;

--- a/items/shield.js
+++ b/items/shield.js
@@ -1,0 +1,126 @@
+import * as THREE from 'three';
+import { getTerrainHeight } from '../environment/terrainHeight.js';
+import { Weapon } from './weapon.js';
+
+export const SHIELD_ITEM_ID = 'shield';
+export const DEFAULT_SHIELD_HEALTH = 60;
+
+const SHIELD_RADIUS = 0.42;
+const SHIELD_THICKNESS = 0.12;
+const SHIELD_COLOR = 0x7a4a20;
+const SHIELD_RIM_COLOR = 0x4d2c12;
+const BAR_VISIBLE_MS = 1200;
+
+export class Shield extends Weapon {
+  constructor(scene) {
+    super(scene, {
+      itemId: SHIELD_ITEM_ID,
+      type: SHIELD_ITEM_ID,
+      hand: 'left',
+      scale: 1,
+      fallbackColor: SHIELD_COLOR,
+      holdOffset: new THREE.Vector3(-0.18, 0.2, 0.2),
+      holdRotation: new THREE.Euler(Math.PI / 2, 0, 0, 'YXZ')
+    });
+    this.maxHealth = DEFAULT_SHIELD_HEALTH;
+    this._groundOffset = 0.45;
+  }
+
+  async load(position = this._defaultPosition) {
+    const group = new THREE.Group();
+    group.name = 'wooden-shield';
+
+    const faceGeometry = new THREE.CylinderGeometry(SHIELD_RADIUS, SHIELD_RADIUS, SHIELD_THICKNESS, 48);
+    faceGeometry.rotateX(Math.PI / 2);
+    const faceMaterial = new THREE.MeshStandardMaterial({
+      color: SHIELD_COLOR,
+      roughness: 0.82,
+      metalness: 0.02
+    });
+    const face = new THREE.Mesh(faceGeometry, faceMaterial);
+    face.castShadow = true;
+    face.receiveShadow = true;
+    group.add(face);
+
+    const rimGeometry = new THREE.TorusGeometry(SHIELD_RADIUS * 0.98, SHIELD_THICKNESS * 0.45, 10, 48);
+    const rimMaterial = new THREE.MeshStandardMaterial({
+      color: SHIELD_RIM_COLOR,
+      roughness: 0.86,
+      metalness: 0.01
+    });
+    const rim = new THREE.Mesh(rimGeometry, rimMaterial);
+    rim.castShadow = true;
+    rim.receiveShadow = true;
+    group.add(rim);
+
+    const bossGeometry = new THREE.CylinderGeometry(0.12, 0.12, SHIELD_THICKNESS * 1.25, 24);
+    bossGeometry.rotateX(Math.PI / 2);
+    const boss = new THREE.Mesh(bossGeometry, rimMaterial.clone());
+    boss.position.z = SHIELD_THICKNESS * 0.42;
+    boss.castShadow = true;
+    boss.receiveShadow = true;
+    group.add(boss);
+
+    const targetPos = position.clone();
+    const terrainHeight = getTerrainHeight(targetPos.x, targetPos.z);
+    targetPos.y = (Number.isFinite(terrainHeight) ? terrainHeight : targetPos.y) + this._groundOffset;
+    group.position.copy(targetPos);
+    group.userData.hideInMapView = true;
+    group.userData.shieldHealth = DEFAULT_SHIELD_HEALTH;
+    group.userData.shieldMaxHealth = DEFAULT_SHIELD_HEALTH;
+
+    this.mesh = group;
+    this.scene.add(this.mesh);
+  }
+
+  showHealthBar(health, maxHealth = this.maxHealth) {
+    const target = (this.useHeldMeshWhenHeld && this.heldMesh) ? this.heldMesh : this.mesh;
+    if (!target) return;
+    const bar = this._ensureHealthBar(target);
+    const safeMax = Number.isFinite(maxHealth) && maxHealth > 0 ? maxHealth : this.maxHealth;
+    const ratio = THREE.MathUtils.clamp((Number.isFinite(health) ? health : safeMax) / safeMax, 0, 1);
+    const fill = bar.userData.fill;
+    if (fill) {
+      fill.scale.x = ratio;
+      fill.position.x = -0.22 + (0.22 * ratio);
+      fill.material.color.setHex(ratio > 0.35 ? 0x43d15a : 0xff5c45);
+    }
+    bar.visible = true;
+    bar.userData.visibleUntil = performance.now() + BAR_VISIBLE_MS;
+  }
+
+  update() {
+    super.update();
+    const targets = [this.mesh, this.heldMesh].filter(Boolean);
+    const now = performance.now();
+    targets.forEach((target) => {
+      const bar = target.userData?.shieldHealthBar;
+      if (bar?.visible && now > (bar.userData.visibleUntil || 0)) {
+        bar.visible = false;
+      }
+    });
+  }
+
+  _ensureHealthBar(target) {
+    if (target.userData.shieldHealthBar) return target.userData.shieldHealthBar;
+    const group = new THREE.Group();
+    group.name = 'shield-health-bar';
+    group.position.set(0, SHIELD_RADIUS + 0.18, 0.08);
+    group.visible = false;
+
+    const bg = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.5, 0.055),
+      new THREE.MeshBasicMaterial({ color: 0x120904, depthTest: false, depthWrite: false })
+    );
+    const fill = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.44, 0.032),
+      new THREE.MeshBasicMaterial({ color: 0x43d15a, depthTest: false, depthWrite: false })
+    );
+    fill.position.z = 0.002;
+    group.add(bg, fill);
+    group.userData.fill = fill;
+    target.add(group);
+    target.userData.shieldHealthBar = group;
+    return group;
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a new buildable defensive option made from `wood` so players can craft and equip a shield that blocks frontal hits instead of taking player damage.
- Persist shield health so shields wear down and can be dropped/picked up with their remaining durability synced across networked play.

### Description
- Added a new `items/shield.js` which defines a left-hand `Shield` Weapon: a brown circular shield mesh, default health (`DEFAULT_SHIELD_HEALTH`), and an on-hold/world health bar (`showHealthBar`).
- Integrated the shield into the game flow by loading it in `features/combatFeature.js` and registering it in `app/bootstrapGameApp.js` (networked entity, pickup/drop handling, inventory entry, equip/unequip, markers, and update loop).
- Added shield inventory state handling and normalization (`SHIELD_HEALTH_KEY`, `normalizeShieldEntry`) and included shield in catalog/hand slots, equip/unequip logic, drop/pickup serialization, and pickup spawn logic.
- Implemented frontal block logic that reduces shield health instead of player health and shows a brief shield health bar; this is wired into melee and monster hit flows (`items/melee.js`, `characters/MonsterCharacter.js`) via `window.tryBlockLocalPlayerHitWithShield` and `damageEquippedShield` helper.
- UI and UX changes: craft build picker includes a `Shield` option that consumes one wood and equips the shield; inventory/home/merchant panels and fallback icons display a shield icon and the inventory details show shield health.

### Testing
- Built the project with `npm run build` successfully (production build completed, assets emitted including `shield` chunk). 
- Ran static checks: `git diff --check` produced no whitespace/merge errors after modifications.
- Attempted automated screenshot with Playwright but environment blocked Playwright install (registry returned 403), so browser-based runtime verification could not run in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca564a1408325ab89e7820486e02b)