### PR TITLE
Tighten Llama AI fallback and action handling

### DIFF
--- a/api/llama.js
+++ b/api/llama.js
@@ -44,10 +44,77 @@ function buildPrompt(state = {}) {
   return `You are controlling an RPG character named Llama.\n\nGoal:\nmaximize XP and survive.\n\nState:\nHP: ${hp}\nHunger: ${hunger}\nMagic: ${magic}\nEquipped: ${equipped}\n\nNearby:\n${nearby}\n\nReturn ONLY JSON. Include a speak string every time.\n\nAvailable actions:\nmove\nattack\nequip\njump\ninteract\nspeak\nspells: fly (magic cost), shield (magic cost)\n\nJSON template:\n{\n  "speak": "short in-character sentence",\n  "actions": [\n    { "type": "move", "direction": "north|south|east|west" },\n    { "type": "attack", "targetId": "id from nearby if known" },\n    { "type": "equip", "item": "sword|ice gun|best available" },\n    { "type": "jump" },\n    { "type": "interact", "targetId": "id from nearby if known" },\n    { "type": "shield" },\n    { "type": "fly" }\n  ]\n}\nChoose at most 2 non-speak actions.`;
 }
 
+
+const ACTION_TYPES = new Set(['move', 'attack', 'equip', 'jump', 'interact', 'fly', 'shield']);
+const DIRECTIONS = new Set(['north', 'south', 'east', 'west']);
+const MAX_ACTIONS = 2;
+const MAX_SPEAK_CHARS = 96;
+const MAX_ITEM_CHARS = 40;
+const MAX_TARGET_ID_CHARS = 80;
+
+function sanitizeText(value, maxChars) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+}
+
 function fallbackDecision() {
   return {
     speak: 'Thinking fast, staying alive.',
-    actions: [{ type: 'move', direction: 'north' }]
+    actions: []
+  };
+}
+
+function normalizeAction(action) {
+  if (!action || typeof action !== 'object' || Array.isArray(action)) return null;
+  const type = sanitizeText(action.type || action.action, 20).toLowerCase();
+  if (!ACTION_TYPES.has(type)) return null;
+
+  if (type === 'move') {
+    const direction = sanitizeText(action.direction, 12).toLowerCase();
+    if (!DIRECTIONS.has(direction)) return null;
+    return { type, direction };
+  }
+
+  if (type === 'attack') {
+    const targetId = sanitizeText(action.targetId || action.target, MAX_TARGET_ID_CHARS);
+    return targetId ? { type, targetId } : { type };
+  }
+
+  if (type === 'equip') {
+    const item = sanitizeText(action.item || action.target, MAX_ITEM_CHARS);
+    if (!item) return null;
+    return { type, item };
+  }
+
+  if (type === 'interact') {
+    const targetId = sanitizeText(action.targetId || action.target, MAX_TARGET_ID_CHARS);
+    if (!targetId) return null;
+    return { type, targetId };
+  }
+
+  return { type };
+}
+
+function normalizeDecision(value) {
+  const base = fallbackDecision();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return base;
+
+  const rawActions = Array.isArray(value.actions)
+    ? value.actions
+    : (value.action ? [{ ...value, type: value.action }] : []);
+  const actions = rawActions
+    .map(normalizeAction)
+    .filter(Boolean)
+    .slice(0, MAX_ACTIONS);
+
+  const spell = sanitizeText(value.spell, 20).toLowerCase();
+  if ((spell === 'fly' || spell === 'shield') && actions.length < MAX_ACTIONS) {
+    actions.push({ type: spell });
+  }
+
+  return {
+    speak: sanitizeText(value.speak || value.say || value.message, MAX_SPEAK_CHARS) || base.speak,
+    actions
   };
 }
 
@@ -110,13 +177,7 @@ export default async function handler(req, res) {
         decision = fallbackDecision();
       }
     }
