### PR TITLE
Add dog companion animal with feeding interaction

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -908,6 +908,7 @@ async function initCore(runtimeContext) {
   let animals = [];
   runtimeContext.entities.animals = animals;
   window.animals = animals;
+  void animalManager?.spawnDogAt?.();
   const npcVoiceSchedule = new Map();
   const zombieVoiceLoops = new Map();
   const getRandomDelayMs = ([min, max]) => {
@@ -3625,6 +3626,20 @@ async function initCore(runtimeContext) {
     scene,
     getPlayerModel: () => playerModel,
     getTerrainHeight,
+    getNearbyMonster: (origin, maxDistance = 9) => {
+      if (!origin) return null;
+      let nearest = null;
+      let nearestDistance = Number.POSITIVE_INFINITY;
+      monsters.forEach((monster) => {
+        if (!monster?.position || monster.userData?.isDead) return;
+        const d = monster.position.distanceTo(origin);
+        if (d <= maxDistance && d < nearestDistance) {
+          nearest = monster;
+          nearestDistance = d;
+        }
+      });
+      return nearest;
+    },
     onAnimalRemoved: ({ animal, wasDead, position }) => {
       if (!wasDead || !position) return;
       notifyAchievementProgress('animalsKilled', 1);
@@ -3639,6 +3654,7 @@ async function initCore(runtimeContext) {
   animals = animalManager.getAnimals();
   runtimeContext.entities.animals = animals;
   window.animals = animals;
+  void animalManager?.spawnDogAt?.();
   let didInitialGpsSnap = false;
   let currentPlayerLevel = 1;
 
@@ -9430,6 +9446,12 @@ async function initCore(runtimeContext) {
     await animalManager?.spawnDeerAt?.(position);
   };
 
+  window.spawnTutorialDogNearby = async () => {
+    const position = getTutorialNearbyPosition(6.5);
+    if (!position) return;
+    await animalManager?.spawnDogAt?.(position);
+  };
+
   window.spawnTutorialBowAndArrowsNearby = () => {
     const bowPos = getTutorialNearbyPosition(4.2);
     if (bowPos) {
@@ -11878,6 +11900,12 @@ async function initCore(runtimeContext) {
     delete mesh.userData.buildHealthBar;
   };
 
+  const feedDogBtn = document.createElement('button');
+  feedDogBtn.type = 'button';
+  feedDogBtn.textContent = 'Feed Dog';
+  feedDogBtn.style.cssText = 'position:fixed;left:50%;bottom:37%;transform:translateX(-50%);z-index:1200;display:none;padding:8px 12px;';
+  document.body.appendChild(feedDogBtn);
+
   const buildInteractionBtn = document.createElement('button');
   buildInteractionBtn.type = 'button';
   buildInteractionBtn.textContent = 'Read Note';
@@ -12266,6 +12294,22 @@ async function initCore(runtimeContext) {
       }
     };
   };
+  feedDogBtn.addEventListener('click', () => {
+    const playerPos = playerModel?.position;
+    const target = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
+    const dog = target?.animal;
+    if (!dog) return;
+    const mushroomId = Object.keys(inventoryState).find((id) => id?.startsWith?.('mushroom_') && (inventoryState[id]?.count || 0) > 0);
+    const feedItem = (inventoryState[APPLE_ITEM_ID]?.count || 0) > 0 ? APPLE_ITEM_ID : mushroomId;
+    if (!feedItem) {
+      showMobileStatusToast('Need an apple or mushroom to feed the dog.');
+      return;
+    }
+    removeFromInventory(feedItem, 1);
+    animalManager?.feedDog?.(dog, 10);
+    showMobileStatusToast('The dog is now your companion!');
+  });
+
   buildInteractionBtn.addEventListener('click', () => { void showNoteInteraction(); });
 
   const locationAdapter = {
@@ -12603,6 +12647,9 @@ async function initCore(runtimeContext) {
         });
         const shouldShow = Boolean(buildState.selectedNoteId) && closestNoteDistance <= closestInteractDistance;
         buildInteractionBtn.style.display = shouldShow ? 'block' : 'none';
+
+        const nearbyDog = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
+        feedDogBtn.style.display = nearbyDog ? 'block' : 'none';
       }
     }
     updateBuildHealthBars();
@@ -13245,6 +13292,7 @@ async function initCore(runtimeContext) {
           animals = animalManager.getAnimals();
           runtimeContext.entities.animals = animals;
           window.animals = animals;
+  void animalManager?.spawnDogAt?.();
         }
 
         if (isHostNow) {

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -908,7 +908,6 @@ async function initCore(runtimeContext) {
   let animals = [];
   runtimeContext.entities.animals = animals;
   window.animals = animals;
-  void animalManager?.spawnDogAt?.();
   const npcVoiceSchedule = new Map();
   const zombieVoiceLoops = new Map();
   const getRandomDelayMs = ([min, max]) => {
@@ -3654,7 +3653,6 @@ async function initCore(runtimeContext) {
   animals = animalManager.getAnimals();
   runtimeContext.entities.animals = animals;
   window.animals = animals;
-  void animalManager?.spawnDogAt?.();
   let didInitialGpsSnap = false;
   let currentPlayerLevel = 1;
 
@@ -13289,10 +13287,10 @@ async function initCore(runtimeContext) {
         }
         if (animalManager) {
           animalManager.update(mixerDelta);
+          void animalManager.maybeSpawnDogByTravelDistance?.();
           animals = animalManager.getAnimals();
           runtimeContext.entities.animals = animals;
           window.animals = animals;
-  void animalManager?.spawnDogAt?.();
         }
 
         if (isHostNow) {

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { MonsterCharacter } from '../characters/MonsterCharacter.js';
 
-const ANIMAL_TYPES = ['Deer', 'dog'];
+const ANIMAL_TYPES = ['Deer'];
 const SPAWN_MIN_RADIUS = 10;
 const SPAWN_MAX_RADIUS = 26;
 const SPAWN_ATTEMPTS = 10;

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -208,42 +208,6 @@ async function spawnAnimal({ scene, getPlayerModel, getTerrainHeight, forcedPosi
 
   scene.add(animal.model);
 
-  const spawnDogAt = async (position) => {
-    const entry = await spawnAnimal({
-      scene,
-      getPlayerModel,
-      getTerrainHeight,
-      forcedPosition: position || null,
-      forcedType: 'dog'
-    });
-    if (entry) animals.push(entry);
-    return entry?.animal || null;
-  };
-
-  const getNearestFeedableDog = (position, maxDistance = 2.5) => {
-    if (!position) return null;
-    let best = null;
-    let bestDistance = Number.POSITIVE_INFINITY;
-    animals.forEach((entry) => {
-      const animal = entry?.animal;
-      if (!animal?.model?.position || animal.isDead) return;
-      if (String(animal.type).toLowerCase() !== 'dog') return;
-      if (animal.model.userData?.isCompanion) return;
-      const dist = animal.model.position.distanceTo(position);
-      if (dist <= maxDistance && dist < bestDistance) { best = animal; bestDistance = dist; }
-    });
-    return best ? { animal: best, distance: bestDistance } : null;
-  };
-
-  const feedDog = (dog, healthGain = 10) => {
-    if (!dog?.model || dog.isDead) return false;
-    dog.health = Math.min(dog.maxHealth || 1, (dog.health || 0) + healthGain);
-    dog.model.userData.health = dog.health;
-    dog.model.userData.isCompanion = true;
-    dog.updateHealthBarTexture?.();
-    return true;
-  };
-
   return { animal, config: template.config };
 }
 
@@ -375,6 +339,8 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
 
 export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, onAnimalRemoved, getNearbyMonster } = {}) {
   const animals = [];
+  let lastDogSpawnPlayerPosition = null;
+  let lastDogSpawnAt = 0;
   const removeAnimal = (entry) => {
     if (!entry?.animal) return;
     const index = animals.indexOf(entry);
@@ -435,7 +401,13 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
   };
 
 
+  const hasLivingDog = () => animals.some((entry) => {
+    const animal = entry?.animal;
+    return animal?.model && !animal.isDead && String(animal.type).toLowerCase() === 'dog';
+  });
+
   const spawnDogAt = async (position) => {
+    if (hasLivingDog()) return null;
     const entry = await spawnAnimal({
       scene,
       getPlayerModel,
@@ -443,8 +415,21 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
       forcedPosition: position || null,
       forcedType: 'dog'
     });
-    if (entry) animals.push(entry);
+    if (entry) {
+      animals.push(entry);
+      lastDogSpawnPlayerPosition = getPlayerModel?.()?.position?.clone?.() || null;
+      lastDogSpawnAt = Date.now();
+    }
     return entry?.animal || null;
+  };
+
+  const maybeSpawnDogByTravelDistance = async ({ minTravelDistance = 220, minSpawnIntervalMs = 90000 } = {}) => {
+    const playerPosition = getPlayerModel?.()?.position;
+    if (!playerPosition || hasLivingDog()) return null;
+    const now = Date.now();
+    if (now - lastDogSpawnAt < minSpawnIntervalMs) return null;
+    if (lastDogSpawnPlayerPosition && playerPosition.distanceTo(lastDogSpawnPlayerPosition) < minTravelDistance) return null;
+    return spawnDogAt();
   };
 
   const getNearestFeedableDog = (position, maxDistance = 2.5) => {
@@ -478,6 +463,7 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
     removeAnimalById,
     spawnDeerAt,
     spawnDogAt,
+    maybeSpawnDogByTravelDistance,
     getNearestFeedableDog,
     feedDog
   };

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { MonsterCharacter } from '../characters/MonsterCharacter.js';
 
-const ANIMAL_TYPES = ['Deer'];
+const ANIMAL_TYPES = ['Deer', 'dog'];
 const SPAWN_MIN_RADIUS = 10;
 const SPAWN_MAX_RADIUS = 26;
 const SPAWN_ATTEMPTS = 10;
@@ -207,6 +207,43 @@ async function spawnAnimal({ scene, getPlayerModel, getTerrainHeight, forcedPosi
   };
 
   scene.add(animal.model);
+
+  const spawnDogAt = async (position) => {
+    const entry = await spawnAnimal({
+      scene,
+      getPlayerModel,
+      getTerrainHeight,
+      forcedPosition: position || null,
+      forcedType: 'dog'
+    });
+    if (entry) animals.push(entry);
+    return entry?.animal || null;
+  };
+
+  const getNearestFeedableDog = (position, maxDistance = 2.5) => {
+    if (!position) return null;
+    let best = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    animals.forEach((entry) => {
+      const animal = entry?.animal;
+      if (!animal?.model?.position || animal.isDead) return;
+      if (String(animal.type).toLowerCase() !== 'dog') return;
+      if (animal.model.userData?.isCompanion) return;
+      const dist = animal.model.position.distanceTo(position);
+      if (dist <= maxDistance && dist < bestDistance) { best = animal; bestDistance = dist; }
+    });
+    return best ? { animal: best, distance: bestDistance } : null;
+  };
+
+  const feedDog = (dog, healthGain = 10) => {
+    if (!dog?.model || dog.isDead) return false;
+    dog.health = Math.min(dog.maxHealth || 1, (dog.health || 0) + healthGain);
+    dog.model.userData.health = dog.health;
+    dog.model.userData.isCompanion = true;
+    dog.updateHealthBarTexture?.();
+    return true;
+  };
+
   return { animal, config: template.config };
 }
 
@@ -221,7 +258,7 @@ function isHitReactPlaying(animal) {
   return !!action?.isRunning?.();
 }
 
-function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight, delta }) {
+function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight, getNearbyMonster, delta }) {
   const playerModel = getPlayerModel?.();
   if (!animal?.model || !playerModel?.position) return;
   if (animal.isDead) {
@@ -239,7 +276,15 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   const distanceToPlayer = animal.model.position.distanceTo(playerModel.position);
   const data = animal.userData || {};
 
-  if (behavior === 'runAway' && distanceToPlayer <= fleeDistance) {
+  const isCompanionBehavior = behavior === 'companion';
+  const isCompanion = !!animal.model?.userData?.isCompanion;
+  const nearbyMonster = isCompanion ? getNearbyMonster?.(animal.model.position, 9) : null;
+
+  if (isCompanionBehavior && isCompanion && nearbyMonster?.position) {
+    data.state = 'companionAttack';
+  } else if (isCompanionBehavior && isCompanion) {
+    data.state = 'companionFollow';
+  } else if (behavior === 'runAway' && distanceToPlayer <= fleeDistance) {
     data.state = 'runAway';
     data.runAwayUntil = now + 1600;
   } else if (behavior === 'attack' && distanceToPlayer <= attackDistance) {
@@ -266,7 +311,33 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
 
   const hitReactLocked = isHitReactPlaying(animal);
 
-  if (data.state === 'runAway') {
+  if (data.state === 'companionFollow') {
+    const direction = new THREE.Vector3().subVectors(playerModel.position, animal.model.position).setY(0);
+    const distance = direction.length();
+    if (distance > 2.2) {
+      direction.normalize();
+      animal.model.position.addScaledVector(direction, runSpeed * 0.8 * delta);
+      animal.model.lookAt(animal.model.position.clone().add(direction));
+      if (!hitReactLocked) animal.playAnimation('Run', 0.12);
+    } else if (!hitReactLocked) {
+      animal.playAnimation('Idle', 0.15);
+    }
+  } else if (data.state === 'companionAttack') {
+    const target = getNearbyMonster?.(animal.model.position, 9);
+    if (target?.position) {
+      const direction = new THREE.Vector3().subVectors(target.position, animal.model.position).setY(0);
+      const distance = direction.length();
+      if (distance > attackDistance) {
+        direction.normalize();
+        animal.model.position.addScaledVector(direction, runSpeed * delta);
+        animal.model.lookAt(animal.model.position.clone().add(direction));
+        if (!hitReactLocked) animal.playAnimation('Run', 0.1);
+      } else if (!hitReactLocked) {
+        animal.playAnimation('Weapon', 0.08);
+        if (!target.userData?.isDead) target.userData.health = Math.max(0, (target.userData.health || 10) - (6 * delta));
+      }
+    }
+  } else if (data.state === 'runAway') {
     const direction = new THREE.Vector3().subVectors(animal.model.position, playerModel.position).setY(0);
     if (direction.lengthSq() < 0.0001) {
       direction.set(Math.random() - 0.5, 0, Math.random() - 0.5);
@@ -302,7 +373,7 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   animal.update(delta);
 }
 
-export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, onAnimalRemoved } = {}) {
+export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, onAnimalRemoved, getNearbyMonster } = {}) {
   const animals = [];
   const removeAnimal = (entry) => {
     if (!entry?.animal) return;
@@ -343,7 +414,7 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
         removeAnimal(entry);
         continue;
       }
-      updateAnimalMovement({ animal, config: entry.config || {}, getPlayerModel, getTerrainHeight, delta });
+      updateAnimalMovement({ animal, config: entry.config || {}, getPlayerModel, getTerrainHeight, getNearbyMonster, delta });
     }
   };
 
@@ -363,11 +434,51 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
     return entry?.animal || null;
   };
 
+
+  const spawnDogAt = async (position) => {
+    const entry = await spawnAnimal({
+      scene,
+      getPlayerModel,
+      getTerrainHeight,
+      forcedPosition: position || null,
+      forcedType: 'dog'
+    });
+    if (entry) animals.push(entry);
+    return entry?.animal || null;
+  };
+
+  const getNearestFeedableDog = (position, maxDistance = 2.5) => {
+    if (!position) return null;
+    let best = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    animals.forEach((entry) => {
+      const animal = entry?.animal;
+      if (!animal?.model?.position || animal.isDead) return;
+      if (String(animal.type).toLowerCase() !== 'dog') return;
+      if (animal.model.userData?.isCompanion) return;
+      const dist = animal.model.position.distanceTo(position);
+      if (dist <= maxDistance && dist < bestDistance) { best = animal; bestDistance = dist; }
+    });
+    return best ? { animal: best, distance: bestDistance } : null;
+  };
+
+  const feedDog = (dog, healthGain = 10) => {
+    if (!dog?.model || dog.isDead) return false;
+    dog.health = Math.min(dog.maxHealth || 1, (dog.health || 0) + healthGain);
+    dog.model.userData.health = dog.health;
+    dog.model.userData.isCompanion = true;
+    dog.updateHealthBarTexture?.();
+    return true;
+  };
+
   return {
     update,
     getAnimals,
     removeAnimal,
     removeAnimalById,
-    spawnDeerAt
+    spawnDeerAt,
+    spawnDogAt,
+    getNearestFeedableDog,
+    feedDog
   };
 }


### PR DESCRIPTION
### Motivation
- Introduce a new animal type `dog` that can be tamed and act as a companion, reusing the model and animation aliases provided by `/public/models/animals/dog.json`.
- Provide a simple player interaction to feed and convert a roaming dog into a follower that helps in combat.

### Description
- Added `dog` to the spawnable types and wired template-driven animation resolution so the animations listed in `dog.json` are applied via the existing animation map (`environment/animals.js`).
- Implemented companion behavior states in `updateAnimalMovement` to support `companionFollow` and `companionAttack`, where a fed dog follows the player and attacks nearby monsters using a provided `getNearbyMonster` callback.
- Exposed new manager APIs: `spawnDogAt`, `getNearestFeedableDog`, and `feedDog` from `createAnimalManager`, and passed a `getNearbyMonster` helper into the manager from the runtime (`app/bootstrapGameApp.js`).
- Added UI and interaction flow in the main app to show a `Feed Dog` overlay/button when the player is near a non-companion dog, consume one `apple` (preferred) or a `mushroom` from inventory on click, heal the dog, and mark it as a companion; also added `window.spawnTutorialDogNearby` and a runtime auto-spawn call to help test the feature.

### Testing
- Built the project with `npm run -s build` and the build completed successfully.
- No additional automated tests were added; the change was validated by a successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd50c19248333a2e82d953f2e8237)