### PR TITLE
Improve companion follow spacing and reduce follow jitter

### DIFF
--- a/characters/FriendlyCharacter.js
+++ b/characters/FriendlyCharacter.js
@@ -31,6 +31,7 @@ export class FriendlyCharacter extends MonsterCharacter {
     this.followTargetModel = null;
     this.followDistance = 3;
     this.followStartDistance = 4.5;
+    this.isFollowingTarget = false;
     this.helpingPlayerFight = false;
     this.monsterHelpRadius = FRIENDLY_MONSTER_HELP_RADIUS;
     this.alwaysShowHealthBar = true;
@@ -93,6 +94,7 @@ export class FriendlyCharacter extends MonsterCharacter {
     if (Number.isFinite(followStartDistance)) {
       this.followStartDistance = Math.max(this.followDistance + 0.1, followStartDistance);
     }
+    this.isFollowingTarget = false;
   }
 
   setLevel(level, { preserveHealth = true } = {}) {
@@ -229,6 +231,12 @@ export class FriendlyCharacter extends MonsterCharacter {
       const followDir = followDistance > 0.0001 ? toTarget.clone().multiplyScalar(1 / followDistance) : null;
 
       if (followDistance > this.followStartDistance && followDir) {
+        this.isFollowingTarget = true;
+      } else if (followDistance <= this.followDistance) {
+        this.isFollowingTarget = false;
+      }
+
+      if (this.isFollowingTarget && followDir) {
         this.setDirection(followDir);
         const movement = followDir.clone().multiplyScalar(CHARACTER_MOVEMENT.walkSpeed * IDLE_SPEED_MULTIPLIER);
         body.setLinvel({ x: movement.x, y: 0, z: movement.z }, true);
@@ -249,6 +257,7 @@ export class FriendlyCharacter extends MonsterCharacter {
       this.update(delta);
       return;
     }
+    this.isFollowingTarget = false;
 
     if (this.isEngaged && (closestPlayer || this.forceEngaged)) {
       const targetSource = closestPlayer?.model?.position || this.homePosition;

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -276,9 +276,40 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   const hitReactLocked = isHitReactPlaying(animal);
 
   if (data.state === 'companionFollow') {
-    const direction = new THREE.Vector3().subVectors(playerModel.position, animal.model.position).setY(0);
+    if (!Number.isFinite(data.followRadius)) {
+      data.followRadius = randomRange(2.8, 6.2);
+    }
+    if (!Number.isFinite(data.followStartPadding)) {
+      data.followStartPadding = randomRange(0.9, 1.8);
+    }
+    if (!Number.isFinite(data.nextFollowRetargetAt)) {
+      data.nextFollowRetargetAt = now;
+    }
+    if (!Number.isFinite(data.followSlotAngle)) {
+      data.followSlotAngle = Math.random() * Math.PI * 2;
+    }
+
+    if (now >= data.nextFollowRetargetAt || !data.followAnchor) {
+      data.followSlotAngle += randomRange(-0.9, 0.9);
+      const offset = new THREE.Vector3(
+        Math.cos(data.followSlotAngle) * data.followRadius,
+        0,
+        Math.sin(data.followSlotAngle) * data.followRadius
+      );
+      data.followAnchor = playerModel.position.clone().add(offset);
+      data.nextFollowRetargetAt = now + randomRange(3000, 10000);
+    }
+
+    const direction = new THREE.Vector3().subVectors(data.followAnchor, animal.model.position).setY(0);
     const distance = direction.length();
-    if (distance > 2.2) {
+    const followStartDistance = data.followRadius + data.followStartPadding;
+    if (distance > followStartDistance) {
+      data.isFollowingAnchor = true;
+    } else if (distance <= data.followRadius) {
+      data.isFollowingAnchor = false;
+    }
+
+    if (data.isFollowingAnchor && distance > 0.0001) {
       direction.normalize();
       animal.model.position.addScaledVector(direction, runSpeed * 0.8 * delta);
       animal.model.lookAt(animal.model.position.clone().add(direction));


### PR DESCRIPTION
### Motivation
- Prevent multiple dog companions from stacking on the exact same spot by giving each companion a distinct follow position. 
- Reduce rapid toggling between running and idling when companions or the quest friend follow a slowly-moving player. 
- Apply the same follow hysteresis improvements to the quest `FriendlyCharacter` to make its follow behavior less twitchy.

### Description
- Companion dogs now pick a randomized personal follow radius and angular slot and pursue a local `followAnchor` instead of the player position every frame, stored in `environment/animals.js`.
- Companion follow anchors are retargeted at randomized intervals between `3000–10000 ms` to add natural variation and avoid continuous recomputation, implemented in `environment/animals.js`.
- Companion follow uses start/stop hysteresis (`followRadius` and `followStartPadding`) so companions require a larger distance to start running and a smaller distance to stop, reducing rapid run/idle flips, implemented in `environment/animals.js`.
- `FriendlyCharacter` follow logic was updated to use hysteresis: it now sets/clears an `isFollowingTarget` flag and only moves when the target is beyond `followStartDistance` and stops when within `followDistance`, and the flag is reset when follow target settings change, implemented in `characters/FriendlyCharacter.js`.

### Testing
- Ran the production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf160c69c83339ea1267411c0c6e0)