### PR TITLE
Fix auto-aim camera release orbit

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3441,7 +3441,7 @@ export class PlayerControls {
       this.autoAimLastManualInputAt = 0;
     } else {
       if (this.autoAimCameraDirection) {
-        this.syncCameraOrbitToCameraDirection();
+        this.syncCameraOrbitToCurrentCameraPosition();
       }
       this.aimReleaseHoldUntil = performance.now() + this.aimReleaseDelayMs;
       this.autoAimBreakUntilRelease = false;
@@ -3512,9 +3512,47 @@ export class PlayerControls {
   }
 
 
+  getPlayerOrbitCenter() {
+    if (this.playerModel?.position) {
+      return this.playerModel.position.clone().add(new THREE.Vector3(0, 1, 0));
+    }
+    if (this.controls?.target) {
+      return this.controls.target.clone();
+    }
+    return null;
+  }
+
+  syncCameraOrbitToCurrentCameraPosition() {
+    if (!this.camera) return;
+    const orbitCenter = this.getPlayerOrbitCenter();
+    if (!orbitCenter) {
+      this.syncCameraOrbitToCameraDirection();
+      return;
+    }
+
+    // Auto-aim cameras can look past the player toward a target, so deriving the
+    // restored orbit from the camera's facing direction can choose the opposite
+    // side of the player.  Preserve the actual camera side instead.
+    const cameraDelta = this.camera.position.clone().sub(orbitCenter);
+    const horizontalDistance = Math.hypot(cameraDelta.x, cameraDelta.z);
+    if (horizontalDistance <= 0.0001) {
+      this.syncCameraOrbitToCameraDirection();
+      return;
+    }
+
+    this.yaw = Math.atan2(cameraDelta.x, cameraDelta.z);
+
+    const cameraOffset = this.cameraOffset || this.aimCameraOffset || this.baseCameraOffset;
+    const cameraOffsetY = cameraOffset?.y ?? 0;
+    const pitchRatio = THREE.MathUtils.clamp((cameraDelta.y - cameraOffsetY) / 5, -1, 1);
+    const maxPitch = Math.PI / 3;
+    const minPitch = -Math.PI / 8;
+    this.pitch = THREE.MathUtils.clamp(Math.asin(pitchRatio), minPitch, maxPitch);
+  }
+
   syncCameraOrbitToCameraDirection() {
     if (!this.camera) return;
-    const d = new THREE.Vector3(0, 0, 1).applyQuaternion(this.camera.quaternion);
+    const d = new THREE.Vector3(0, 0, -1).applyQuaternion(this.camera.quaternion);
     if (d.lengthSq() <= 0.0001) return;
     d.normalize();
     this.syncCameraOrbitToAutoAimDirection(d);

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3512,7 +3512,7 @@ export class PlayerControls {
   }
 
 
-  getPlayerOrbitCenter() {
+  getPlayerOrbitBaseCenter() {
     if (this.playerModel?.position) {
       return this.playerModel.position.clone().add(new THREE.Vector3(0, 1, 0));
     }
@@ -3524,27 +3524,38 @@ export class PlayerControls {
 
   syncCameraOrbitToCurrentCameraPosition() {
     if (!this.camera) return;
-    const orbitCenter = this.getPlayerOrbitCenter();
-    if (!orbitCenter) {
+    const orbitBaseCenter = this.getPlayerOrbitBaseCenter();
+    if (!orbitBaseCenter) {
       this.syncCameraOrbitToCameraDirection();
       return;
     }
 
     // Auto-aim cameras can look past the player toward a target, so deriving the
     // restored orbit from the camera's facing direction can choose the opposite
-    // side of the player.  Preserve the actual camera side instead.
-    const cameraDelta = this.camera.position.clone().sub(orbitCenter);
+    // side of the player. Preserve the camera's actual world-space side instead.
+    const cameraDelta = this.camera.position.clone().sub(orbitBaseCenter);
     const horizontalDistance = Math.hypot(cameraDelta.x, cameraDelta.z);
     if (horizontalDistance <= 0.0001) {
       this.syncCameraOrbitToCameraDirection();
       return;
     }
 
-    this.yaw = Math.atan2(cameraDelta.x, cameraDelta.z);
+    // Normal camera placement rotates both the look-target offset and camera
+    // offset by yaw. Invert that same transform rather than assuming a zero-X
+    // offset; otherwise shoulder/aim offsets restore about 90 degrees off.
+    const cameraOffset = this.cameraOffset || this.aimCameraOffset || this.baseCameraOffset || new THREE.Vector3(0, 0, 1);
+    const targetOffset = this.cameraTargetOffset || this.aimCameraTargetOffset || this.baseCameraTargetOffset || new THREE.Vector3();
+    const combinedOffsetX = (cameraOffset.x ?? 0) + (targetOffset.x ?? 0);
+    const combinedOffsetZ = (cameraOffset.z ?? 0) + (targetOffset.z ?? 0);
+    const combinedHorizontalDistance = Math.hypot(combinedOffsetX, combinedOffsetZ);
+    if (combinedHorizontalDistance <= 0.0001) {
+      this.yaw = Math.atan2(-cameraDelta.x, cameraDelta.z);
+    } else {
+      this.yaw = Math.atan2(cameraDelta.z, cameraDelta.x) - Math.atan2(combinedOffsetZ, combinedOffsetX);
+    }
 
-    const cameraOffset = this.cameraOffset || this.aimCameraOffset || this.baseCameraOffset;
-    const cameraOffsetY = cameraOffset?.y ?? 0;
-    const pitchRatio = THREE.MathUtils.clamp((cameraDelta.y - cameraOffsetY) / 5, -1, 1);
+    const combinedOffsetY = (cameraOffset.y ?? 0) + (targetOffset.y ?? 0);
+    const pitchRatio = THREE.MathUtils.clamp((cameraDelta.y - combinedOffsetY) / 5, -1, 1);
     const maxPitch = Math.PI / 3;
     const minPitch = -Math.PI / 8;
     this.pitch = THREE.MathUtils.clamp(Math.asin(pitchRatio), minPitch, maxPitch);


### PR DESCRIPTION
### Motivation
- Exiting auto-aim was restoring the camera orbit from the camera facing direction, which could pick the opposite side of the player and cause a sudden flip when returning to normal view. 
- The intent is to preserve the camera's current side around the player after auto-aim ends so the camera remains visually consistent.

### Description
- Replace the restore behavior on aim release to derive orbit from the camera's current world position around the player instead of the camera forward vector by calling `syncCameraOrbitToCurrentCameraPosition()` from `setAiming(false)` in `controls/controls.js`.
- Add `getPlayerOrbitCenter()` to compute a robust orbit center (player position + fallback to `controls.target`) and `syncCameraOrbitToCurrentCameraPosition()` to compute `yaw`/`pitch` from `camera.position` relative to that center, preserving the same side of the player.
- Correct the fallback camera-forward calculation in `syncCameraOrbitToCameraDirection()` to use Three.js camera forward (`-Z`) via `new THREE.Vector3(0, 0, -1)` to avoid inverted orbit calculations.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build succeeded). 
- Build emitted non-fatal Rollup/warning messages about a comment in `three-mesh-bvh` and large chunk size, but the build exited with success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07703085008325ba88361b16a632c5)