-    if (!decision || typeof decision !== 'object') {
-      decision = fallbackDecision();
-    }
-    if (typeof decision.speak !== 'string' || !decision.speak.trim()) {
-      decision.speak = fallbackDecision().speak;
-    }
-    return res.status(200).json({ decision });
+    return res.status(200).json({ decision: normalizeDecision(decision) });
   } catch (error) {
     return res.status(200).json({
       decision: fallbackDecision(),

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -26,6 +26,10 @@ const LLAMA_ACTION_DURATION_MS = 3_000;
 const LLAMA_SPEECH_MAX_CHARS = 96;
 const LLAMA_PROMPT_NEARBY_RADIUS = 32;
 const LLAMA_DRIFT_STOP_DISTANCE = 3.25;
+const LLAMA_ALLOWED_ACTION_TYPES = new Set(['move', 'attack', 'equip', 'jump', 'interact', 'fly', 'shield']);
+const LLAMA_ALLOWED_DIRECTIONS = new Set(['north', 'south', 'east', 'west']);
+const LLAMA_MAX_ACTIONS = 2;
+const LLAMA_TEXT_FIELD_MAX_CHARS = 80;
 const FRIENDLY_MAX_ACTIVE = 6;
 const FRIENDLY_ACTIVE_RADIUS = 360;
 const FRIENDLY_PLAYER_SPAWN_BLOCK_RADIUS = 32;
@@ -256,20 +260,64 @@ export function createFriendlyNpcManager({
     return nearby.slice(0, 10);
   };
 
+  const sanitizeLlamaActionField = (value, maxChars = LLAMA_TEXT_FIELD_MAX_CHARS) => {
+    if (typeof value !== 'string') return '';
+    return value.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+  };
+
+  const normalizeLlamaAction = (action) => {
+    if (!action || typeof action !== 'object' || Array.isArray(action)) return null;
+    const type = sanitizeLlamaActionField(action.type || action.action, 20).toLowerCase();
+    if (!LLAMA_ALLOWED_ACTION_TYPES.has(type)) return null;
+
+    if (type === 'move') {
+      const direction = sanitizeLlamaActionField(action.direction, 12).toLowerCase();
+      if (LLAMA_ALLOWED_DIRECTIONS.has(direction)) return { type, direction };
+      if (Array.isArray(action.vector) && action.vector.length >= 3) {
+        const vector = action.vector.slice(0, 3).map(Number);
+        if (vector.every(Number.isFinite) && vector.some((value) => Math.abs(value) > 0.0001)) {
+          return { type, vector };
+        }
+      }
+      return null;
+    }
+
+    if (type === 'attack') {
+      const targetId = sanitizeLlamaActionField(action.targetId || action.target);
+      return targetId ? { type, targetId } : { type };
+    }
+
+    if (type === 'equip') {
+      const item = sanitizeLlamaActionField(action.item || action.target, 40);
+      if (!item) return null;
+      return { type, item };
+    }
+
+    if (type === 'interact') {
+      const targetId = sanitizeLlamaActionField(action.targetId || action.target);
+      if (!targetId) return null;
+      return { type, targetId };
+    }
+
+    return { type };
+  };
+
   const normalizeLlamaDecision = (raw) => {
-    const source = raw && typeof raw === 'object' ? raw : {};
+    const source = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
     const actions = Array.isArray(source.actions)
       ? source.actions
-      : (source.action ? [{ type: source.action, ...source }] : []);
+      : (source.action ? [{ ...source, type: source.action }] : []);
     const normalized = actions
-      .filter((action) => action && typeof action === 'object')
-      .map((action) => ({ ...action, type: String(action.type || action.action || '').toLowerCase() }))
-      .filter((action) => ['move', 'attack', 'equip', 'jump', 'interact', 'fly', 'shield'].includes(action.type));
-    const spell = typeof source.spell === 'string' ? source.spell.toLowerCase() : null;
-    if (spell === 'fly' || spell === 'shield') normalized.push({ type: spell });
+      .map(normalizeLlamaAction)
+      .filter(Boolean)
+      .slice(0, LLAMA_MAX_ACTIONS);
+    const spell = sanitizeLlamaActionField(source.spell, 20).toLowerCase();
+    if ((spell === 'fly' || spell === 'shield') && normalized.length < LLAMA_MAX_ACTIONS) {
+      normalized.push({ type: spell });
+    }
     return {
       speak: sanitizeLlamaSpeech(source.speak || source.say || source.message || 'Still hunting XP.'),
-      actions: normalized.slice(0, 3)
+      actions: normalized
     };
   };
 
@@ -289,7 +337,12 @@ export function createFriendlyNpcManager({
         magic: Number.isFinite(llama.model.userData.magic) ? llama.model.userData.magic : 30,
         level: llama.level,
         equipped: llama.model.userData.llamaEquipped || 'sword',
-        nearby: collectLlamaNearby(llama)
+        nearby: collectLlamaNearby(llama),
+        position: {
+          x: Math.round(llama.model.position.x * 100) / 100,
+          y: Math.round(llama.model.position.y * 100) / 100,
+          z: Math.round(llama.model.position.z * 100) / 100
+        }
       }
     };
     fetch('/api/llama', {
@@ -300,6 +353,7 @@ export function createFriendlyNpcManager({
     })
       .then((response) => (response.ok ? response.json() : Promise.reject(new Error(`Groq llama status ${response.status}`))))
       .then((data) => {
+        console.log('[Llama] decision response', data);
         const decision = normalizeLlamaDecision(data?.decision || data);
         llamaDecision = decision;
         llamaActionStartedAt = 0;
@@ -466,6 +520,8 @@ export function createFriendlyNpcManager({
       llama.body?.applyImpulse?.({ x: 0, y: 4.5, z: 0 }, true);
       llama.playAnimation('JumpAttack', 0.1);
       llama.update(delta);
+      llamaDecision.actions.shift();
+      llamaActionStartedAt = 0;
       return;
     }
 
@@ -777,7 +833,7 @@ const getHealthForLevel = (level) => {
         friendly.setEngageRadius(FRIENDLY_ENGAGE_RADIUS);
         friendly.setDisengageRadius(FRIENDLY_DISENGAGE_RADIUS);
         friendly.lastAIUpdateMs = 0;
-        const level = isLlamaId(slotId) ? 1 : (Number.isFinite(record.level) ? record.level : getRandomLevel());
+        const level = Number.isFinite(record.level) ? record.level : (isLlamaId(slotId) ? 1 : getRandomLevel());
         friendly.setLevel(level, { preserveHealth: false });
         friendly.resetHealth();
 


### PR DESCRIPTION
### Motivation
- Make the Llama NPC behave more naturally when the Groq/API path fails by avoiding a forced `move north` fallback so the idle drift can handle movement.
- Harden action parsing to prevent malformed or malicious actions from the Llama model and to avoid repeated physics impulses (the very-high jump issue).
- Surface what the Llama AI actually returned in the browser for easier debugging and verify persistence of Llama state in Firebase.

### Description
- Change the server fallback in `api/llama.js` to return `speak` + `actions: []` instead of a forced move, and add server-side action normalization with `sanitizeText`, `normalizeAction`, allowed action sets, and action limits (`MAX_ACTIONS`).
- Add client-side validation in `friendlyNpcManager.js` mirroring the server: `sanitizeLlamaActionField`, `normalizeLlamaAction`, allowed types/directions, max actions, and stronger decision normalization before execution.
- Include the Llama model position in the AI request payload and log the raw `/api/llama` response to the browser console via `console.log('[Llama] decision response', data);` to help triage behavior.
- Make `jump` a one-shot action in `friendlyNpcManager.js` by shifting the action immediately after applying the impulse so it does not repeatedly apply upward force for the duration of the action.
- Respect persisted `record.level` when spawning friendlies so a Llama loaded from Firebase will keep its saved level (and then `setLevel` recomputes `maxHealth`, attack stats, etc.).
- No changes to Firebase schema were required; `npcPersistence.js` already persists `hp`, `level`, `alive`, `llamaSpeech`, `llamaEquipped`, `pos`, and `rot` and `friendlyPersistence` is used for friendlies.

### Testing
- Ran `npm run build` and the production build completed successfully (Vite build output shown); result: success.
- Ran `node --check api/llama.js` and `node --check friendlyNpcManager.js` to validate syntax; both checks succeeded.
- Ran a smoke test invoking the Llama handler with no `GROQ_KEY` and asserted the returned fallback decision contains `actions: []`; test returned `{"decision":{"speak":"Thinking fast, staying alive.","actions":[]},"warning":"GROQ_KEY is not configured."}` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b34f1dbd48325bed4a332aba03e0f)