### PR TITLE
Track monster kills, show kill toast and add Leaderboard (Top Kills / Top XP)

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -114,6 +114,7 @@ import {
   deleteProfileData,
   getStoredPinHash,
   getSleepTimestamp,
+  loadLeaderboards,
   loadOrCreateWithPin,
   renameProfile,
   saveCharacterModel,
@@ -4970,6 +4971,7 @@ async function initCore(runtimeContext) {
     charm: playerProfile.stats.charm,
     luck: playerProfile.stats.luck,
     xp: playerProfile.stats.xp,
+    monsterKills: playerProfile.stats.monsterKills,
     coins: playerProfile.stats.coins
   };
   statsState.maxHealthSegments = Math.max(BASE_HEALTH_SEGMENTS, Math.round(statsState.maxHealthSegments || BASE_HEALTH_SEGMENTS));
@@ -5072,6 +5074,24 @@ async function initCore(runtimeContext) {
       treasurePopup.classList.remove('visible');
       treasurePopupTimer = null;
     }, 2000);
+  };
+  const killPopup = document.createElement('div');
+  killPopup.id = 'monster-kill-popup';
+  killPopup.setAttribute('aria-live', 'polite');
+  killPopup.setAttribute('aria-atomic', 'true');
+  document.body.appendChild(killPopup);
+  let killPopupTimer = null;
+  const showMonsterKillPopup = (totalKills) => {
+    const displayCount = Number.isFinite(totalKills) ? Math.max(0, Math.floor(totalKills)) : 0;
+    killPopup.textContent = `☠️ x${displayCount} kills +1`;
+    killPopup.classList.add('visible');
+    if (killPopupTimer) {
+      clearTimeout(killPopupTimer);
+    }
+    killPopupTimer = setTimeout(() => {
+      killPopup.classList.remove('visible');
+      killPopupTimer = null;
+    }, 1500);
   };
   const achievementBanner = document.createElement('div');
   achievementBanner.className = 'achievement-banner hidden';
@@ -7903,7 +7923,7 @@ async function initCore(runtimeContext) {
       if (!Number.isFinite(num)) return BASE_MAGIC_SEGMENTS;
       return Math.max(BASE_MAGIC_SEGMENTS, Math.min(MAGIC_MAX_SEGMENTS, Math.round(num)));
     }
