### PR TITLE
Add Hammer weapon (right-hand) with smash/pummel attacks and rock-breaking

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -2288,7 +2288,7 @@ async function initCore(runtimeContext) {
 
     if (previousHostId !== newHostId) {
       clearAllRemoteHeldWeaponMeshes();
-      [iceGun, bow, bomb, autumnSword, lantern, torch].forEach((weapon) => {
+      [iceGun, bow, bomb, autumnSword, hammer, lantern, torch].forEach((weapon) => {
         if (!weapon) return;
         weapon.remoteHolderId = null;
       });
@@ -2366,6 +2366,7 @@ async function initCore(runtimeContext) {
   let iceGun;
   let bow;
   let autumnSword;
+  let hammer;
   let lantern;
   let torch;
   let bomb;
@@ -2486,7 +2487,7 @@ async function initCore(runtimeContext) {
   };
 
   const dropOtherWeapons = (activeWeapon) => {
-    [iceGun, bow, autumnSword, bomb].forEach(weapon => {
+    [iceGun, bow, autumnSword, hammer, bomb].forEach(weapon => {
       if (!weapon || weapon === activeWeapon) return;
       if (weapon.holder === playerControls) {
         if (weapon.itemId) {
@@ -2655,7 +2656,8 @@ async function initCore(runtimeContext) {
       iceGun: iceGun,
       bow,
       bomb,
-      sword: autumnSword
+      sword: autumnSword,
+      hammer
     };
 
     const setRemoteEquipState = (weaponType, isEquipped) => {
@@ -2674,6 +2676,7 @@ async function initCore(runtimeContext) {
     setRemoteEquipState('bow', nextRight === 'bow');
     setRemoteEquipState('bomb', nextRight === 'bomb');
     setRemoteEquipState('sword', nextRight === 'sword');
+    setRemoteEquipState('hammer', nextRight === 'hammer');
 
     remotePlayer.model.userData.equippedWeaponType = nextRight || nextLeft || null;
   };
@@ -2682,7 +2685,7 @@ async function initCore(runtimeContext) {
     Array.from(remoteHeldWeaponMeshes.keys()).forEach(disposeRemoteHeldWeaponMesh);
   };
 
-  const { IceGun, Bow, Lantern, AutumnSword, Bomb } = await loadSpecialWeapons();
+  const { IceGun, Bow, Lantern, AutumnSword, Hammer, Bomb } = await loadSpecialWeapons();
 
   const updateWeaponMarker = (weapon, marker, rotationSpeed, offsetY = 1.2) => {
     if (!weapon?.mesh || !marker) return;
@@ -3029,8 +3032,73 @@ async function initCore(runtimeContext) {
     isLocallyControlled: () => autumnSword?.holder === playerControls
   });
 
-  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword };
-  window.weapons = { iceGun, bow, bomb, autumnSword };
+
+  hammer = new Hammer(scene);
+  await hammer.load();
+  window.hammer = hammer;
+  const hammerMarker = createWeaponMarker(0xb08a4a);
+  hammer.onPickup = (holder) => {
+    if (holder !== playerControls) return;
+    const heldMesh = ensureLocalHeldWeaponMesh(hammer, 'hammer');
+    hammer.useHeldMeshWhenHeld = true;
+    if (heldMesh) heldMesh.visible = true;
+    unequipOtherInventoryItems('hammer');
+    addToInventory('hammer', 1);
+    notifyAchievementProgress('weaponsCollected', 1);
+    hammer.localHoldOrigin = 'world';
+    setPlayerWeaponType(holder, hammer.type);
+  };
+  hammer.onDrop = (holder, { removeFromInventory: shouldRemoveFromInventory } = {}) => {
+    if (holder !== playerControls) return;
+    hammer.localHoldOrigin = null;
+    if (shouldRemoveFromInventory) {
+      removeFromInventory('hammer', 1);
+    }
+    clearPlayerWeaponType(holder, hammer.type);
+    if (hammer.heldMesh) {
+      hammer.heldMesh.visible = false;
+    }
+    hammer.useHeldMeshWhenHeld = true;
+  };
+  if (hammer.mesh) {
+    hammer.mesh.userData.hideInMapView = true;
+    hammer.mesh.visible = false;
+  }
+  registerNetworkedEntity('hammer', {
+    getState: () => {
+      if (!hammer?.mesh) return null;
+      const pos = hammer.mesh.position;
+      const q = hammer.mesh.quaternion;
+      return {
+        position: [pos.x, pos.y, pos.z],
+        rotation: [q.x, q.y, q.z, q.w],
+        holderId: (hammer.holder === playerControls && hammer.localHoldOrigin === 'world') ? multiplayer?.getId?.() : null
+      };
+    },
+    applyState: state => {
+      if (!hammer?.mesh || !state) return;
+      const [px, py, pz] = state.position || [];
+      const [rx, ry, rz, rw] = state.rotation || [];
+      if (Number.isFinite(px) && Number.isFinite(py) && Number.isFinite(pz)) {
+        hammer.mesh.position.set(px, py, pz);
+      }
+      if (Number.isFinite(rx) && Number.isFinite(ry) && Number.isFinite(rz) && Number.isFinite(rw)) {
+        hammer.mesh.quaternion.set(rx, ry, rz, rw);
+      }
+      const previousHolderId = hammer.remoteHolderId ?? null;
+      hammer.remoteHolderId = state.holderId ?? getPresenceHolderForWeaponType(hammer.type);
+      updateRemoteWeaponType(hammer, hammer.remoteHolderId, previousHolderId);
+      if (state.holderId !== multiplayer?.getId?.() && hammer.holder === playerControls && hammer.localHoldOrigin === 'world') {
+        hammer.holder = null;
+        hammer.localHoldOrigin = null;
+        clearPlayerWeaponType(playerControls, hammer.type);
+      }
+    },
+    isLocallyControlled: () => hammer?.holder === playerControls
+  });
+
+  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, hammer };
+  window.weapons = { iceGun, bow, bomb, autumnSword, hammer };
 
   function attachMonsterPhysics(monster, { mode = 'dynamic' } = {}) {
     const model = monster?.model;
@@ -3253,8 +3321,8 @@ async function initCore(runtimeContext) {
     isLocallyControlled: () => torch?.holder === playerControls
   });
 
-  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch };
-  window.weapons = { iceGun, bow, bomb, autumnSword, lantern, torch };
+  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, hammer, lantern, torch };
+  window.weapons = { iceGun, bow, bomb, autumnSword, hammer, lantern, torch };
   treasureChest = new TreasureChest(scene);
   await treasureChest.load();
   window.treasureChest = treasureChest;
@@ -4648,6 +4716,10 @@ async function initCore(runtimeContext) {
       name: 'Autumn Sword',
       icon: '/assets/ui/items/sword.png'
     },
+    hammer: {
+      name: 'Hammer',
+      icon: ''
+    },
     lantern: {
       name: 'Lantern (Left Hand)',
       icon: '/assets/ui/items/lantern.png'
@@ -4783,14 +4855,15 @@ async function initCore(runtimeContext) {
     saveStatsThrottled(profileNameKey, statsState, lastStatUpdateAt, inventoryState, homeStorageState);
   }
 
-  const equippableItems = new Set(['lantern', 'torch', 'iceGun', 'bow', 'bomb', 'autumnSword']);
+  const equippableItems = new Set(['lantern', 'torch', 'iceGun', 'bow', 'bomb', 'autumnSword', 'hammer']);
   const inventoryHandSlots = {
     lantern: 'left',
     torch: 'left',
     iceGun: 'right',
     bow: 'right',
     bomb: 'right',
-    autumnSword: 'right'
+    autumnSword: 'right',
+    hammer: 'right'
   };
   const getInventoryItemHand = (itemId) => inventoryHandSlots[itemId] || null;
   const isMushroomItem = (itemId) => mushroomItemIds.has(itemId);
@@ -5157,6 +5230,9 @@ async function initCore(runtimeContext) {
     if (itemId === 'autumnSword') {
       return autumnSword?.holder === playerControls;
     }
+    if (itemId === 'hammer') {
+      return hammer?.holder === playerControls;
+    }
     return false;
   }
 
@@ -5171,6 +5247,7 @@ async function initCore(runtimeContext) {
       if (isInventoryItemEquipped('bow')) return 'bow';
       if (isInventoryItemEquipped('bomb')) return 'bomb';
       if (isInventoryItemEquipped('autumnSword')) return 'autumnSword';
+      if (isInventoryItemEquipped('hammer')) return 'hammer';
     }
     return null;
   }
@@ -5335,6 +5412,20 @@ async function initCore(runtimeContext) {
       audioManager?.playSFX('SFX/Attacks/Sword Attacks Hits and Blocks/Sword Unsheath 1.ogg', 0.62, { cooldownKey: 'sword-equip', cooldownMs: 100 });
       updateSettingsUI();
     }
+    if (itemId === 'hammer') {
+      if (!hammer?.mesh || !playerControls) return;
+      const heldMesh = ensureLocalHeldWeaponMesh(hammer, 'hammer', { forceNew: true });
+      hammer.useHeldMeshWhenHeld = true;
+      if (heldMesh) {
+        heldMesh.visible = true;
+      }
+      hammer.mesh.visible = false;
+      hammer.localHoldOrigin = 'inventory';
+      hammer.holder = playerControls;
+      setPlayerWeaponType(playerControls, hammer.type);
+      audioManager?.playSFX('SFX/Attacks/Sword Attacks Hits and Blocks/Sword Unsheath 1.ogg', 0.62, { cooldownKey: 'hammer-equip', cooldownMs: 100 });
+      updateSettingsUI();
+    }
   }
 
   function unequipInventoryItem(itemId) {
@@ -5426,6 +5517,20 @@ async function initCore(runtimeContext) {
       }
       clearPlayerWeaponType(playerControls, autumnSword.type);
       audioManager?.playSFX('SFX/Attacks/Sword Attacks Hits and Blocks/Sword Sheath 1.ogg', 0.58, { cooldownKey: 'sword-unequip', cooldownMs: 100 });
+      updateSettingsUI();
+    }
+    if (itemId === 'hammer') {
+      if (hammer?.holder !== playerControls) return;
+      hammer.holder = null;
+      hammer.localHoldOrigin = null;
+      if (hammer.mesh) {
+        hammer.mesh.visible = false;
+      }
+      if (hammer.heldMesh) {
+        hammer.heldMesh.visible = false;
+      }
+      clearPlayerWeaponType(playerControls, hammer.type);
+      audioManager?.playSFX('SFX/Attacks/Sword Attacks Hits and Blocks/Sword Sheath 1.ogg', 0.58, { cooldownKey: 'hammer-unequip', cooldownMs: 100 });
       updateSettingsUI();
     }
   }
@@ -6826,6 +6931,7 @@ async function initCore(runtimeContext) {
     if ((inventoryState.bow?.count || 0) > 0) weaponDrops.push('bow');
     if ((inventoryState.bomb?.count || 0) > 0) weaponDrops.push('bomb');
     if ((inventoryState.autumnSword?.count || 0) > 0) weaponDrops.push('autumnSword');
+    if ((inventoryState.hammer?.count || 0) > 0) weaponDrops.push('hammer');
     if ((inventoryState.lantern?.count || 0) > 0) weaponDrops.push('lantern');
     if ((inventoryState[TORCH_ITEM_ID]?.count || 0) > 0) weaponDrops.push(TORCH_ITEM_ID);
     const weaponPositions = createRingPositions(deathPosition, weaponDrops.length, 2.2);
@@ -6839,6 +6945,8 @@ async function initCore(runtimeContext) {
         spawnBombPickup(position);
       } else if (weaponId === 'autumnSword') {
         spawnAutumnSwordPickup(position);
+      } else if (weaponId === 'hammer') {
+        spawnHammerPickup(position);
       } else if (weaponId === 'lantern') {
         spawnLanternPickup(position);
       } else if (weaponId === TORCH_ITEM_ID) {
@@ -7506,7 +7614,7 @@ async function initCore(runtimeContext) {
     } = {}
   ) {
     if (!itemId) return false;
-    const itemMap = { iceGun, bow, autumnSword, lantern, torch };
+    const itemMap = { iceGun, bow, autumnSword, hammer, lantern, torch };
     const resolvedItem = sourceItem || itemMap[itemId];
     if (!resolvedItem?.mesh) return false;
 
@@ -7515,6 +7623,7 @@ async function initCore(runtimeContext) {
       torch: 0xffa54c,
       lantern: 0xffd400,
       autumnSword: 0xffd400,
+      hammer: 0xb08a4a,
       iceGun: 0xffd400
     };
 
@@ -8738,6 +8847,19 @@ async function initCore(runtimeContext) {
     autumnSword.holder = null;
   }
 
+
+  function spawnHammerPickup(position) {
+    if (!hammer?.mesh) return;
+    const spawnPos = asVec3(position);
+    if (!spawnPos) return;
+
+    if (!applySpawnY(spawnPos, 0.5, { allowOnBuildings: true })) return;
+    hammer.mesh.position.copy(spawnPos);
+    hammer.mesh.quaternion.set(0, 0, 0, 1);
+    hammer.mesh.visible = true;
+    hammer.holder = null;
+  }
+
   function spawnLanternPickup(position) {
     if (!lantern?.mesh) return;
     const spawnPos = asVec3(position);
@@ -8787,6 +8909,7 @@ async function initCore(runtimeContext) {
       torch: { item: torch, markerColor: 0xffa54c },
       bomb: { item: bomb, markerColor: 0xff4d4d },
       autumnSword: { item: autumnSword, markerColor: 0xffd400 },
+      hammer: { item: hammer, markerColor: 0xb08a4a },
       iceGun: { item: iceGun, markerColor: 0xffd400 }
     }[drop.itemId];
     if (!pickupConfig?.item?.mesh) return;
@@ -8997,7 +9120,7 @@ async function initCore(runtimeContext) {
       return playerControls.throwBomb(position, direction);
     }
 
-    const itemMap = { iceGun, bow, autumnSword, lantern, torch };
+    const itemMap = { iceGun, bow, autumnSword, hammer, lantern, torch };
     const sourceItem = itemMap[itemId];
     if (!sourceItem?.mesh) return false;
 
@@ -9258,6 +9381,13 @@ async function initCore(runtimeContext) {
       markerColor: 0xffd400,
       markerOffsetY: 1.2,
       groundOffset: 0.5,
+    },
+    {
+      itemId: 'hammer',
+      item: hammer,
+      markerColor: 0xb08a4a,
+      markerOffsetY: 1.2,
+      groundOffset: 0.5,
     }
   ]);
   const spawnWeaponPickupCopy = (position) => {
@@ -9359,6 +9489,15 @@ async function initCore(runtimeContext) {
           spawnAutumnSwordPickup(spawnPos);
         }
       }
+
+      const hasHammer = (inventoryState?.hammer?.count || 0) > 0;
+      const canSpawnHammer = hammer?.mesh && !hammer.holder && !hasHammer && !hammer.mesh.visible;
+      if (canSpawnHammer) {
+        const spawnPos = getRandomPickupPosition(center);
+        if (spawnPos) {
+          spawnHammerPickup(spawnPos);
+        }
+      }
     }
 
     const canSpawnTreasureChest = treasureChest?.mesh
@@ -9371,7 +9510,7 @@ async function initCore(runtimeContext) {
       }
     }
 
-    [iceGun, bow, autumnSword, bomb].forEach((weapon) => {
+    [iceGun, bow, autumnSword, hammer, bomb].forEach((weapon) => {
       if (!weapon?.mesh || weapon.holder || !weapon.mesh.visible) return;
       if (center.distanceTo(weapon.mesh.position) > PICKUP_SPAWN_RADIUS) {
         weapon.mesh.visible = false;
@@ -10983,10 +11122,28 @@ async function initCore(runtimeContext) {
     return true;
   };
 
-  const handleBuildAttackHit = ({ attacker, range, region, damage } = {}) => {
+  const handleBuildAttackHit = ({ attacker, range, region, damage, attackTypes } = {}) => {
     const attackerPosition = attacker?.model?.position;
     if (!attackerPosition) return false;
     const effectiveRange = Math.max(0.8, Number.isFinite(range) ? range : 1.5);
+    const isHammerSmash = Array.isArray(attackTypes)
+      && (attackTypes.includes('smash') || attackTypes.includes('pummel'));
+    if (isHammerSmash && natureController?.removeRocksInRadius) {
+      const removedRockPositions = natureController.removeRocksInRadius(attackerPosition, effectiveRange + 0.7);
+      if (removedRockPositions.length > 0) {
+        notifyAchievementProgress('rocksBlownUp', removedRockPositions.length);
+        window.questManager?.handleRockBlownUp?.(removedRockPositions.length);
+        removedRockPositions.forEach((rockPosition) => {
+          spawnImpactBurst(scene, rockPosition);
+          for (let i = 0; i < 3; i += 1) {
+            const angle = (i / 3) * Math.PI * 2;
+            const offset = new THREE.Vector3(Math.cos(angle) * 0.28, 0, Math.sin(angle) * 0.28);
+            spawnSaltPickup(rockPosition.clone().add(offset));
+          }
+        });
+        return true;
+      }
+    }
     const bush = natureController?.getClosestBush?.(attackerPosition, effectiveRange, {
       attackerModel: attacker?.model,
       region: region || 'around'
@@ -12243,12 +12400,14 @@ async function initCore(runtimeContext) {
     bow?.update();
     bomb?.update();
     autumnSword?.update();
+    hammer?.update();
     lantern?.update();
     torch?.update();
     syncRemoteHeldWeaponMesh(iceGun);
     syncRemoteHeldWeaponMesh(bow);
     syncRemoteHeldWeaponMesh(bomb);
     syncRemoteHeldWeaponMesh(autumnSword);
+    syncRemoteHeldWeaponMesh(hammer);
     syncRemoteHeldWeaponMesh(lantern);
     syncRemoteHeldWeaponMesh(torch);
     if (bowHeldArrow) {
@@ -12259,9 +12418,10 @@ async function initCore(runtimeContext) {
     updateWeaponMarker(bow, bowMarker, 0.03);
     updateWeaponMarker(bomb, bombMarker, 0.03);
     updateWeaponMarker(autumnSword, autumnSwordMarker, 0.03);
+    updateWeaponMarker(hammer, hammerMarker, 0.03);
     updateWeaponMarker(lantern, lanternMarker, 0.03);
     updateWeaponMarker(torch, torchMarker, 0.03);
-    [iceGun, bow, bomb, autumnSword, lantern, torch].forEach((weapon) => {
+    [iceGun, bow, bomb, autumnSword, hammer, lantern, torch].forEach((weapon) => {
       const mesh = weapon?.mesh;
       if (!mesh || weapon?.holder || playerDead) return;
       if (playerModel.position.distanceTo(mesh.position) <= getPickupAttractRadius()) {
@@ -12633,7 +12793,7 @@ async function initCore(runtimeContext) {
           ? 'bow'
           : (isInventoryItemEquipped('bomb')
             ? 'bomb'
-            : (isInventoryItemEquipped('autumnSword') ? 'sword' : null)));
+            : (isInventoryItemEquipped('autumnSword') ? 'sword' : (isInventoryItemEquipped('hammer') ? 'hammer' : null))));
       const dx = payload.x - (lastSentPresenceState.x ?? payload.x);
       const dy = payload.y - (lastSentPresenceState.y ?? payload.y);
       const dz = payload.z - (lastSentPresenceState.z ?? payload.z);

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -828,7 +828,7 @@ export class PlayerControls {
       this.mobileMeleeComboIndex = (this.mobileMeleeComboIndex + 1) % cycle.length;
       return;
     }
-    if (weapon?.itemId === 'autumnSword') {
+    if (weapon?.itemId === 'autumnSword' || weapon?.itemId === 'hammer') {
       const attackAction = this.getNextSwordAttackAction({ advance: false });
       const started = this.playAction(attackAction);
       if (!started) return;
@@ -859,6 +859,7 @@ export class PlayerControls {
       { id: 'bow', label: 'Bow' },
       { id: 'iceGun', label: 'Ice Gun' },
       { id: 'autumnSword', label: 'Sword' },
+      { id: 'hammer', label: 'Hammer' },
       { id: 'lantern', label: 'Lantern' },
       { id: 'torch', label: 'Torch' }
     ];
@@ -1675,6 +1676,7 @@ export class PlayerControls {
     const getWeaponLabel = (weapon) => {
       if (!weapon) return 'weapon';
       if (weapon.type === 'sword') return 'sword';
+      if (weapon.type === 'hammer') return 'hammer';
       if (weapon.type === 'gun') return 'gun';
       if (weapon.type === 'bow') return 'bow';
       if (weapon.type === 'lantern') return 'lantern';
@@ -1944,8 +1946,16 @@ export class PlayerControls {
 
     if (["mutantPunch", "swordSlash", "swordSlashLeft", "swordSpin", "swordFwdSpin", "leftPunch", "hurricaneKick", "mmaKick", "runningKick"].includes(resolvedAction)) {
       const isPunch = resolvedAction === 'mutantPunch' || resolvedAction === 'leftPunch' || swordAttackActions.includes(resolvedAction);
-      const attackName = isPunch && this.getEquippedSword()
-        ? (swordAttackActions.includes(resolvedAction) ? resolvedAction : 'swordSlash')
+      const meleeWeapon = this.getEquippedSword();
+      const swordAction = swordAttackActions.includes(resolvedAction) ? resolvedAction : 'swordSlash';
+      const hammerAttackMap = {
+        swordSlash: 'hammerSlash',
+        swordSlashLeft: 'hammerSlashLeft',
+        swordFwdSpin: 'hammerFwdSpin',
+        swordSpin: 'hammerSpin'
+      };
+      const attackName = isPunch && meleeWeapon
+        ? (meleeWeapon.type === 'hammer' ? (hammerAttackMap[swordAction] || 'hammerSlash') : swordAction)
         : isPunch
           ? 'mutantPunch'
           : resolvedAction;
@@ -2895,7 +2905,7 @@ export class PlayerControls {
     return this.getWeapons().find(
       weapon => weapon.holder === this
         && (hand === 'left' ? weapon.hand === 'left' : weapon.hand !== 'left')
-        && weapon.type === 'sword'
+        && (weapon.type === 'sword' || weapon.type === 'hammer')
     ) || null;
   }
 

--- a/controls/homeStoragePanel.js
+++ b/controls/homeStoragePanel.js
@@ -125,6 +125,7 @@ function getFallbackIcon(itemId) {
   if (itemId === 'iceGun') return '❄️';
   if (itemId === 'bow') return '🏹';
   if (itemId === 'autumnSword') return '🗡️';
+  if (itemId === 'hammer') return '🔨';
   if (itemId === 'lantern') return '🏮';
   if (itemId === 'apple') return '🍎';
   if (itemId === 'wood') return '🪵';

--- a/controls/merchantPanel.js
+++ b/controls/merchantPanel.js
@@ -129,6 +129,7 @@ function getFallbackIcon(itemId) {
   if (itemId === 'bow') return '🏹';
   if (itemId === 'arrow ammo') return '🏹';
   if (itemId === 'autumnSword') return '🗡️';
+  if (itemId === 'hammer') return '🔨';
   if (itemId === 'lantern') return '🏮';
   if (itemId === 'apple') return '🍎';
   if (itemId === 'wood') return '🪵';

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1204,6 +1204,7 @@ function renderInventory() {
     iceGun: '❄️',
     bow: '🏹',
     autumnSword: '🗡️',
+    hammer: '🔨',
     lantern: '🏮',
     apple: '🍎',
     wood: '🪵',

--- a/features/combatFeature.js
+++ b/features/combatFeature.js
@@ -25,12 +25,14 @@ export async function loadSpecialWeapons() {
       import('../items/bow.js'),
       import('../items/lantern.js'),
       import('../items/autumnSword.js'),
+      import('../items/hammer.js'),
       import('../items/bomb.js')
-    ]).then(([iceGunModule, bowModule, lanternModule, autumnSwordModule, bombModule]) => ({
+    ]).then(([iceGunModule, bowModule, lanternModule, autumnSwordModule, hammerModule, bombModule]) => ({
       IceGun: iceGunModule.IceGun,
       Bow: bowModule.Bow,
       Lantern: lanternModule.Lantern,
       AutumnSword: autumnSwordModule.AutumnSword,
+      Hammer: hammerModule.Hammer,
       Bomb: bombModule.Bomb
     })).finally(() => {
       hideLoading();

--- a/items/hammer.js
+++ b/items/hammer.js
@@ -1,0 +1,17 @@
+import * as THREE from 'three';
+import { Weapon } from './weapon.js';
+
+export class Hammer extends Weapon {
+  constructor(scene) {
+    super(scene, {
+      itemId: 'hammer',
+      type: 'hammer',
+      hand: 'right',
+      modelUrl: '/assets/props/hammer.glb',
+      scale: 1.0,
+      holdOffset: new THREE.Vector3(0.45, -0.05, 0.0),
+      fallbackSize: new THREE.Vector3(0.22, 0.85, 0.32),
+      fallbackColor: 0x8a6a4a
+    });
+  }
+}

--- a/items/melee.js
+++ b/items/melee.js
@@ -8,6 +8,10 @@ export const ATTACKS = {
   swordSlashLeft: { damage: 2, range: 2.5, hitTime: 200, hitWindow: 300, knockbackStrength: 3, region: 'forward', types: ['cut'] },
   swordFwdSpin: { damage: 3, range: 2.0, hitTime: 280, hitWindow: 500, knockbackStrength: 5, region: 'forward', types: ['cut'] },
   swordSpin: { damage: 4, range: 4.0, hitTime: 800, hitWindow: 300, knockbackStrength: 12, region: 'around', types: ['cut'] },
+  hammerSlash: { damage: 1, range: 2.5, hitTime: 100, hitWindow: 300, knockbackStrength: 7, region: 'forward', types: ['smash'] },
+  hammerSlashLeft: { damage: 1, range: 2.5, hitTime: 200, hitWindow: 300, knockbackStrength: 7, region: 'forward', types: ['pummel'] },
+  hammerFwdSpin: { damage: 2, range: 2.0, hitTime: 280, hitWindow: 500, knockbackStrength: 10, region: 'forward', types: ['smash'] },
+  hammerSpin: { damage: 2, range: 4.0, hitTime: 800, hitWindow: 300, knockbackStrength: 18, region: 'around', types: ['pummel'] },
   hurricaneKick: { damage: 1, range: 2.0, hitTime: 280, hitWindow: 800, knockbackStrength: 5, region: 'around', types: ['melee', 'kick'] },
   mmaKick: { damage: 1, range: 1.7, hitTime: 100, hitWindow: 300, knockbackStrength: 8, region: 'forward', types: ['melee', 'kick'] },
   torchSwing: { damage: 1, range: 1.5, hitTime: 100, hitWindow: 300, knockbackStrength: 2, region: 'forward', types: ['fire'] },
@@ -28,6 +32,28 @@ export function getAttackTypes(attackName, fallback = []) {
 const tempToTarget = new THREE.Vector3();
 const tempForward = new THREE.Vector3();
 const tempRight = new THREE.Vector3();
+
+function getEquippedMeleeAttackName(attackName, equippedWeaponType) {
+  if (equippedWeaponType === 'hammer') {
+    if (attackName === 'mutantPunch' || attackName === 'swordSlash') return 'hammerSlash';
+    if (attackName === 'swordSlashLeft') return 'hammerSlashLeft';
+    if (attackName === 'swordFwdSpin') return 'hammerFwdSpin';
+    if (attackName === 'swordSpin') return 'hammerSpin';
+  }
+  if (equippedWeaponType === 'sword' && attackName === 'mutantPunch') {
+    return 'swordSlash';
+  }
+  return attackName;
+}
+
+function getAnimationActionForAttack(attackName) {
+  return ({
+    hammerSlash: 'swordSlash',
+    hammerSlashLeft: 'swordSlashLeft',
+    hammerFwdSpin: 'swordFwdSpin',
+    hammerSpin: 'swordSpin'
+  })[attackName] || attackName;
+}
 
 function isTargetInAttackRange(attackerModel, targetPosition, cfg) {
   if (!attackerModel?.position || !targetPosition || !cfg) return false;
@@ -74,9 +100,7 @@ function isAttackInterrupted(attacker, attackName) {
   if (!model?.userData) return true;
   if (model.userData.isKnocked) return true;
   if (model.userData.currentAction === 'hit') return true;
-  const resolved = attackName === 'mutantPunch' && model.userData?.equippedWeaponType === 'sword'
-    ? 'swordSlash'
-    : attackName;
+  const resolved = getAnimationActionForAttack(attackName);
   if (resolved && model.userData.currentAction && model.userData.currentAction !== resolved) {
     return true;
   }
@@ -107,9 +131,7 @@ export function updateMeleeAttacks({
     if (!attacker.model || !attacker.model.userData) continue;
     const info = attacker.model.userData.attack;
     if (!info) continue;
-    const attackName = info.name === 'mutantPunch' && attacker.model.userData?.equippedWeaponType === 'sword'
-      ? 'swordSlash'
-      : info.name;
+    const attackName = getEquippedMeleeAttackName(info.name, attacker.model.userData?.equippedWeaponType);
     const cfg = ATTACKS[attackName];
     if (!cfg) continue;
     const attackCfg = info.overrides ? { ...cfg, ...info.overrides } : cfg;
@@ -126,7 +148,9 @@ export function updateMeleeAttacks({
           ? 'torchSwing'
           : attacker.model.userData?.equippedWeaponType === 'lantern'
             ? 'lanternSwing'
-            : attackName,
+            : attacker.model.userData?.equippedWeaponType === 'hammer'
+              ? attackName
+              : attackName,
         ['melee']
       );
       if (attacker.id === 'local'

--- a/public/models/golem.json
+++ b/public/models/golem.json
@@ -12,7 +12,9 @@
       "cut": 0.3,
       "ice": 0.2,
       "arrow": 0.2,
-      "melee": 0.2
+      "melee": 0.2,
+      "smash": 4.0,
+      "pummel": 4.0
     },
     "drops": [
       "salt",


### PR DESCRIPTION
### Motivation
- Introduce a new melee weapon type, `hammer`, that uses sword animations but provides higher knockback, lower damage, and the ability to break rocks in one hit with distinct `smash`/`pummel` attack types.

### Description
- Add a new weapon class `Hammer` in `items/hammer.js` that loads `/assets/props/hammer.glb` and uses the right hand when equipped via the existing `Weapon` base. 
- Extend `items/melee.js` by adding `hammerSlash`, `hammerSlashLeft`, `hammerFwdSpin`, and `hammerSpin` entries and helpers so hammer attacks reuse the same animation actions as the sword (mapping hammer attack names to sword animation action names). 
- Wire hammer into the weapon load/equip/drop/pickup/networking flow by updating `features/combatFeature.js` and `app/bootstrapGameApp.js` to load `Hammer`, register it as a networked entity, spawn pickups, add to `runtimeContext.entities.weapons`, and handle equip/unequip and inventory integration (`addToInventory`/`removeFromInventory`).
- Make controls treat the hammer like the sword for animation combos and mobile equip menus by updating `controls/controls.js` to include `hammer` in melee flows and to map equipped melee attack names. 
- Implement rock-breaking: `handleBuildAttackHit` in `app/bootstrapGameApp.js` checks for hammer attack `types` (`smash`/`pummel`) and removes rocks in radius, spawning salt drops and notifying the `rocksBlownUp` achievement. 
- Increase golem vulnerability to hammer damage by adding `"smash": 4.0` and `"pummel": 4.0` to `public/models/golem.json` `attackSensitivity`. 
- Add UI/inventory fallbacks and catalog entries so `hammer` shows a fallback icon and an inventory/catalog entry (`controls/settingsPanel.js`, `controls/homeStoragePanel.js`, `controls/merchantPanel.js`, `app/bootstrapGameApp.js`).

### Testing
- Ran the production build with `npm run build` and the build completed successfully. 
- Verified the hammer model file exists with `test -f public/assets/props/hammer.glb`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca98e0f588325845a35355ce1a2a2)