### PR TITLE
Tighten interaction overlays, require click for quest friend, reuse bazooka SFX for bombs, and merchant UI tweak

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -7537,6 +7537,7 @@ async function initCore(runtimeContext) {
   }
 
   let mapViewEnabled = false;
+  window.mapViewEnabled = mapViewEnabled;
   let playerDead = false;
   let isBuildPlacementActive = false;
   const updateControlAvailability = () => {
@@ -10089,6 +10090,10 @@ async function initCore(runtimeContext) {
     if ((inventoryState.bomb?.count || 0) <= 0) return false;
     const shooterId = multiplayer?.getId?.();
     spawnBombProjectileWithPerfFlags(scene, projectiles, position, direction, shooterId);
+    audioManager?.playSFX('SFX/Explosions/Explosion 1.ogg', 0.45, {
+      cooldownKey: 'bomb-throw',
+      cooldownMs: audioManager?.performanceProfile?.attackCooldownMs ?? 120
+    });
     unequipInventoryItem('bomb');
     removeFromInventory('bomb', 1);
     notifyAchievementProgress('bombsThrown', 1);
@@ -10194,6 +10199,8 @@ async function initCore(runtimeContext) {
 
   mapToggleButton.addEventListener('click', () => {
     mapViewEnabled = !mapViewEnabled;
+    window.mapViewEnabled = mapViewEnabled;
+    document.body.classList.toggle('map-open', mapViewEnabled);
     void setMapViewEnabledFeature(mapViewEnabled);
     updateControlAvailability();
     mapToggleButton.classList.toggle('active', mapViewEnabled);
@@ -12246,6 +12253,16 @@ async function initCore(runtimeContext) {
   feedDogBtn.style.cssText = 'position:fixed;left:50%;bottom:37%;transform:translateX(-50%);z-index:1200;display:none;padding:8px 12px;';
   document.body.appendChild(feedDogBtn);
   const animalNameLabels = new Map();
+  const areInteractionLabelsBlocked = () => {
+    if (window.mapViewEnabled === true || document.body.classList.contains('map-open')) return true;
+    const blockingOverlayIds = ['settings-overlay', 'inventory-overlay', 'merchant-overlay'];
+    return blockingOverlayIds.some((id) => {
+      const overlay = document.getElementById(id);
+      if (!overlay) return false;
+      if (overlay.getAttribute('aria-hidden') === 'false') return true;
+      return overlay.style?.display && overlay.style.display !== 'none';
+    });
+  };
   const dogColliderEntries = new Map();
   const companionData = { ...(playerProfile?.companions || {}) };
   const DOG_FOOD_HEAL = 10;
@@ -13146,10 +13163,11 @@ async function initCore(runtimeContext) {
             buildState.selectedNoteId = id;
           }
         });
-        const shouldShow = Boolean(buildState.selectedNoteId) && closestNoteDistance <= closestInteractDistance;
+        const labelsBlocked = areInteractionLabelsBlocked();
+        const shouldShow = !labelsBlocked && Boolean(buildState.selectedNoteId) && closestNoteDistance <= closestInteractDistance;
         buildInteractionBtn.style.display = shouldShow ? 'block' : 'none';
 
-        const nearbyDog = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
+        const nearbyDog = labelsBlocked ? null : animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
         feedDogBtn.style.display = nearbyDog ? 'block' : 'none';
       }
     }
@@ -14073,6 +14091,11 @@ async function initCore(runtimeContext) {
         const activeCompanionAnimalIds = new Set();
         (animals || []).forEach((animal) => {
           if (!animal?.id || !animal?.model || !animal.model.userData?.isCompanion) return;
+          if (areInteractionLabelsBlocked()) {
+            const label = animalNameLabels.get(animal.id);
+            if (label) label.style.display = 'none';
+            return;
+          }
           activeCompanionAnimalIds.add(animal.id);
           const name = animal.model.userData?.companionName;
           if (!name) {

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -29,6 +29,7 @@ const GROUND_DOWNWARD_CORRECTION_MAX_VERTICAL_SPEED = 0.18;
 const MAX_WALKABLE_SLOPE_DEGREES = 42;
 const STEEP_SLOPE_SPEED_MULTIPLIER = 0.55;
 const FRIENDLY_INTERACT_RANGE = 6;
+const QUEST_FRIEND_INTERACT_RANGE = 2.5;
 const MUSHROOM_INTERACT_RANGE = 1.2;
 const APPLE_INTERACT_RANGE = 3;
 const WOOD_INTERACT_RANGE = 3;
@@ -1444,7 +1445,7 @@ export class PlayerControls {
   }
 
   handleFriendlyInteractionAction() {
-    if (!this.enabled || this.isSleeping) return;
+    if (!this.enabled || this.isSleeping || this.areInteractionOverlaysBlocked()) return;
 
     if (this.isInteracting) {
       this.advanceFriendlyDialogue();
@@ -1459,7 +1460,7 @@ export class PlayerControls {
   }
 
   handleClimbAction() {
-    if (!this.enabled || this.isSleeping || this.vehicle || this.isInteracting) return false;
+    if (!this.enabled || this.isSleeping || this.vehicle || this.isInteracting || this.areInteractionOverlaysBlocked()) return false;
     if (this.isClimbing) return false;
     if (!this.playerModel) return false;
 
@@ -1476,7 +1477,7 @@ export class PlayerControls {
   }
 
   handlePickupAction() {
-    if (!this.enabled && !this.isSleeping) return;
+    if ((!this.enabled && !this.isSleeping) || this.areInteractionOverlaysBlocked()) return;
 
     if (this.isSleeping) {
       this.wakeFromSleep();
@@ -1502,6 +1503,7 @@ export class PlayerControls {
     }
 
     if (closest.type === 'friendly') {
+      if (this.isQuestFriend(closest.friendly)) return;
       this.startFriendlyInteraction(closest.friendly);
       return;
     }
@@ -1561,6 +1563,14 @@ export class PlayerControls {
     }
   }
 
+  getFriendlyInteractionRange(friendly) {
+    return this.isQuestFriend(friendly) ? QUEST_FRIEND_INTERACT_RANGE : FRIENDLY_INTERACT_RANGE;
+  }
+
+  isQuestFriend(friendly) {
+    return !!friendly && (this.questManager?.isQuestFriend?.(friendly) || friendly?.model?.userData?.isQuestFriend === true);
+  }
+
   getClosestFriendly(maxDistance) {
     if (!this.playerModel) return null;
     const friendlies = Array.isArray(window.friendlies) ? window.friendlies : [];
@@ -1569,7 +1579,8 @@ export class PlayerControls {
     friendlies.forEach((friendly) => {
       if (!friendly?.model || friendly.isDead) return;
       const dist = this.playerModel.position.distanceTo(friendly.model.position);
-      if (dist <= maxDistance && dist < closestDistance) {
+      const interactRange = Math.min(maxDistance, this.getFriendlyInteractionRange(friendly));
+      if (dist <= interactRange && dist < closestDistance) {
         closestDistance = dist;
         closest = friendly;
       }
@@ -1577,7 +1588,8 @@ export class PlayerControls {
     const merchant = window.merchantFriendly;
     if (merchant?.model && !merchant.isDead) {
       const dist = this.playerModel.position.distanceTo(merchant.model.position);
-      if (dist <= maxDistance && dist < closestDistance) {
+      const interactRange = Math.min(maxDistance, this.getFriendlyInteractionRange(merchant));
+      if (dist <= interactRange && dist < closestDistance) {
         closestDistance = dist;
         closest = merchant;
       }
@@ -1585,7 +1597,8 @@ export class PlayerControls {
     const questFriend = this.questManager?.getQuestFriend();
     if (questFriend?.model && !questFriend.isDead) {
       const dist = this.playerModel.position.distanceTo(questFriend.model.position);
-      if (dist <= maxDistance && dist < closestDistance) {
+      const interactRange = Math.min(maxDistance, this.getFriendlyInteractionRange(questFriend));
+      if (dist <= interactRange && dist < closestDistance) {
         closestDistance = dist;
         closest = questFriend;
       }
@@ -1884,15 +1897,16 @@ export class PlayerControls {
   }
 
   updateFriendlyInteractionUI() {
-    if (this.isSleeping) {
+    if (this.isSleeping || this.areInteractionOverlaysBlocked()) {
       this.friendlyInteractButton?.classList.add('hidden');
-      this.friendlyDialogueEl?.classList.add('hidden');
+      if (!this.isInteracting) this.friendlyDialogueEl?.classList.add('hidden');
       return;
     }
     if (!this.friendlyInteractButton) return;
 
     if (this.isInteracting) {
-      if (this.activeFriendly && !this.isFriendlyWithinRange(this.activeFriendly, FRIENDLY_INTERACT_RANGE * 1.6)) {
+      const activeRange = this.getFriendlyInteractionRange(this.activeFriendly) * 1.6;
+      if (this.activeFriendly && !this.isFriendlyWithinRange(this.activeFriendly, activeRange)) {
         this.endFriendlyInteraction();
         return;
       }
@@ -1912,7 +1926,9 @@ export class PlayerControls {
     if (nearby?.friendly && closest?.type === 'friendly' && closest.friendly === nearby.friendly) {
       this.friendlyInteractButton.classList.remove('hidden');
       this.friendlyInteractButton.disabled = false;
-      this.friendlyInteractButton.textContent = this.isMobile ? 'Talk' : 'Interact (X)';
+      this.friendlyInteractButton.textContent = this.isQuestFriend(nearby.friendly)
+        ? (this.isMobile ? 'Talk' : 'Interact')
+        : (this.isMobile ? 'Talk' : 'Interact (X)');
       return;
     }
 
@@ -2922,7 +2938,7 @@ export class PlayerControls {
 
   updateClimbOverlay() {
     if (!this.climbOverlayEl || !this.playerModel) return;
-    if (this.isClimbing || this.isSleeping || this.vehicle || this.isInteracting) {
+    if (this.isClimbing || this.isSleeping || this.vehicle || this.isInteracting || this.areInteractionOverlaysBlocked()) {
       this.climbOverlayEl.classList.add('hidden');
       return;
     }
@@ -2944,6 +2960,11 @@ export class PlayerControls {
 
   updateInteractionPrompt() {
     if (!this.interactionPromptEl || !this.playerModel) return;
+    if (this.areInteractionOverlaysBlocked()) {
+      this.interactionPromptEl.classList.remove('visible');
+      this.interactionPromptEl.textContent = '';
+      return;
+    }
 
     let promptText = '';
     let visible = false;
@@ -2978,6 +2999,17 @@ export class PlayerControls {
       this.interactionPromptEl.classList.remove('visible');
       this.interactionPromptEl.textContent = '';
     }
+  }
+
+  areInteractionOverlaysBlocked() {
+    if (window.mapViewEnabled === true || document.body?.classList?.contains('map-open')) return true;
+    const blockingOverlayIds = ['settings-overlay', 'inventory-overlay', 'merchant-overlay'];
+    return blockingOverlayIds.some((id) => {
+      const overlay = document.getElementById(id);
+      if (!overlay) return false;
+      if (overlay.getAttribute('aria-hidden') === 'false') return true;
+      return overlay.style?.display && overlay.style.display !== 'none';
+    });
   }
 
   formatInteractionPrompt(text) {

--- a/controls/merchantPanel.js
+++ b/controls/merchantPanel.js
@@ -128,6 +128,7 @@ function getFallbackIcon(itemId) {
   if (itemId === 'ice ammo') return '❄️';
   if (itemId === 'bow') return '🏹';
   if (itemId === 'arrow ammo') return '🏹';
+  if (itemId === 'bazooka' || itemId === 'missiles') return '🚀';
   if (itemId === 'autumnSword') return '🗡️';
   if (itemId === 'hammer') return '🔨';
   if (itemId === 'lantern') return '🏮';


### PR DESCRIPTION
### Motivation
- Prevent accidental interactions and reduce confusion by making quest-friend talk/overlay only available when very close and only via the interact button (not the keyboard ‘x’ shortcut).
- Ensure interaction prompts (interact, climb, pick-up, feed dog, companion names) do not appear while modal overlays (map, inventory, settings, merchant) are open.
- Make thrown bombs use the same explosion SFX as bazooka missiles for consistent audio feedback.
- Surface missile/bazooka ammo clearly in the merchant UI.

### Description
- Added `QUEST_FRIEND_INTERACT_RANGE` and `getFriendlyInteractionRange`/`isQuestFriend` helpers to tighten quest friend proximity and to choose labels without the `(X)` hint for quest friends in `controls/controls.js`.
- Prevented the pickup/`x` path from starting quest-friend dialogue by early-returning when the closest friendly is the quest friend in `handlePickupAction` (so quest friend must be clicked/tapped via the interact button).
- Introduced `areInteractionOverlaysBlocked()` in `controls/controls.js` and applied it across `handleFriendlyInteractionAction`, `handlePickupAction`, `handleClimbAction`, `updateClimbOverlay`, `updateInteractionPrompt`, and `updateFriendlyInteractionUI` to hide/disable overlays when map/settings/inventory/merchant are open.
- Exposed `window.mapViewEnabled`, toggle a `map-open` body class when the map is shown, and added `areInteractionLabelsBlocked` in `app/bootstrapGameApp.js` to hide `feedDog` button, build/note interaction, and companion dog name labels while overlays are open.
- Play the bazooka missile explosion SFX when throwing bombs by calling `audioManager.playSFX('SFX/Explosions/Explosion 1.ogg', ...)` in the bomb throw handler in `app/bootstrapGameApp.js`.
- Added a rocket fallback icon for bazooka/missiles in `controls/merchantPanel.js` and left missile ammo available in the merchant catalog (`characters/merchant.js` already includes missiles entries).

### Testing
- Ran `git diff --check` with no issues.
- Linted/parsed modified files with `node --check controls/controls.js`, `node --check app/bootstrapGameApp.js`, and `node --check controls/merchantPanel.js`, all succeeded.
- Built the project with `npm run build`, which completed successfully and produced the production bundles.
- Verified the edited files in the output diff (controls, app bootstrap, merchant panel) and confirmed the changes compile and the UI/asset references are intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e1137400832489d456e98d56a15e)