### PR TITLE
Sync friendly/animal multiplayer spawns via host authority

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -1441,13 +1441,20 @@ async function initCore(runtimeContext) {
 
   const requestHostSpawnEvent = (spawnEvent) => {
     if (!multiplayer || multiplayer.isHost || !spawnEvent?.position) return;
-    if (spawnEvent.type !== 'monster') return;
     const hostId = multiplayer.getHostId?.();
     if (!hostId) return;
     const direction = spawnEvent.direction?.clone?.().normalize?.() || null;
+    const spawnTypeMap = {
+      monster: 'monster',
+      friendly: 'friendly',
+      animal: 'animal',
+      companionDog: 'companionDog'
+    };
+    const mappedType = spawnTypeMap[spawnEvent.type];
+    if (!mappedType) return;
     multiplayer.sendTo(hostId, {
       type: 'spawnRequest',
-      spawnType: 'monster',
+      spawnType: mappedType,
       position: [spawnEvent.position.x, spawnEvent.position.y, spawnEvent.position.z],
       direction: direction ? [direction.x, direction.y, direction.z] : undefined
     });
@@ -1795,7 +1802,7 @@ async function initCore(runtimeContext) {
 
     const isSpawnRequestMessage = payload => isObject(payload)
       && payload.type === 'spawnRequest'
-      && payload.spawnType === 'monster'
+      && ['monster', 'friendly', 'animal', 'companionDog'].includes(payload.spawnType)
       && isVector3Array(payload.position)
       && (payload.direction == null || isVector3Array(payload.direction));
 
@@ -1905,7 +1912,12 @@ async function initCore(runtimeContext) {
       const position = new THREE.Vector3(px, py, pz);
       const direction = new THREE.Vector3(dx, dy, dz);
       if (direction.lengthSq() > 0.0001) direction.normalize();
-      void handleCharacterSpawnEvent({ type: 'monster', position, direction });
+      void handleCharacterSpawnEvent({
+        type: data.spawnType,
+        position,
+        direction,
+        requesterId: peerId
+      });
       return;
     }
 
@@ -2281,6 +2293,7 @@ async function initCore(runtimeContext) {
     isHost = !!isCurrentHost;
     setMonsterPersistenceHost(isHost);
     friendlyNpcManager?.setHost(isHost);
+    animalManager?.setHost?.(isHost);
     setMerchantHostFeature(isHost);
     logMonsterPersist('isHost', isHost);
     if (previousHostId && previousHostId === multiplayer.getId() && previousHostId !== newHostId) {
@@ -3641,6 +3654,8 @@ async function initCore(runtimeContext) {
       });
       return nearest;
     },
+    isHost,
+    onRemoteSpawnRequest: requestHostSpawnEvent,
     onAnimalRemoved: ({ animal, wasDead, position }) => {
       const dogCollider = dogColliderEntries.get(animal?.id);
       if (dogCollider) removeStaticBoxCollider(dogCollider);
@@ -3958,9 +3973,23 @@ async function initCore(runtimeContext) {
       spawnEncounterMonster(spawnEvent);
       return;
     }
+    if (spawnEvent.type === 'friendly') {
+      await trimTravelSpawnPopulationIfNeeded(1, spawnEvent.position);
+      friendlyNpcManager?.spawnFriendlyAt?.(spawnEvent.position);
+      return;
+    }
     if (spawnEvent.type === 'animal') {
       await trimTravelSpawnPopulationIfNeeded(1, spawnEvent.position);
       await animalManager?.spawnDeerAt?.(spawnEvent.position);
+      return;
+    }
+    if (spawnEvent.type === 'companionDog') {
+      await trimTravelSpawnPopulationIfNeeded(1, spawnEvent.position);
+      const dog = await animalManager?.spawnDogAt?.(spawnEvent.position);
+      if (dog?.model?.userData) {
+        dog.model.userData.isCompanion = true;
+        dog.model.userData.companionOwnerId = spawnEvent.requesterId || multiplayer?.getId?.() || null;
+      }
       return;
     }
   }

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -368,8 +368,17 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   animal.update(delta);
 }
 
-export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, onAnimalRemoved, getNearbyMonster } = {}) {
+export function createAnimalManager({
+  scene,
+  getPlayerModel,
+  getTerrainHeight,
+  onAnimalRemoved,
+  getNearbyMonster,
+  isHost = false,
+  onRemoteSpawnRequest
+} = {}) {
   const animals = [];
+  let currentHost = !!isHost;
   let lastDogSpawnPlayerPosition = null;
   let lastDogSpawnAt = 0;
   const removeAnimal = (entry) => {
@@ -459,7 +468,20 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
     const now = Date.now();
     if (now - lastDogSpawnAt < minSpawnIntervalMs) return null;
     if (lastDogSpawnPlayerPosition && playerPosition.distanceTo(lastDogSpawnPlayerPosition) < minTravelDistance) return null;
+    if (!currentHost) {
+      onRemoteSpawnRequest?.({
+        type: 'companionDog',
+        position: playerPosition.clone()
+      });
+      lastDogSpawnPlayerPosition = playerPosition.clone();
+      lastDogSpawnAt = now;
+      return null;
+    }
     return spawnDogAt();
+  };
+
+  const setHost = (nextHost) => {
+    currentHost = !!nextHost;
   };
 
   const getNearestFeedableDog = (position, maxDistance = 2.5) => {
@@ -493,6 +515,7 @@ export function createAnimalManager({ scene, getPlayerModel, getTerrainHeight, o
     spawnDeerAt,
     spawnDogAt,
     maybeSpawnDogByTravelDistance,
+    setHost,
     getNearestFeedableDog,
     feedDog
   };

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -171,13 +171,37 @@ export function createFriendlyNpcManager({
     records.set(slotId, record);
   };
 
+  const spawnFriendlyAt = (position) => {
+    if (!position) return null;
+    const resolved = resolveFriendlyPosition(position);
+    if (!resolved) return null;
+    dropFurthestFriendlyRecord(playerModel?.position?.clone?.() || resolved);
+    spawnedCount += 1;
+    const slotId = `friendly:distance:${spawnedCount}`;
+    const level = getRandomLevel();
+    const hp = getHealthForLevel(level);
+    const modelPath = getRandomFriendlyModel();
+    const angle = Math.random() * Math.PI * 2;
+    const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
+    const record = {
+      id: slotId,
+      type: modelPath,
+      hp,
+      level,
+      alive: true,
+      pos: { x: resolved.x, y: resolved.y, z: resolved.z },
+      rot: { x: rot.x, y: rot.y, z: rot.z, w: rot.w }
+    };
+    records.set(slotId, record);
+    return slotId;
+  };
+
 
 
   const maybeRequestSpawnFromDistance = () => {
     if (!playerModel) return;
     const spawnEvent = characterSpawner.getSpawnEvent();
     if (!spawnEvent?.position) return;
-    if (spawnEvent.type !== 'monster') return;
     onRemoteSpawnRequest?.(spawnEvent);
   };
 
@@ -545,6 +569,7 @@ const getHealthForLevel = (level) => {
     recordGpsTravel,
     onRoomReady,
     update,
-    removeFriendlyById
+    removeFriendlyById,
+    spawnFriendlyAt
   };
 }


### PR DESCRIPTION
### Motivation
- Ensure friendlies, companion dogs, and animals use the same host-authoritative spawn workflow as monsters so all players see consistent entities. 
- Let clients notify the host when they cross distance thresholds that would normally spawn a friendly/animal so the host can create and persist the entity. 
- Support per-player companion dogs that are visible to other players while keeping spawning authority on the host.

### Description
- Broadened client→host spawn forwarding by updating `requestHostSpawnEvent` to support `monster`, `friendly`, `animal`, and `companionDog` spawn types and map them to a single host `spawnRequest` flow. 
- Expanded spawn request validation to accept the new spawn types and changed host-side handling to call `handleCharacterSpawnEvent` with the `spawnType` and `requesterId` so the host dispatches the correct spawn. 
- Added `spawnFriendlyAt(position)` to the friendly NPC manager and exposed it in the manager API so the host can create friendlies from remote requests. 
- Made the animal manager host-aware (`isHost`, `setHost`) and added `onRemoteSpawnRequest` support so non-host clients request companion-dog spawns and the host performs the actual `spawnDogAt` and marks the dog as a companion with `companionOwnerId`. 
- Wired `animalManager.setHost` on host changes and passed `isHost`/`onRemoteSpawnRequest` when creating the animal manager so authority stays correct across host migrations.

### Testing
- Ran a syntax check with `node --check` on `app/bootstrapGameApp.js`, `friendlyNpcManager.js`, and `environment/animals.js`, and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1427207883338a09a14cb8b7d1e9)