### PR TITLE
Fix leaderboard overlay interactions

### DIFF
--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -1573,6 +1573,7 @@ function bindEvents() {
 
   panel.addEventListener('click', handlePanelClick);
   inventoryPanel?.addEventListener('click', handlePanelClick);
+  leaderboardPanel?.addEventListener('click', handlePanelClick);
 
   elements.nameInput.addEventListener('input', () => {
     setNameStatus('');

--- a/playerProfile.js
+++ b/playerProfile.js
@@ -245,11 +245,29 @@ async function loadLeaderboard(metric, limit = 10) {
 }
 
 export async function loadLeaderboards(limit = 10) {
-  const [topKills, topXp] = await Promise.all([
+  const [killsResult, xpResult] = await Promise.allSettled([
     loadLeaderboard('monsterKills', limit),
     loadLeaderboard('xp', limit)
   ]);
-  return { topKills, topXp };
+
+  if (killsResult.status === 'rejected') {
+    console.warn('Failed to load monster-kill leaderboard:', killsResult.reason);
+  }
+  if (xpResult.status === 'rejected') {
+    console.warn('Failed to load XP leaderboard:', xpResult.reason);
+  }
+
+  if (killsResult.status === 'rejected' && xpResult.status === 'rejected') {
+    throw new AggregateError(
+      [killsResult.reason, xpResult.reason],
+      'Failed to load leaderboards'
+    );
+  }
+
+  return {
+    topKills: killsResult.status === 'fulfilled' ? killsResult.value : [],
+    topXp: xpResult.status === 'fulfilled' ? xpResult.value : []
+  };
 }
 
 async function loadProfileForName(profileRef, trimmedName) {

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,10 @@ body {
   cursor: not-allowed;
 }
 
+body.map-open #friendly-interact {
+  display: none !important;
+}
+
 .friendly-dialogue {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
### Motivation
- Leaderboard overlay buttons (`X`, `OK`, tabs) were not handled by the shared click handler and leaderboards could fail to display when one metric failed to load, and the friendly-`interact` button remained visible while the map was open.

### Description
- Make leaderboard loading resilient by using `Promise.allSettled` in `loadLeaderboards` and return available `topKills`/`topXp` arrays while logging failures, throwing only if both metrics fail (`playerProfile.js`).
- Wire `leaderboardPanel` into the shared panel click handler so close/tab/OK buttons are processed by the same `handlePanelClick` logic (`controls/settingsPanel.js`).
- Hide the on-screen quest/friendly `interact` button when the map is open by adding a `body.map-open #friendly-interact { display: none !important; }` rule (`styles.css`).

### Testing
- Ran the production build with `npm run build`, which completed successfully and produced the optimized `dist` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032b2871f48324bd009de98202b004)