### PR TITLE
Fix bazooka and hammer equipped visuals

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -2464,12 +2464,14 @@ async function initCore(runtimeContext) {
   const setPlayerWeaponType = (controls, weaponType) => {
     if (!controls?.playerModel) return;
     controls.playerModel.userData.equippedWeaponType = weaponType || null;
+    controls.refreshActionButtons?.();
   };
 
   const clearPlayerWeaponType = (controls, weaponType) => {
     if (!controls?.playerModel) return;
     if (!weaponType || controls.playerModel.userData.equippedWeaponType === weaponType) {
       controls.playerModel.userData.equippedWeaponType = null;
+      controls.refreshActionButtons?.();
     }
   };
 
@@ -3482,8 +3484,8 @@ async function initCore(runtimeContext) {
   });
 
 
-  runtimeContext.entities.weapons = { iceGun, bow, bomb, autumnSword, hammer, lantern, torch, shield };
-  window.weapons = { iceGun, bow, bomb, autumnSword, hammer, lantern, torch, shield };
+  runtimeContext.entities.weapons = { iceGun, bow, bazooka, bomb, autumnSword, hammer, lantern, torch, shield };
+  window.weapons = { iceGun, bow, bazooka, bomb, autumnSword, hammer, lantern, torch, shield };
   treasureChest = new TreasureChest(scene);
   await treasureChest.load();
   window.treasureChest = treasureChest;
@@ -13062,6 +13064,7 @@ async function initCore(runtimeContext) {
 
     iceGun?.update();
     bow?.update();
+    bazooka?.update();
     bomb?.update();
     autumnSword?.update();
     hammer?.update();
@@ -13070,6 +13073,7 @@ async function initCore(runtimeContext) {
     shield?.update();
     syncRemoteHeldWeaponMesh(iceGun);
     syncRemoteHeldWeaponMesh(bow);
+    syncRemoteHeldWeaponMesh(bazooka);
     syncRemoteHeldWeaponMesh(bomb);
     syncRemoteHeldWeaponMesh(autumnSword);
     syncRemoteHeldWeaponMesh(hammer);

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -786,7 +786,7 @@ export class PlayerControls {
   getMobileAttackLabel() {
     const weapon = this.getEquippedWeapon('right');
     if (weapon?.itemId === 'bow') return 'Bow';
-    if (weapon?.itemId === 'bazooka') return 'Bazooka';
+    if (weapon?.itemId === 'bazooka') return 'Fire';
     if (weapon?.itemId === 'bomb') return 'Bomb';
     return 'Attack';
   }

--- a/items/bazooka.js
+++ b/items/bazooka.js
@@ -7,10 +7,11 @@ export class Bazooka extends Weapon {
       itemId: 'bazooka',
       type: 'bazooka',
       modelUrl: '/assets/props/bazooka.glb',
-      scale: 0.22,
+      scale: 0.04,
       fallbackColor: 0x3f5f3f,
       fallbackSize: new THREE.Vector3(0.9, 0.28, 0.28),
-      holdOffset: new THREE.Vector3(-0.08, 0.16, 0.12),
+      recenterModel: true,
+      holdOffset: new THREE.Vector3(-0.05, 0.12, 0.08),
       holdRotation: new THREE.Euler(-Math.PI / 2, Math.PI, 0, 'YXZ')
     });
   }

--- a/items/hammer.js
+++ b/items/hammer.js
@@ -8,9 +8,10 @@ export class Hammer extends Weapon {
       type: 'hammer',
       hand: 'right',
       modelUrl: '/assets/props/hammer.glb',
-      scale: 100.0,
-      holdOffset: new THREE.Vector3(0.45, -0.05, 0.0),
+      scale: 0.72,
+      holdOffset: new THREE.Vector3(0.18, 0.02, 0.04),
       fallbackSize: new THREE.Vector3(0.22, 0.85, 0.32),
+      recenterModel: true,
       fallbackColor: 0x8a6a4a
     });
   }

--- a/items/weapon.js
+++ b/items/weapon.js
@@ -30,6 +30,7 @@ export class Weapon {
       ? options.pickupRadius
       : DEFAULT_PICKUP_RADIUS;
     this._scale = Number.isFinite(options.scale) ? options.scale : 0.001;
+    this._recenterModel = Boolean(options.recenterModel);
     this._fallbackSize = options.fallbackSize || new THREE.Vector3(0.6, 0.2, 0.8);
     this._fallbackColor = options.fallbackColor || 0x99ccff;
   }
@@ -51,6 +52,20 @@ export class Weapon {
     }
 
     if (!this.mesh) return;
+
+    if (this._recenterModel && this.mesh.isObject3D) {
+      this.mesh.updateWorldMatrix(true, true);
+      const bounds = new THREE.Box3().setFromObject(this.mesh);
+      if (!bounds.isEmpty()) {
+        const center = new THREE.Vector3();
+        bounds.getCenter(center);
+        this.mesh.position.sub(center);
+        const wrapper = new THREE.Group();
+        wrapper.name = `${this.itemId}-centered`;
+        wrapper.add(this.mesh);
+        this.mesh = wrapper;
+      }
+    }
 
     const targetPos = position.clone();
     const terrainHeight = getTerrainHeight(targetPos.x, targetPos.z);


### PR DESCRIPTION
### Motivation
- Oversized or off-origin weapon GLB models caused held meshes to appear misplaced or invisible when equipped. 
- The bazooka was not consistently present in the active weapon collection/frame update path which prevented proper held positioning, remote syncing, and ammo UI updates when equipped. 
- Mobile controls did not immediately reflect equip/unequip changes (attack button label/behavior) after weapon type changes.

### Description
- Add an optional `recenterModel` option to `Weapon` and center model geometry when requested by computing bounds and wrapping the mesh so held meshes align with hand bones (`items/weapon.js`).
- Enable `recenterModel`, adjust `scale` and `holdOffset` for `Hammer` and `Bazooka` to make held meshes render at the correct size/position in the player hand (`items/hammer.js`, `items/bazooka.js`).
- Keep `bazooka` in `runtimeContext.entities.weapons` and `window.weapons`, call `bazooka.update()` each frame, and include it in `syncRemoteHeldWeaponMesh` and pickup/update loops so equipped lookups, held positioning and remote sync work (`app/bootstrapGameApp.js`).
- Refresh mobile action buttons when the player weapon type changes by calling `controls.refreshActionButtons()` from `setPlayerWeaponType`/`clearPlayerWeaponType`, and change the mobile attack label for bazooka from `Bazooka` to `Fire` (`app/bootstrapGameApp.js`, `controls/controls.js`).

### Testing
- Ran the production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcbd48a0f48331abd20badccc97400)