-    if (key === 'xp') {
+    if (key === 'xp' || key === 'monsterKills') {
       const num = Number(value);
       if (!Number.isFinite(num)) {
         return 0;
@@ -8132,6 +8152,9 @@ async function initCore(runtimeContext) {
   window.getMonsterXpForLevel = getMonsterXpForLevel;
 
   window.onMonsterKill = (monster, { withFriend = false } = {}) => {
+    const currentKills = Number.isFinite(statsState.monsterKills) ? statsState.monsterKills : 0;
+    setStat('monsterKills', currentKills + 1, { skipSave: true });
+    showMonsterKillPopup(statsState.monsterKills);
     const monsterLevel = Number.isFinite(monster?.level) ? monster.level : 1;
     const baseXp = getMonsterXpForLevel(monsterLevel);
     const bonusXp = withFriend ? 50 : 0;
@@ -12661,6 +12684,7 @@ async function initCore(runtimeContext) {
       }
     },
     getPlayerStats: () => ({ ...statsState }),
+    getLeaderboards: (limit = 10) => loadLeaderboards(limit),
     getQuestLog: () => window.questManager?.getQuestLog?.() || [],
     getAchievements: () => getAchievementView(achievementState),
     claimAchievementReward: (achievementId) => {

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -18,6 +18,7 @@ const TABS = [
 const CHARACTER_STATS = [
   { key: 'level', label: 'Level' },
   { key: 'xp', label: 'XP' },
+  { key: 'monsterKills', label: 'Monster Kills' },
   { key: 'strength', label: 'Strength' },
   { key: 'agility', label: 'Agility' },
   { key: 'smarts', label: 'Smarts' },
@@ -31,6 +32,8 @@ let overlay;
 let panel;
 let inventoryOverlay;
 let inventoryPanel;
+let leaderboardOverlay;
+let leaderboardPanel;
 let context = {};
 let elements = {};
 let activeTab = 'character';
@@ -239,6 +242,10 @@ function buildMultiplayerPanel() {
   const playersList = createElement('ul', 'settings-list');
   playersList.dataset.field = 'players';
 
+  const leaderboardButton = createElement('button', 'settings-button', 'Leaderboard');
+  leaderboardButton.type = 'button';
+  leaderboardButton.dataset.action = 'open-leaderboard';
+
   const reconnectButton = createElement('button', 'settings-button', 'Reconnect');
   reconnectButton.type = 'button';
   reconnectButton.dataset.action = 'reconnect';
@@ -248,12 +255,13 @@ function buildMultiplayerPanel() {
   errorText.dataset.field = 'connection-error';
   errorText.textContent = 'None';
 
-  panelEl.append(statusRow, pingRow, playersTitle, playersList, reconnectButton, errorTitle, errorText);
+  panelEl.append(statusRow, pingRow, playersTitle, playersList, leaderboardButton, reconnectButton, errorTitle, errorText);
 
   elements.connectionStatus = statusRow.querySelector('[data-field="connection-status"]');
   elements.ping = pingRow.querySelector('[data-field="ping"]');
   elements.playersList = playersList;
   elements.connectionError = errorText;
+  elements.leaderboardButton = leaderboardButton;
 
   return panelEl;
 }
@@ -904,6 +912,134 @@ function buildPanels() {
   return body;
 }
 
+
+function buildLeaderboardOverlay() {
+  leaderboardOverlay = document.getElementById('leaderboard-overlay');
+  if (!leaderboardOverlay) {
+    leaderboardOverlay = createElement('div', 'settings-overlay');
+    leaderboardOverlay.id = 'leaderboard-overlay';
+    leaderboardOverlay.style.display = 'none';
+    document.body.appendChild(leaderboardOverlay);
+  }
+  leaderboardOverlay.setAttribute('aria-hidden', 'true');
+
+  leaderboardPanel = createElement('div', 'settings-shell leaderboard-shell');
+  leaderboardPanel.id = 'leaderboard-panel';
+  leaderboardPanel.setAttribute('role', 'dialog');
+  leaderboardPanel.setAttribute('aria-modal', 'true');
+  leaderboardPanel.setAttribute('aria-labelledby', 'leaderboard-title');
+  leaderboardPanel.tabIndex = -1;
+
+  const header = createElement('div', 'settings-header');
+  const title = createElement('h2', 'settings-title', 'Leaderboard');
+  title.id = 'leaderboard-title';
+  const closeButton = createElement('button', 'settings-close', '✕');
+  closeButton.type = 'button';
+  closeButton.dataset.leaderboardAction = 'close';
+  closeButton.setAttribute('aria-label', 'Close leaderboard');
+  header.append(title, closeButton);
+
+  const tabs = createElement('div', 'leaderboard-tabs');
+  tabs.setAttribute('role', 'tablist');
+  const killsTab = createElement('button', 'leaderboard-tab is-active', 'Top Kills');
+  killsTab.type = 'button';
+  killsTab.dataset.leaderboardTab = 'kills';
+  killsTab.setAttribute('role', 'tab');
+  killsTab.setAttribute('aria-selected', 'true');
+  const xpTab = createElement('button', 'leaderboard-tab', 'Top XP');
+  xpTab.type = 'button';
+  xpTab.dataset.leaderboardTab = 'xp';
+  xpTab.setAttribute('role', 'tab');
+  xpTab.setAttribute('aria-selected', 'false');
+  tabs.append(killsTab, xpTab);
+
+  const body = createElement('div', 'leaderboard-body');
+  const status = createElement('div', 'settings-muted', 'Loading leaderboard...');
+  const list = createElement('ol', 'leaderboard-list');
+  body.append(status, list);
+
+  const actions = createElement('div', 'leaderboard-actions');
+  const okButton = createElement('button', 'settings-button', 'OK');
+  okButton.type = 'button';
+  okButton.dataset.leaderboardAction = 'close';
+  actions.append(okButton);
+
+  leaderboardPanel.append(header, tabs, body, actions);
+  leaderboardOverlay.replaceChildren(leaderboardPanel);
+
+  elements.leaderboardTabs = { kills: killsTab, xp: xpTab };
+  elements.leaderboardList = list;
+  elements.leaderboardStatus = status;
+  elements.leaderboardActiveTab = 'kills';
+  elements.leaderboardData = { topKills: [], topXp: [] };
+}
+
+function setLeaderboardTab(tabId) {
+  const safeTab = tabId === 'xp' ? 'xp' : 'kills';
+  elements.leaderboardActiveTab = safeTab;
+  Object.entries(elements.leaderboardTabs || {}).forEach(([id, button]) => {
+    const active = id === safeTab;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+  renderLeaderboard();
+}
+
+function renderLeaderboard() {
+  if (!elements.leaderboardList || !elements.leaderboardStatus) return;
+  const activeTab = elements.leaderboardActiveTab === 'xp' ? 'xp' : 'kills';
+  const rows = activeTab === 'xp'
+    ? (elements.leaderboardData?.topXp || [])
+    : (elements.leaderboardData?.topKills || []);
+  const valueLabel = activeTab === 'xp' ? 'XP' : 'kills';
+  elements.leaderboardList.innerHTML = '';
+  if (!rows.length) {
+    elements.leaderboardStatus.textContent = 'No scores yet.';
+    elements.leaderboardStatus.hidden = false;
+    return;
+  }
+  elements.leaderboardStatus.hidden = true;
+  rows.forEach((entry, index) => {
+    const item = createElement('li', 'leaderboard-row');
+    const rank = createElement('span', 'leaderboard-rank', `#${index + 1}`);
+    const name = createElement('span', 'leaderboard-name', entry.name || 'Unknown Player');
+    const value = createElement('span', 'leaderboard-value', `${Math.max(0, Math.floor(entry.value || 0)).toLocaleString()} ${valueLabel}`);
+    item.append(rank, name, value);
+    elements.leaderboardList.appendChild(item);
+  });
+}
+
+async function openLeaderboardOverlay() {
+  if (!leaderboardOverlay || !leaderboardPanel) return;
+  closeOverlay();
+  leaderboardOverlay.style.display = 'flex';
+  leaderboardOverlay.setAttribute('aria-hidden', 'false');
+  syncOverlayBodyState();
+  leaderboardPanel.focus?.();
+  elements.leaderboardStatus.hidden = false;
+  elements.leaderboardStatus.textContent = 'Loading leaderboard...';
+  elements.leaderboardList.innerHTML = '';
+  setLeaderboardTab(elements.leaderboardActiveTab || 'kills');
+  try {
+    if (!context.appState?.getLeaderboards) {
+      throw new Error('Leaderboards unavailable');
+    }
+    elements.leaderboardData = await context.appState.getLeaderboards(10);
+    renderLeaderboard();
+  } catch (error) {
+    console.warn('Failed to load leaderboard:', error);
+    elements.leaderboardStatus.hidden = false;
+    elements.leaderboardStatus.textContent = 'Failed to load leaderboard.';
+  }
+}
+
+function closeLeaderboardOverlay() {
+  if (!leaderboardOverlay) return;
+  leaderboardOverlay.style.display = 'none';
+  leaderboardOverlay.setAttribute('aria-hidden', 'true');
+  syncOverlayBodyState();
+}
+
 function buildInventoryOverlay() {
   if (!inventoryPanel) return;
   inventoryPanel.innerHTML = '';
@@ -1011,7 +1147,8 @@ function closeInventoryOverlay() {
 function syncOverlayBodyState() {
   const isSettingsOpen = overlay?.getAttribute('aria-hidden') === 'false';
   const isInventoryOpen = inventoryOverlay?.getAttribute('aria-hidden') === 'false';
-  document.body.classList.toggle('settings-open', isSettingsOpen || isInventoryOpen);
+  const isLeaderboardOpen = leaderboardOverlay?.getAttribute('aria-hidden') === 'false';
+  document.body.classList.toggle('settings-open', isSettingsOpen || isInventoryOpen || isLeaderboardOpen);
 }
 
 async function handleAction(target) {
@@ -1023,6 +1160,8 @@ async function handleAction(target) {
     if (isMobileView) {
       setListView(true);
     }
+  } else if (action === 'open-leaderboard') {
+    await openLeaderboardOverlay();
   } else if (action === 'reconnect') {
     context.multiplayer?.reconnect?.();
   } else if (action === 'location-retry') {
@@ -1361,10 +1500,23 @@ function bindEvents() {
       closeInventoryOverlay();
     }
   });
+  leaderboardOverlay?.addEventListener('click', (event) => {
+    if (event.target === leaderboardOverlay) {
+      closeLeaderboardOverlay();
+    }
+  });
 
   const handlePanelClick = (event) => {
     const button = event.target.closest('button');
     if (!button) return;
+    if (button.dataset.leaderboardAction === 'close') {
+      closeLeaderboardOverlay();
+      return;
+    }
+    if (button.dataset.leaderboardTab) {
+      setLeaderboardTab(button.dataset.leaderboardTab);
+      return;
+    }
     if (button.dataset.inventoryAction) {
       const action = button.dataset.inventoryAction;
       if (!selectedInventoryId && action !== 'close-info') return;
@@ -1947,6 +2099,7 @@ export function initSettingsPanel({ appState, multiplayer, location, player } = 
   const body = buildPanels();
   panel.append(header, tabs, body);
   buildInventoryOverlay();
+  buildLeaderboardOverlay();
 
   updateCharacterOptions();
   refreshLayout();

--- a/features/persistenceFeature.js
+++ b/features/persistenceFeature.js
@@ -3,6 +3,7 @@ export {
   deleteProfileData,
   getStoredPinHash,
   getSleepTimestamp,
+  loadLeaderboards,
   loadOrCreateWithPin,
   renameProfile,
   saveCharacterModel,

--- a/playerProfile.js
+++ b/playerProfile.js
@@ -1,4 +1,4 @@
-import { ref, get, set, update, runTransaction } from 'firebase/database';
+import { ref, get, set, update, runTransaction, query, orderByChild, limitToLast } from 'firebase/database';
 import { db } from './firebase-init.js';
 import { getCookie, setCookie } from './utils.js';
 import { BASE_HEALTH_SEGMENTS, normalizeHealthSegments } from './healthUtils.js';
@@ -29,6 +29,7 @@ const DEFAULT_STATS = {
   charm: 5,
   luck: 5,
   xp: 0,
+  monsterKills: 0,
   coins: 0
 };
 const DEFAULT_INVENTORY = {};
@@ -168,7 +169,7 @@ function normalizeStatValue(key, value) {
   if (key === 'level') {
     return Math.max(1, Math.floor(numeric));
   }
-  if (key === 'xp' || key === 'coins') {
+  if (key === 'xp' || key === 'monsterKills' || key === 'coins') {
     return Math.max(0, Math.floor(numeric));
   }
   if (['maxHealthSegments', 'maxHungerSegments', 'maxMagicSegments'].includes(key)) {
@@ -212,6 +213,43 @@ function mergeCustomization(customization) {
 
 function mergeSpells(spells) {
   return { ...DEFAULT_SPELLS, ...(spells || {}) };
+}
+
+
+function normalizeLeaderboardEntry(nameKey, profile, metric) {
+  const stats = profile?.stats && typeof profile.stats === 'object' ? profile.stats : {};
+  const value = Number(stats[metric]);
+  return {
+    id: nameKey,
+    name: typeof profile?.name === 'string' && profile.name.trim() ? profile.name.trim() : nameKey,
+    value: Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+  };
+}
+
+async function loadLeaderboard(metric, limit = 10) {
+  const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(50, Math.floor(limit))) : 10;
+  const leaderboardQuery = query(
+    ref(db, 'profiles'),
+    orderByChild(`stats/${metric}`),
+    limitToLast(safeLimit)
+  );
+  const snapshot = await get(leaderboardQuery);
+  const entries = [];
+  snapshot.forEach((child) => {
+    entries.push(normalizeLeaderboardEntry(child.key, child.val(), metric));
+  });
+  return entries
+    .filter((entry) => entry.value > 0)
+    .sort((a, b) => b.value - a.value || a.name.localeCompare(b.name))
+    .slice(0, safeLimit);
+}
+
+export async function loadLeaderboards(limit = 10) {
+  const [topKills, topXp] = await Promise.all([
+    loadLeaderboard('monsterKills', limit),
+    loadLeaderboard('xp', limit)
+  ]);
+  return { topKills, topXp };
 }
 
 async function loadProfileForName(profileRef, trimmedName) {

--- a/styles.css
+++ b/styles.css
@@ -2091,6 +2091,7 @@ body.settings-open #inventory-button {
   body.settings-open #ammo-popup,
   body.settings-open #coin-popup,
   body.settings-open #treasure-popup,
+  body.settings-open #monster-kill-popup,
   body.settings-open #craft-message,
   body.settings-open #voice-transcript {
     display: none;
@@ -2512,3 +2513,116 @@ body.settings-open #inventory-button {
   white-space: pre-wrap; max-height: 36vh; overflow: auto; border: 1px solid #8d6430; border-radius: 8px; background: #fff8ea; padding: 10px; margin: 10px 0;
 }
 .build-modal-actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+
+#leaderboard-overlay {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 999;
+  overflow-y: auto;
+  padding: env(safe-area-inset-top) 0 env(safe-area-inset-bottom);
+}
+
+.leaderboard-shell {
+  width: min(480px, 92vw);
+  max-height: 78vh;
+}
+
+.leaderboard-tabs {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px 0;
+}
+
+.leaderboard-tab {
+  flex: 1;
+  border: 1px solid #d2d2d2;
+  background: #f6f6f6;
+  padding: 8px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.leaderboard-tab.is-active {
+  background: #1f8bff;
+  border-color: #1f8bff;
+  color: #fff;
+}
+
+.leaderboard-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+}
+
+.leaderboard-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.leaderboard-row {
+  display: grid;
+  grid-template-columns: 52px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  border: 1px solid #e3e8f2;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #f8fbff;
+}
+
+.leaderboard-rank {
+  font-weight: 700;
+  color: #1f62b8;
+}
+
+.leaderboard-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leaderboard-value {
+  font-weight: 700;
+  color: #222;
+}
+
+.leaderboard-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 20px 18px;
+}
+
+#monster-kill-popup {
+  position: absolute;
+  top: 248px;
+  left: 10px;
+  padding: 6px 10px;
+  background: rgba(25, 18, 18, 0.88);
+  border: 2px solid #000;
+  border-radius: 6px;
+  color: #ffd9d9;
+  font-family: 'Press Start 2P', sans-serif;
+  font-size: 11px;
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  z-index: 1100;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#monster-kill-popup.visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
### Motivation
- Persist each player's monster kill count and surface leaderboards so players can compare Top Kills and Top XP. 
- Show immediate feedback when a player kills a monster with a brief skull/count toast. 
- Provide a simple UI entry under Multiplayer settings to view leaderboards without leaving the settings flow.

### Description
- Add `monsterKills` to persisted player stats, include it in stat normalization, and expose a `loadLeaderboards` helper that queries Firebase (`orderByChild` + `limitToLast`) for Top Kills and Top XP in `playerProfile.js` and re-export it via `features/persistenceFeature.js`.
- Increment `monsterKills` on each local kill inside the existing `window.onMonsterKill` hook, and show a short `☠️ x<number> kills +1` popup/toast; wire the stat through the existing save/persist flow so it is saved with other stats.
- Expose a `getLeaderboards` app-state method and add a Leaderboard button to the Multiplayer settings tab that closes settings and opens a new Leaderboard overlay with two tabs (Top Kills, Top XP), an OK button and an X close button, plus necessary CSS and overlay state syncing in `controls/settingsPanel.js` and `styles.css`.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build finished; Rollup warnings about chunk size remained but did not block the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f0b4fda483248500a50f5ab8c0aa)