### PR TITLE
Add dog companion naming popup, persistence, labels, and colliders

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -106,6 +106,7 @@ import { claimAchievement, getAchievementView, mergeAchievementState, recordAchi
 import { getDistanceUnitPreference, setDistanceUnitPreference } from '../distanceUnits.js';
 import { db } from '../firebase-init.js';
 import { onValue, push, ref, remove, set, update } from 'firebase/database';
+import { openPopupDialog } from '../controls/popupDialog.js';
 
 import {
   clearStoredPin,
@@ -118,6 +119,7 @@ import {
   saveCustomization,
   saveQuestState,
   saveAchievementState,
+  saveCompanions,
   saveSleepTimestamp,
   saveWalkingStats,
   saveStatsImmediate,
@@ -3640,6 +3642,12 @@ async function initCore(runtimeContext) {
       return nearest;
     },
     onAnimalRemoved: ({ animal, wasDead, position }) => {
+      const dogCollider = dogColliderEntries.get(animal?.id);
+      if (dogCollider) removeStaticBoxCollider(dogCollider);
+      dogColliderEntries.delete(animal?.id);
+      const label = animalNameLabels.get(animal?.id);
+      label?.parentNode?.removeChild(label);
+      animalNameLabels.delete(animal?.id);
       if (!wasDead || !position) return;
       notifyAchievementProgress('animalsKilled', 1);
       window.questManager?.handleAnimalKilled?.(animal);
@@ -11903,6 +11911,9 @@ async function initCore(runtimeContext) {
   feedDogBtn.textContent = 'Feed Dog';
   feedDogBtn.style.cssText = 'position:fixed;left:50%;bottom:37%;transform:translateX(-50%);z-index:1200;display:none;padding:8px 12px;';
   document.body.appendChild(feedDogBtn);
+  const animalNameLabels = new Map();
+  const dogColliderEntries = new Map();
+  const companionData = { ...(playerProfile?.companions || {}) };
 
   const buildInteractionBtn = document.createElement('button');
   buildInteractionBtn.type = 'button';
@@ -12304,7 +12315,27 @@ async function initCore(runtimeContext) {
       return;
     }
     removeFromInventory(feedItem, 1);
+    const isNewCompanion = !dog.model.userData?.isCompanion;
     animalManager?.feedDog?.(dog, 10);
+    const persistDog = async (name) => {
+      const key = String(dog.id || `${dog.type}-unknown`);
+      companionData[key] = { id: key, type: 'dog', name: name || dog.model.userData?.companionName || 'Companion', health: dog.health || 1, maxHealth: dog.maxHealth || 1 };
+      dog.model.userData.companionName = companionData[key].name;
+      playerProfile = playerProfile || {};
+      playerProfile.companions = { ...companionData };
+      if (profileNameKey) await saveCompanions(profileNameKey, companionData);
+    };
+    if (isNewCompanion) {
+      void openPopupDialog({
+        title: 'New Animal Companion',
+        message: "you've made an animal companion! remember to feed them!",
+        inputLabel: "Name your dog",
+        inputPlaceholder: 'Companion name',
+        confirmText: 'Save Name'
+      }).then((name) => persistDog(name));
+    } else {
+      void persistDog(dog.model.userData?.companionName || 'Companion');
+    }
     showMobileStatusToast('The dog is now your companion!');
   });
 
@@ -13560,6 +13591,27 @@ async function initCore(runtimeContext) {
           nameLabel.style.transform = `translate(-50%, -50%) scale(${scale})`;
           nameLabel.style.opacity = opacity.toFixed(2);
         });
+        (animals || []).forEach((animal) => {
+          if (!animal?.model || !animal.model.userData?.isCompanion) return;
+          const name = animal.model.userData?.companionName;
+          if (!name) return;
+          let label = animalNameLabels.get(animal.id);
+          if (!label) {
+            label = document.createElement('div');
+            label.className = 'name-tag';
+            label.style.cssText = 'position:fixed;z-index:1200;color:white;background:rgba(0,0,0,0.5);padding:2px 6px;border-radius:6px;font-size:12px;pointer-events:none;';
+            document.body.appendChild(label);
+            animalNameLabels.set(animal.id, label);
+          }
+          label.textContent = name;
+          const pos = animal.model.position.clone().add(new THREE.Vector3(0, 2, 0));
+          pos.project(camera);
+          if (pos.z < 0 || pos.z > 1) { label.style.display = 'none'; return; }
+          label.style.display = 'block';
+          label.style.left = `${(pos.x * 0.5 + 0.5) * window.innerWidth}px`;
+          label.style.top = `${(-pos.y * 0.5 + 0.5) * window.innerHeight}px`;
+          label.style.transform = 'translate(-50%, -50%)';
+        });
       });
     }
 
