### PR TITLE
Keep Feed overlay for companion dogs; unify feeding (apple/mushroom/meat) and add quest food action

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11943,6 +11943,12 @@ async function initCore(runtimeContext) {
   const companionData = { ...(playerProfile?.companions || {}) };
   const DOG_FOOD_HEAL = 10;
   const MEAT_FEED_HEAL = 30;
+  const FRIENDLY_FEED_RESULT = Object.freeze({
+    success: 'success',
+    notHungry: 'notHungry',
+    noFood: 'noFood',
+    invalidTarget: 'invalidTarget'
+  });
   const getFeedItemFromInventory = () => {
     const hasApples = (inventoryState[APPLE_ITEM_ID]?.count || 0) > 0;
     if (hasApples) return { itemId: APPLE_ITEM_ID, healAmount: DOG_FOOD_HEAL };
@@ -11952,17 +11958,32 @@ async function initCore(runtimeContext) {
     return null;
   };
   const consumeFoodAndHealFriendly = (friendly) => {
-    if (!friendly?.model || friendly.isDead) return false;
+    if (!friendly?.model || friendly.isDead) {
+      return { status: FRIENDLY_FEED_RESULT.invalidTarget };
+    }
+    const maxHealth = Math.max(1, Number(friendly.maxHealth || 1));
+    const currentHealth = Math.max(0, Number(friendly.health || 0));
+    if (currentHealth >= maxHealth) {
+      friendly.showHealthBar?.();
+      showMobileStatusToast("They're not hungry right now.");
+      return { status: FRIENDLY_FEED_RESULT.notHungry };
+    }
     const feedSelection = getFeedItemFromInventory();
     if (!feedSelection) {
       showMobileStatusToast("You don't have any food for them.");
-      return false;
+      return { status: FRIENDLY_FEED_RESULT.noFood };
     }
     removeFromInventory(feedSelection.itemId, 1);
-    friendly.health = Math.min(friendly.maxHealth || 1, (friendly.health || 0) + feedSelection.healAmount);
+    friendly.health = Math.min(maxHealth, currentHealth + feedSelection.healAmount);
     friendly.model.userData.health = friendly.health;
     friendly.updateHealthBarTexture?.();
-    return true;
+    friendly.showHealthBar?.();
+    const foodLabel = inventoryCatalog?.[feedSelection.itemId]?.name || feedSelection.itemId;
+    return {
+      status: FRIENDLY_FEED_RESULT.success,
+      itemId: feedSelection.itemId,
+      foodLabel
+    };
   };
   window.feedFriendlyWithFood = consumeFoodAndHealFriendly;
 
@@ -12359,6 +12380,13 @@ async function initCore(runtimeContext) {
     const target = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
     const dog = target?.animal;
     if (!dog) return;
+    const maxHealth = Math.max(1, Number(dog.maxHealth || 1));
+    const currentHealth = Math.max(0, Number(dog.health || 0));
+    if (currentHealth >= maxHealth) {
+      dog.showHealthBar?.();
+      showMobileStatusToast("They're not hungry right now.");
+      return;
+    }
     const feedSelection = getFeedItemFromInventory();
     if (!feedSelection) {
       showMobileStatusToast("You don't have any food for them.");
@@ -12367,6 +12395,9 @@ async function initCore(runtimeContext) {
     removeFromInventory(feedSelection.itemId, 1);
     const isNewCompanion = !dog.model.userData?.isCompanion;
     animalManager?.feedDog?.(dog, feedSelection.healAmount);
+    dog.showHealthBar?.();
+    const foodLabel = inventoryCatalog?.[feedSelection.itemId]?.name || feedSelection.itemId;
+    showMobileStatusToast(`Fed dog a ${foodLabel}`);
     const persistDog = async (name) => {
       const key = String(dog.id || `${dog.type}-unknown`);
       companionData[key] = { id: key, type: 'dog', name: name || dog.model.userData?.companionName || 'Companion', health: dog.health || 1, maxHealth: dog.maxHealth || 1 };

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11941,6 +11941,30 @@ async function initCore(runtimeContext) {
   const animalNameLabels = new Map();
   const dogColliderEntries = new Map();
   const companionData = { ...(playerProfile?.companions || {}) };
+  const DOG_FOOD_HEAL = 10;
+  const MEAT_FEED_HEAL = 30;
+  const getFeedItemFromInventory = () => {
+    const hasApples = (inventoryState[APPLE_ITEM_ID]?.count || 0) > 0;
+    if (hasApples) return { itemId: APPLE_ITEM_ID, healAmount: DOG_FOOD_HEAL };
+    const mushroomId = Object.keys(inventoryState).find((id) => id?.startsWith?.('mushroom_') && (inventoryState[id]?.count || 0) > 0);
+    if (mushroomId) return { itemId: mushroomId, healAmount: DOG_FOOD_HEAL };
+    if ((inventoryState[MEAT_ITEM_ID]?.count || 0) > 0) return { itemId: MEAT_ITEM_ID, healAmount: MEAT_FEED_HEAL };
+    return null;
+  };
+  const consumeFoodAndHealFriendly = (friendly) => {
+    if (!friendly?.model || friendly.isDead) return false;
+    const feedSelection = getFeedItemFromInventory();
+    if (!feedSelection) {
+      showMobileStatusToast("You don't have any food for them.");
+      return false;
+    }
+    removeFromInventory(feedSelection.itemId, 1);
+    friendly.health = Math.min(friendly.maxHealth || 1, (friendly.health || 0) + feedSelection.healAmount);
+    friendly.model.userData.health = friendly.health;
+    friendly.updateHealthBarTexture?.();
+    return true;
+  };
+  window.feedFriendlyWithFood = consumeFoodAndHealFriendly;
 
   const buildInteractionBtn = document.createElement('button');
   buildInteractionBtn.type = 'button';
@@ -12335,15 +12359,14 @@ async function initCore(runtimeContext) {
     const target = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
     const dog = target?.animal;
     if (!dog) return;
-    const mushroomId = Object.keys(inventoryState).find((id) => id?.startsWith?.('mushroom_') && (inventoryState[id]?.count || 0) > 0);
-    const feedItem = (inventoryState[APPLE_ITEM_ID]?.count || 0) > 0 ? APPLE_ITEM_ID : mushroomId;
-    if (!feedItem) {
-      showMobileStatusToast('Need an apple or mushroom to feed the dog.');
+    const feedSelection = getFeedItemFromInventory();
+    if (!feedSelection) {
+      showMobileStatusToast("You don't have any food for them.");
       return;
     }
-    removeFromInventory(feedItem, 1);
+    removeFromInventory(feedSelection.itemId, 1);
     const isNewCompanion = !dog.model.userData?.isCompanion;
-    animalManager?.feedDog?.(dog, 10);
+    animalManager?.feedDog?.(dog, feedSelection.healAmount);
     const persistDog = async (name) => {
       const key = String(dog.id || `${dog.type}-unknown`);
       companionData[key] = { id: key, type: 'dog', name: name || dog.model.userData?.companionName || 'Companion', health: dog.health || 1, maxHealth: dog.maxHealth || 1 };

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -12423,10 +12423,10 @@ async function initCore(runtimeContext) {
         inputPlaceholder: 'Companion name',
         confirmText: 'Save Name'
       }).then((name) => persistDog(name));
+      showStatusToast('The dog is now your companion!');
     } else {
       void persistDog(dog.model.userData?.companionName || 'Companion');
     }
-    showStatusToast('The dog is now your companion!');
   });
 
   buildInteractionBtn.addEventListener('click', () => { void showNoteInteraction(); });

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -8957,6 +8957,7 @@ async function initCore(runtimeContext) {
       return;
     }
 
+    const ammoType = options.type || 'ammo';
     const geometry = options.geometry || new THREE.IcosahedronGeometry(0.25, 0);
     const material = options.material || new THREE.MeshStandardMaterial({
       color: ammoType === 'missile' ? 0xb72a2a : 0x7fd0ff,
@@ -8977,7 +8978,7 @@ async function initCore(runtimeContext) {
     pickup.userData.baseY = spawnPos.y;
     pickup.userData.phase = Math.random() * Math.PI * 2;
     pickup.userData.amount = amount;
-    pickup.userData.type = options.type || 'ammo';
+    pickup.userData.type = ammoType;
     pickup.userData.sparkle = !!options.sparkle;
     pickup.userData.noFloat = !!options.noFloat;
     if (options.sparkle) {
@@ -11943,6 +11944,14 @@ async function initCore(runtimeContext) {
   const companionData = { ...(playerProfile?.companions || {}) };
   const DOG_FOOD_HEAL = 10;
   const MEAT_FEED_HEAL = 30;
+  const showStatusToast = (message) => {
+    if (!message) return;
+    if (typeof playerControls?.showMobileStatusToast === 'function') {
+      playerControls.showMobileStatusToast(message);
+      return;
+    }
+    showTreasurePopup?.(message);
+  };
   const FRIENDLY_FEED_RESULT = Object.freeze({
     success: 'success',
     notHungry: 'notHungry',
@@ -11965,12 +11974,12 @@ async function initCore(runtimeContext) {
     const currentHealth = Math.max(0, Number(friendly.health || 0));
     if (currentHealth >= maxHealth) {
       friendly.showHealthBar?.();
-      showMobileStatusToast("They're not hungry right now.");
+      showStatusToast("They're not hungry right now.");
       return { status: FRIENDLY_FEED_RESULT.notHungry };
     }
     const feedSelection = getFeedItemFromInventory();
     if (!feedSelection) {
-      showMobileStatusToast("You don't have any food for them.");
+      showStatusToast("You don't have any food for them.");
       return { status: FRIENDLY_FEED_RESULT.noFood };
     }
     removeFromInventory(feedSelection.itemId, 1);
@@ -12384,12 +12393,12 @@ async function initCore(runtimeContext) {
     const currentHealth = Math.max(0, Number(dog.health || 0));
     if (currentHealth >= maxHealth) {
       dog.showHealthBar?.();
-      showMobileStatusToast("They're not hungry right now.");
+      showStatusToast("They're not hungry right now.");
       return;
     }
     const feedSelection = getFeedItemFromInventory();
     if (!feedSelection) {
-      showMobileStatusToast("You don't have any food for them.");
+      showStatusToast("You don't have any food for them.");
       return;
     }
     removeFromInventory(feedSelection.itemId, 1);
@@ -12397,7 +12406,7 @@ async function initCore(runtimeContext) {
     animalManager?.feedDog?.(dog, feedSelection.healAmount);
     dog.showHealthBar?.();
     const foodLabel = inventoryCatalog?.[feedSelection.itemId]?.name || feedSelection.itemId;
-    showMobileStatusToast(`Fed dog a ${foodLabel}`);
+    showStatusToast(`Fed dog a ${foodLabel}`);
     const persistDog = async (name) => {
       const key = String(dog.id || `${dog.type}-unknown`);
       companionData[key] = { id: key, type: 'dog', name: name || dog.model.userData?.companionName || 'Companion', health: dog.health || 1, maxHealth: dog.maxHealth || 1 };
@@ -12417,7 +12426,7 @@ async function initCore(runtimeContext) {
     } else {
       void persistDog(dog.model.userData?.companionName || 'Companion');
     }
-    showMobileStatusToast('The dog is now your companion!');
+    showStatusToast('The dog is now your companion!');
   });
 
   buildInteractionBtn.addEventListener('click', () => { void showNoteInteraction(); });

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -2882,8 +2882,11 @@ export class PlayerControls {
 
   handleDialogueOption(option) {
     if (option?.onSelect === "feedQuestGuy") {
-      const fed = window.feedFriendlyWithFood?.(this.activeFriendly);
-      if (!fed) return;
+      const feedResult = window.feedFriendlyWithFood?.(this.activeFriendly);
+      if (feedResult?.status === 'success') {
+        this.showMobileStatusToast(`Fed quest guy a ${feedResult.foodLabel}`);
+      }
+      if (feedResult?.status !== 'success') return;
     }
     this.questManager?.handleDialogueOption(option, this.activeFriendly);
     if (option?.merchantAction) {

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -2881,6 +2881,10 @@ export class PlayerControls {
   }
 
   handleDialogueOption(option) {
+    if (option?.onSelect === "feedQuestGuy") {
+      const fed = window.feedFriendlyWithFood?.(this.activeFriendly);
+      if (!fed) return;
+    }
     this.questManager?.handleDialogueOption(option, this.activeFriendly);
     if (option?.merchantAction) {
       void import('./merchantPanel.js').then(({ openMerchantPanel }) => openMerchantPanel(option.merchantAction));

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -470,7 +470,6 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
       const animal = entry?.animal;
       if (!animal?.model?.position || animal.isDead) return;
       if (String(animal.type).toLowerCase() !== 'dog') return;
-      if (animal.model.userData?.isCompanion) return;
       const dist = animal.model.position.distanceTo(position);
       if (dist <= maxDistance && dist < bestDistance) { best = animal; bestDistance = dist; }
     });

--- a/quest.js
+++ b/quest.js
@@ -441,6 +441,11 @@ export class QuestManager {
           reply: "No worries. Come back anytime.",
           onSelect: "declineTutorialQuest"
         },
+        {
+          label: "Here's some food",
+          reply: "Thanks! That really helps.",
+          onSelect: "feedQuestGuy"
+        },
         ...(this.state.shouldFollowPlayer ? [
           {
             label: "why are you following me?",


### PR DESCRIPTION
### Motivation
- Companion dogs should remain feedable when nearby so the `Feed` overlay/button stays visible after the dog is fed/tamed. 
- Feeding should actually consume food from the player's inventory, heal the animal (meat heals more), and provide the same behavior when giving food to the quest NPC.

### Description
- Allow companion dogs to be returned by `getNearestFeedableDog` by removing the companion-only filter in `environment/animals.js` so companion dogs keep showing the feed overlay. 
- Add a shared food-selection and consumption helper in `app/bootstrapGameApp.js`: `getFeedItemFromInventory` picks apple → mushroom → meat and `consumeFoodAndHealFriendly` removes the item and heals the target (meat heals more). This helper is exposed as `window.feedFriendlyWithFood`. 
- Update the existing `Feed Dog` button to use the shared feed helper and apply variable heal amounts based on selected food. 
- Add a new dialogue response `"Here's some food"` in `quest.js` and wire the dialogue path in `controls/controls.js` to call the same `window.feedFriendlyWithFood` helper so the quest NPC can be healed via the dialogue option.

### Testing
- Attempted `npm run -s test` which failed because the repository has no `test` script (command exited non-zero). 
- Verified available npm scripts with `npm run`. 
- Built a production bundle with `npm run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde8b3878483338f11d50a9bea0d2b)