### PR TITLE
Sync quest friends and companion dogs in multiplayer

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "../characters/PlayerCharacter.js";
 import { loadMonsterModel } from "../models/monsterModel.js";
 import { MonsterCharacter } from "../characters/MonsterCharacter.js";
+import { FriendlyCharacter } from "../characters/FriendlyCharacter.js";
 import { createFriendlyNpcManager } from "../friendlyNpcManager.js";
 import {
   clearTerrainStampsForTile,
@@ -797,6 +798,9 @@ async function initCore(runtimeContext) {
   const networkedLocalControlState = new Map();
   const pendingEntityStates = new Map();
   const authoritativeEntityStates = new Map();
+  const localDynamicNetworkedEntities = new Map();
+  const remoteQuestFriends = new Map();
+  const remoteCompanionDogSpawns = new Set();
   let lastEntityBroadcast = 0;
   let lastFullEntityBroadcast = 0;
   let lastControlSend = 0;
@@ -1529,9 +1533,170 @@ async function initCore(runtimeContext) {
     const entry = networkedEntities.get(id);
     if (entry && typeof entry.applyState === 'function') {
       entry.applyState(state);
-    } else {
-      pendingEntityStates.set(id, cloneState(state));
+      return;
     }
+    if (ensureRemoteDynamicNetworkedEntity(id, state)) {
+      return;
+    }
+    pendingEntityStates.set(id, cloneState(state));
+  }
+
+  function applyNetworkTransformToObject(target, state) {
+    if (!target?.model || !state) return;
+    const [px, py, pz] = state.position || [];
+    const [rx, ry, rz, rw] = state.rotation || [];
+    if (Number.isFinite(px) && Number.isFinite(py) && Number.isFinite(pz)) {
+      target.model.position.set(px, py, pz);
+      target.body?.setTranslation?.({ x: px, y: py, z: pz }, true);
+    }
+    if (Number.isFinite(rx) && Number.isFinite(ry) && Number.isFinite(rz) && Number.isFinite(rw)) {
+      target.model.quaternion.set(rx, ry, rz, rw);
+      target.body?.setRotation?.({ x: rx, y: ry, z: rz, w: rw }, true);
+    }
+    if (Number.isFinite(state.health)) {
+      target.health = state.health;
+      target.model.userData.health = state.health;
+      target.updateHealthBarTexture?.();
+    }
+    if (state.dead && !target.isDead) {
+      target.markDead?.();
+    }
+    if (typeof state.action === 'string' && state.action && target.currentAction !== state.action) {
+      target.playAnimation?.(state.action, 0.12);
+    }
+  }
+
+  function getCharacterNetworkState(character, extra = {}) {
+    if (!character?.model) return null;
+    const pos = character.model.position;
+    const q = character.model.quaternion;
+    return {
+      position: [pos.x, pos.y, pos.z],
+      rotation: [q.x, q.y, q.z, q.w],
+      action: character.currentAction || character.model.userData?.currentAction || null,
+      health: Number.isFinite(character.health) ? character.health : character.model.userData?.health,
+      dead: !!character.isDead,
+      ...extra
+    };
+  }
+
+  function registerLocalDynamicNetworkedEntity(id, character, extraState = {}) {
+    if (!id || !character?.model) return;
+    if (localDynamicNetworkedEntities.get(id) === character) return;
+    localDynamicNetworkedEntities.set(id, character);
+    registerNetworkedEntity(id, {
+      getState: () => getCharacterNetworkState(character, extraState),
+      applyState: state => applyNetworkTransformToObject(character, state),
+      isLocallyControlled: () => !!character?.model && !character.model.userData?.remoteSynced
+    });
+  }
+
+  function ensureRemoteDynamicNetworkedEntity(id, state) {
+    if (typeof id !== 'string') return false;
+    if (id.startsWith('questFriend:')) {
+      ensureRemoteQuestFriend(id, state);
+      return true;
+    }
+    if (id.startsWith('companionDog:')) {
+      ensureRemoteCompanionDog(id, state);
+      return true;
+    }
+    return false;
+  }
+
+  function ensureRemoteQuestFriend(id, state) {
+    const existing = remoteQuestFriends.get(id);
+    if (existing?.model) {
+      applyNetworkTransformToObject(existing, state);
+      return;
+    }
+    if (remoteQuestFriends.has(id)) {
+      pendingEntityStates.set(id, cloneState(state));
+      return;
+    }
+    remoteQuestFriends.set(id, { pending: true });
+    loadMonsterModel('/models/cowboy.fbx', data => {
+      const questFriend = new FriendlyCharacter(data);
+      questFriend.id = id;
+      questFriend.modelPath = '/models/cowboy.fbx';
+      questFriend.type = '/models/cowboy.fbx';
+      questFriend.model.userData.hideInMapView = true;
+      questFriend.model.userData.isQuestFriend = true;
+      questFriend.model.userData.remoteSynced = true;
+      questFriend.enableDanceWhileEngaged = false;
+      questFriend.setNoticeRadius?.(10);
+      questFriend.setWanderRadius?.(5);
+      questFriend.setEngageRadius?.(5);
+      questFriend.setDisengageRadius?.(8);
+      questFriend.setLevel?.(1, { preserveHealth: false });
+      questFriend.resetHealth?.();
+      scene?.add(questFriend.model);
+      attachMonsterPhysics?.(questFriend);
+      remoteQuestFriends.set(id, questFriend);
+      registerNetworkedEntity(id, {
+        getState: () => null,
+        applyState: nextState => applyNetworkTransformToObject(questFriend, nextState),
+        isLocallyControlled: () => false
+      });
+      applyNetworkTransformToObject(questFriend, pendingEntityStates.get(id) || state);
+      pendingEntityStates.delete(id);
+    });
+  }
+
+  async function ensureRemoteCompanionDog(id, state) {
+    if (!animalManager || remoteCompanionDogSpawns.has(id)) {
+      pendingEntityStates.set(id, cloneState(state));
+      return;
+    }
+    const existing = animals.find(animal => animal?.id === id);
+    if (existing?.model) {
+      applyNetworkTransformToObject(existing, state);
+      return;
+    }
+    remoteCompanionDogSpawns.add(id);
+    const [px = playerModel?.position?.x ?? 0, py = playerModel?.position?.y ?? 0, pz = playerModel?.position?.z ?? 0] = state?.position || [];
+    const spawnPosition = new THREE.Vector3(px, py, pz);
+    const dog = await animalManager.spawnDogAt?.(spawnPosition);
+    if (!dog?.model) {
+      remoteCompanionDogSpawns.delete(id);
+      return;
+    }
+    dog.id = id;
+    dog.model.userData.isCompanion = true;
+    dog.model.userData.remoteSynced = true;
+    if (typeof state?.name === 'string') {
+      dog.model.userData.companionName = state.name;
+    }
+    registerNetworkedEntity(id, {
+      getState: () => null,
+      applyState: nextState => applyNetworkTransformToObject(dog, nextState),
+      isLocallyControlled: () => false
+    });
+    applyNetworkTransformToObject(dog, pendingEntityStates.get(id) || state);
+    pendingEntityStates.delete(id);
+  }
+
+  function syncLocalDynamicNetworkedEntities() {
+    const myId = multiplayer?.getId?.();
+    if (!myId) return;
+    const questFriend = window.questManager?.getQuestFriend?.();
+    if (questFriend?.model) {
+      registerLocalDynamicNetworkedEntity(`questFriend:${myId}`, questFriend, { ownerId: myId });
+    }
+    (animals || []).forEach((animal) => {
+      if (!animal?.model || animal.model.userData?.remoteSynced) return;
+      if (String(animal.type).toLowerCase() !== 'dog' || !animal.model.userData?.isCompanion) return;
+      registerLocalDynamicNetworkedEntity(`companionDog:${myId}:${animal.id}`, animal, {
+        ownerId: myId,
+        name: animal.model.userData?.companionName || null
+      });
+    });
+  }
+
+  function updateRemoteDynamicNetworkedEntities(delta) {
+    remoteQuestFriends.forEach((friend) => {
+      if (friend?.model) friend.update?.(delta);
+    });
   }
 
   function registerNetworkedEntity(id, entry) {
@@ -13303,6 +13468,9 @@ async function initCore(runtimeContext) {
       pickup?.tryPickup?.(playerControls);
       updateWeaponMarker(pickup, pickup.marker, 0.03, pickup.markerOffsetY ?? 1.2);
     });
+    syncLocalDynamicNetworkedEntities();
+    updateRemoteDynamicNetworkedEntities(frameDelta);
+
     const localStates = collectLocalControlStates();
 
     if (multiplayer.isHost) {
@@ -13457,7 +13625,7 @@ async function initCore(runtimeContext) {
         }
         const roomFriendlies = friendlyNpcManager?.friendlies || [];
         const combatFriendlies = [...roomFriendlies];
-        const questFriend = questManager?.getQuestFriend?.();
+        const questFriend = window.questManager?.getQuestFriend?.();
         if (questFriend?.model && !questFriend.isDead) {
           combatFriendlies.push(questFriend);
         }

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -287,6 +287,7 @@ const METERS_PER_DEGREE_LAT = 111_132.92;
 const PLAYER_VISIBILITY_RADIUS_M = 200;
 const PRESENCE_STALE_MS = 5000;
 const PRESENCE_SEND_MS = 350;
+const PRESENCE_HEARTBEAT_MS = 2000;
 const PRESENCE_SWEEP_MS = 250;
 const REMOTE_LERP_ALPHA = 0.15;
 const REMOTE_TELEPORT_THRESHOLD_M = 25;
@@ -801,6 +802,7 @@ async function initCore(runtimeContext) {
   const localDynamicNetworkedEntities = new Map();
   const remoteQuestFriends = new Map();
   const remoteCompanionDogSpawns = new Set();
+  const removedRemotePlayerIds = new Set();
   let lastEntityBroadcast = 0;
   let lastFullEntityBroadcast = 0;
   let lastControlSend = 0;
@@ -824,7 +826,8 @@ async function initCore(runtimeContext) {
     y: null,
     z: null,
     rotation: null,
-    action: null
+    action: null,
+    sentAt: 0
   };
   const lastSentEntityControlStates = new Map();
   const projectiles = [];
@@ -1517,6 +1520,7 @@ async function initCore(runtimeContext) {
       delete otherPlayers[remoteId];
     }
     clearRemoteHeldWeaponsForHolder(remoteId);
+    cleanupRemoteDynamicNetworkedEntitiesForPlayer(remoteId);
     remotePresenceEquipment.delete(remoteId);
     if (remotePresenceMeta[remoteId]) {
       delete remotePresenceMeta[remoteId];
@@ -1604,6 +1608,13 @@ async function initCore(runtimeContext) {
     return false;
   }
 
+  function getRemoteDynamicOwnerId(id) {
+    if (typeof id !== 'string') return null;
+    if (id.startsWith('questFriend:')) return id.slice('questFriend:'.length) || null;
+    if (id.startsWith('companionDog:')) return id.slice('companionDog:'.length).split(':')[0] || null;
+    return null;
+  }
+
   function ensureRemoteQuestFriend(id, state) {
     const existing = remoteQuestFriends.get(id);
     if (existing?.model) {
@@ -1616,6 +1627,11 @@ async function initCore(runtimeContext) {
     }
     remoteQuestFriends.set(id, { pending: true });
     loadMonsterModel('/models/cowboy.fbx', data => {
+      const ownerId = getRemoteDynamicOwnerId(id);
+      if (ownerId && removedRemotePlayerIds.has(ownerId)) {
+        remoteQuestFriends.delete(id);
+        return;
+      }
       const questFriend = new FriendlyCharacter(data);
       questFriend.id = id;
       questFriend.modelPath = '/models/cowboy.fbx';
@@ -1657,6 +1673,15 @@ async function initCore(runtimeContext) {
     const [px = playerModel?.position?.x ?? 0, py = playerModel?.position?.y ?? 0, pz = playerModel?.position?.z ?? 0] = state?.position || [];
     const spawnPosition = new THREE.Vector3(px, py, pz);
     const dog = await animalManager.spawnDogAt?.(spawnPosition);
+    const ownerId = getRemoteDynamicOwnerId(id);
+    if (ownerId && removedRemotePlayerIds.has(ownerId)) {
+      if (dog?.model) {
+        dog.id = id;
+        animalManager?.removeAnimalById?.(id);
+      }
+      remoteCompanionDogSpawns.delete(id);
+      return;
+    }
     if (!dog?.model) {
       remoteCompanionDogSpawns.delete(id);
       return;
@@ -1697,6 +1722,42 @@ async function initCore(runtimeContext) {
     remoteQuestFriends.forEach((friend) => {
       if (friend?.model) friend.update?.(delta);
     });
+  }
+
+  function cleanupRemoteDynamicNetworkedEntitiesForPlayer(playerId) {
+    if (!playerId) return;
+    removedRemotePlayerIds.add(playerId);
+    const prefixes = [`questFriend:${playerId}`, `companionDog:${playerId}:`];
+    const matchesPlayerEntity = id => prefixes.some(prefix => id === prefix || id.startsWith(prefix));
+
+    remoteQuestFriends.forEach((friend, id) => {
+      if (!matchesPlayerEntity(id)) return;
+      detachNpcPhysics?.(friend);
+      friend?.model?.userData?.mixer?.stopAllAction?.();
+      if (friend?.model?.parent) {
+        friend.model.parent.remove(friend.model);
+      }
+      remoteQuestFriends.delete(id);
+    });
+
+    for (const id of Array.from(remoteCompanionDogSpawns)) {
+      if (!matchesPlayerEntity(id)) continue;
+      animalManager?.removeAnimalById?.(id);
+      remoteCompanionDogSpawns.delete(id);
+    }
+
+    for (const id of Array.from(networkedEntities.keys())) {
+      if (matchesPlayerEntity(id)) networkedEntities.delete(id);
+    }
+    for (const id of Array.from(pendingEntityStates.keys())) {
+      if (matchesPlayerEntity(id)) pendingEntityStates.delete(id);
+    }
+    for (const id of Array.from(authoritativeEntityStates.keys())) {
+      if (matchesPlayerEntity(id)) authoritativeEntityStates.delete(id);
+    }
+    for (const id of Array.from(localDynamicNetworkedEntities.keys())) {
+      if (matchesPlayerEntity(id)) localDynamicNetworkedEntities.delete(id);
+    }
   }
 
   function registerNetworkedEntity(id, entry) {
@@ -2092,6 +2153,7 @@ async function initCore(runtimeContext) {
         return;
       }
       const remoteId = data.id || peerId;
+      removedRemotePlayerIds.delete(remoteId);
       if (remoteId === multiplayer.getId()) {
         return;
       }
@@ -13838,13 +13900,15 @@ async function initCore(runtimeContext) {
       const moved = ((dx * dx) + (dy * dy) + (dz * dz)) > POSITION_DEADBAND_SQ;
       const rotated = Math.abs(wrapDeltaRad((payload.rotation ?? 0) - (lastSentPresenceState.rotation ?? 0))) >= ROTATION_DEADBAND_RAD;
       const actionChanged = payload.action !== lastSentPresenceState.action;
-      if (lastSentPresenceState.x == null || moved || rotated || actionChanged) {
+      const heartbeatDue = now - (lastSentPresenceState.sentAt || 0) >= PRESENCE_HEARTBEAT_MS;
+      if (lastSentPresenceState.x == null || moved || rotated || actionChanged || heartbeatDue) {
         queueNetMessage(payload, 'presence:self');
         lastSentPresenceState.x = payload.x;
         lastSentPresenceState.y = payload.y;
         lastSentPresenceState.z = payload.z;
         lastSentPresenceState.rotation = payload.rotation ?? 0;
         lastSentPresenceState.action = payload.action ?? null;
+        lastSentPresenceState.sentAt = now;
       } else {
         netStats.dropped += 1;
       }

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -420,6 +420,10 @@ export function createAnimalManager({
         removeAnimal(entry);
         continue;
       }
+      if (animal.model.userData?.remoteSynced) {
+        animal.update(delta);
+        continue;
+      }
       updateAnimalMovement({ animal, config: entry.config || {}, getPlayerModel, getTerrainHeight, getNearbyMonster, delta });
     }
   };


### PR DESCRIPTION
### Motivation
- Remote players' quest NPCs and companion dogs were not visible/kept in sync across browsers, causing missing companions in multiplayer sessions.
- Need to treat each player's quest friend and companion dogs as dynamic networked entities so their transforms and state propagate like monsters and pickups.

### Description
- Added dynamic network entity support and helpers: `applyNetworkTransformToObject`, `getCharacterNetworkState`, `registerLocalDynamicNetworkedEntity`, `syncLocalDynamicNetworkedEntities`, and `updateRemoteDynamicNetworkedEntities` in `app/bootstrapGameApp.js` to register and broadcast per-player quest friends and companion dogs.
- Implemented remote spawners that materialize incoming `questFriend:*` and `companionDog:*` IDs by loading models and registering them as networked entities (`ensureRemoteQuestFriend`, `ensureRemoteCompanionDog`).
- Imported `FriendlyCharacter` and added maps/sets (`localDynamicNetworkedEntities`, `remoteQuestFriends`, `remoteCompanionDogSpawns`) to track these dynamic entities and their pending state.
- Prevented local AI from overwriting networked companion dog transforms by treating `animal.model.userData.remoteSynced` animals as remote-controlled in `environment/animals.js` so they only run `update` and skip local movement/AI.

### Testing
- Built the production bundle with `npm run build`, which completed successfully (Vite emitted non-fatal warnings about a Rollup comment and large chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe33763134832b824bee55de4aea8d)