@@ -13625,6 +13677,15 @@ async function initCore(runtimeContext) {
       sendMonsterAttack: sendMonsterAttackIntent,
       onMonsterHit: handleMonsterDamage,
       onBuildHit: handleBuildProjectileHit
+    });
+    (animals || []).forEach((animal) => {
+      if (!animal?.model || String(animal.type).toLowerCase() !== 'dog') return;
+      if (!dogColliderEntries.has(animal.id)) {
+        const entry = createStaticBoxColliderForObject(animal.model, { rapierWorld, friction: 0.8, restitution: 0.01 });
+        dogColliderEntries.set(animal.id, entry || null);
+      } else {
+        syncStaticBoxColliderForObject(animal.model, dogColliderEntries.get(animal.id));
+      }
     });
     handleBombPickupArrowHit();
 

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3661,6 +3661,33 @@ async function initCore(runtimeContext) {
   animals = animalManager.getAnimals();
   runtimeContext.entities.animals = animals;
   window.animals = animals;
+  const restoreCompanionDogsFromProfile = async () => {
+    const savedCompanions = playerProfile?.companions && typeof playerProfile.companions === 'object'
+      ? Object.values(playerProfile.companions)
+      : [];
+    const dogCompanions = savedCompanions.filter((entry) => String(entry?.type || '').toLowerCase() === 'dog');
+    if (dogCompanions.length === 0) return;
+    const basePosition = playerModel?.position?.clone?.();
+    if (!basePosition) return;
+    for (let i = 0; i < dogCompanions.length; i += 1) {
+      const companion = dogCompanions[i];
+      const angle = (i / Math.max(1, dogCompanions.length)) * Math.PI * 2;
+      const offset = new THREE.Vector3(Math.cos(angle) * 3, 0, Math.sin(angle) * 3);
+      const spawnPos = basePosition.clone().add(offset);
+      const dog = await animalManager?.spawnDogAt?.(spawnPos);
+      if (!dog?.model) continue;
+      dog.model.userData.isCompanion = true;
+      dog.model.userData.companionName = companion?.name || 'Companion';
+      if (Number.isFinite(companion?.health)) {
+        dog.health = Math.max(1, Math.min(dog.maxHealth || 1, Math.round(companion.health)));
+        dog.model.userData.health = dog.health;
+      }
+      if (companion?.id) {
+        dog.id = companion.id;
+      }
+    }
+  };
+  await restoreCompanionDogsFromProfile();
   let didInitialGpsSnap = false;
   let currentPlayerLevel = 1;
 

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -13681,10 +13681,17 @@ async function initCore(runtimeContext) {
     (animals || []).forEach((animal) => {
       if (!animal?.model || String(animal.type).toLowerCase() !== 'dog') return;
       if (!dogColliderEntries.has(animal.id)) {
-        const entry = createStaticBoxColliderForObject(animal.model, { rapierWorld, friction: 0.8, restitution: 0.01 });
+        const entry = createStaticBoxColliderForObject(animal.model, {
+          rapierWorld,
+          friction: 0.8,
+          restitution: 0.01,
+          useObjectPosition: true,
+          centerOffset: [0, 0.4, 0],
+          halfExtents: [0.24, 0.33, 0.5]
+        });
         dogColliderEntries.set(animal.id, entry || null);
       } else {
-        syncStaticBoxColliderForObject(animal.model, dogColliderEntries.get(animal.id));
+        syncStaticBoxColliderForObject(dogColliderEntries.get(animal.id));
       }
     });
     handleBombPickupArrowHit();

--- a/controls/popupDialog.js
+++ b/controls/popupDialog.js
@@ -1,0 +1,52 @@
+export function openPopupDialog({
+  title = '',
+  message = '',
+  inputLabel = '',
+  inputValue = '',
+  inputPlaceholder = '',
+  confirmText = 'Confirm',
+  cancelText = 'Cancel'
+} = {}) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'build-modal-overlay';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:1800;background:rgba(0,0,0,0.55);display:flex;align-items:center;justify-content:center;padding:16px;';
+
+    const modal = document.createElement('div');
+    modal.className = 'build-modal';
+    modal.style.maxWidth = '420px';
+    modal.style.width = '100%';
+    modal.innerHTML = `
+      <h3>${title}</h3>
+      <p style="margin:0 0 10px 0;">${message}</p>
+      <label style="display:block;font-weight:600;margin-bottom:6px;">${inputLabel}</label>
+      <input type="text" class="settings-input" style="width:100%;margin-bottom:12px;" />
+      <div class="build-modal-actions">
+        <button type="button" class="build-cancel-btn" data-popup-cancel="1">${cancelText}</button>
+        <button type="button" class="retro-build-btn" data-popup-confirm="1">${confirmText}</button>
+      </div>
+    `;
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+
+    const input = modal.querySelector('input');
+    input.value = inputValue || '';
+    input.placeholder = inputPlaceholder || '';
+    setTimeout(() => input.focus(), 0);
+
+    const close = (value) => {
+      overlay.remove();
+      resolve(value);
+    };
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) close(null);
+    });
+    modal.querySelector('[data-popup-cancel]')?.addEventListener('click', () => close(null));
+    modal.querySelector('[data-popup-confirm]')?.addEventListener('click', () => close(input.value?.trim?.() || ''));
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') close(input.value?.trim?.() || '');
+      if (event.key === 'Escape') close(null);
+    });
+  });
+}

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -407,7 +407,6 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
   });
 
   const spawnDogAt = async (position) => {
-    if (hasLivingDog()) return null;
     const entry = await spawnAnimal({
       scene,
       getPlayerModel,

--- a/features/persistenceFeature.js
+++ b/features/persistenceFeature.js
@@ -9,6 +9,7 @@ export {
   saveCustomization,
   saveQuestState,
   saveAchievementState,
+  saveCompanions,
   saveSleepTimestamp,
   saveWalkingStats,
   saveStatsImmediate,

--- a/playerProfile.js
+++ b/playerProfile.js
@@ -55,6 +55,7 @@ const DEFAULT_WALKING_STATS = {
   dailyMiles: {},
   updatedAt: null
 };
+const DEFAULT_COMPANIONS = {};
 
 const lastWriteByName = new Map();
 const pendingStatsByName = new Map();
@@ -101,6 +102,7 @@ function buildProfile(name) {
     quests: mergeQuests(DEFAULT_QUESTS),
     achievements: mergeAchievements(DEFAULT_ACHIEVEMENTS),
     walkingStats: { ...DEFAULT_WALKING_STATS },
+    companions: { ...DEFAULT_COMPANIONS },
     characterModel: null,
     sleepStartedAt: null,
     lastStatUpdateAt: now,
@@ -222,6 +224,7 @@ async function loadProfileForName(profileRef, trimmedName) {
   const mergedAchievements = mergeAchievements(profile.achievements);
   const mergedCharacterModel = typeof profile.characterModel === 'string' ? profile.characterModel : null;
   const mergedWalkingStats = mergeWalkingStats(profile.walkingStats);
+  const mergedCompanions = profile.companions && typeof profile.companions === 'object' ? { ...profile.companions } : { ...DEFAULT_COMPANIONS };
   const statsMissing = Object.keys(DEFAULT_STATS).some(key => profile.stats?.[key] == null);
   const hasLastStatUpdateAt = Number.isFinite(profile.lastStatUpdateAt);
   const inventoryMissing = profile.inventory == null;
@@ -234,7 +237,8 @@ async function loadProfileForName(profileRef, trimmedName) {
   const achievementsMissing = profile.achievements == null;
   const characterModelMissing = profile.characterModel !== mergedCharacterModel;
   const walkingStatsMissing = profile.walkingStats == null;
-  if (statsMissing || !hasLastStatUpdateAt || inventoryMissing || homeStorageMissing || customizationMissing || spellsMissing || questsMissing || achievementsMissing || characterModelMissing || walkingStatsMissing) {
+  const companionsMissing = profile.companions == null;
+  if (statsMissing || !hasLastStatUpdateAt || inventoryMissing || homeStorageMissing || customizationMissing || spellsMissing || questsMissing || achievementsMissing || characterModelMissing || walkingStatsMissing || companionsMissing) {
     const updatePayload = { updatedAt: Date.now() };
     if (statsMissing) {
       updatePayload.stats = mergedStats;
@@ -290,6 +294,12 @@ async function loadProfileForName(profileRef, trimmedName) {
     } else {
       profile.walkingStats = mergedWalkingStats;
     }
+    if (companionsMissing) {
+      updatePayload.companions = mergedCompanions;
+      profile.companions = mergedCompanions;
+    } else {
+      profile.companions = mergedCompanions;
+    }
     if (!hasLastStatUpdateAt) {
       updatePayload.lastStatUpdateAt = Date.now();
       profile.lastStatUpdateAt = updatePayload.lastStatUpdateAt;
@@ -304,7 +314,8 @@ async function loadProfileForName(profileRef, trimmedName) {
     profile.quests = mergedQuests;
     profile.achievements = mergedAchievements;
     profile.characterModel = mergedCharacterModel;
-    profile.walkingStats = mergedWalkingStats;
+  profile.walkingStats = mergedWalkingStats;
+  profile.companions = mergedCompanions;
   }
 
   console.log('✅ Loaded profile for', trimmedName);
@@ -678,6 +689,18 @@ export async function saveWalkingStats(nameKey, walkingStats) {
     });
   } catch (error) {
     console.error('Failed to save walking stats for', nameKey, error);
+  }
+}
+
+export async function saveCompanions(nameKey, companions) {
+  if (!nameKey) return;
+  try {
+    await update(ref(db, `profiles/${nameKey}`), {
+      companions: companions && typeof companions === 'object' ? companions : {},
+      updatedAt: Date.now()
+    });
+  } catch (error) {
+    console.error('Failed to save companions for', nameKey, error);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Make dogs into tangible companions that players can bump into and name when first fed. 
- Persist companion state (name + health) so companions survive across sessions and can be recreated for the player.

### Description
- Add a reusable popup utility `openPopupDialog` in `controls/popupDialog.js` for message + text-input flows used when creating a new companion. 
- Update the feeding flow in `app/bootstrapGameApp.js` to show the companion onboarding popup, capture a dog name on first feed, persist companion records to the player profile via `saveCompanions`, and handle subsequent feeds for other dogs. 
- Show companion names above companion animals in-world by projecting a `div` label for each companion in the per-frame `remoteLabels` update. 
- Add physical collision for dogs by creating per-dog static colliders with `createStaticBoxColliderForObject`, syncing them each frame with `syncStaticBoxColliderForObject`, and cleaning up colliders and labels in `onAnimalRemoved`. 
- Extend profile schema and persistence: add `companions` to profile defaults and loading/merge logic in `playerProfile.js`, add `saveCompanions(nameKey, companions)` to persist to Firebase, and re-export `saveCompanions` from `features/persistenceFeature.js`.

### Testing
- Ran the production build with `npm run build`, which completed successfully (no build errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce29ff4588333aa30ea5c841244fd)