### PR TITLE
Improve Llama behavior variety and food interactions

### DIFF
--- a/api/llama.js
+++ b/api/llama.js
@@ -34,16 +34,121 @@ function formatNearby(nearby = []) {
   }).join('\n');
 }
 
-function buildPrompt(state = {}) {
+function formatActions(actions = []) {
+  if (!Array.isArray(actions) || actions.length === 0) return 'none';
+  return actions.map((action) => {
+    if (!action || typeof action !== 'object') return '';
+    if (action.type === 'move') return `move:${action.direction || 'vector'}`;
+    if (action.type === 'attack') return `attack:${action.targetId || 'nearest monster'}`;
+    if (action.type === 'interact') return `interact:${action.targetId || 'target'}`;
+    if (action.type === 'equip') return `equip:${action.item || 'item'}`;
+    return action.type || '';
+  }).filter(Boolean).join(' > ') || 'none';
+}
+
+function formatHistory(history = []) {
+  if (!Array.isArray(history) || history.length === 0) return '- No recent turns yet';
+  return history.slice(-5).map((entry) => {
+    const turn = Number.isFinite(entry?.turn) ? `turn ${entry.turn}` : 'recent turn';
+    const mode = typeof entry?.behaviorMode === 'string' && entry.behaviorMode ? entry.behaviorMode : 'unspecified';
+    const speak = sanitizeText(entry?.speak, MAX_SPEAK_CHARS) || '(no speech)';
+    const actions = formatActions(entry?.actions);
+    const outcome = sanitizeText(entry?.outcome, 80) || 'unknown outcome';
+    return `- ${turn} [${mode}] said: "${speak}" actions: ${actions}; outcome: ${outcome}`;
+  }).join('\n');
+}
+
+function formatGoal(goal) {
+  if (!goal || typeof goal !== 'object') return 'none';
+  const text = sanitizeText(goal.text, 120);
+  return text ? `${text} (started turn ${Number.isFinite(goal.startedTurn) ? goal.startedTurn : '?'})` : 'none';
+}
+
+function formatGoalHistory(goalHistory = []) {
+  if (!Array.isArray(goalHistory) || goalHistory.length === 0) return '- No completed or failed goals yet';
+  return goalHistory.slice(-8).map((goal) => {
+    const text = sanitizeText(goal?.text, 120) || '(untitled goal)';
+    const status = sanitizeText(goal?.status, 20) || 'unknown';
+    const note = sanitizeText(goal?.note, 80);
+    return `- ${text}: ${status}${note ? ` (${note})` : ''}`;
+  }).join('\n');
+}
+
+function buildPrompt(state = {}, meta = {}) {
   const hp = clampNumber(state.hp, 0);
   const hunger = clampNumber(state.hunger, 40);
   const magic = clampNumber(state.magic, 30);
   const equipped = typeof state.equipped === 'string' && state.equipped.trim() ? state.equipped.trim() : 'sword';
   const nearby = formatNearby(state.nearby);
+  const history = formatHistory(meta.history);
+  const currentGoal = formatGoal(meta.currentGoal);
+  const goalHistory = formatGoalHistory(meta.goalHistory);
+  const turnNumber = Number.isFinite(meta.turnNumber) ? meta.turnNumber : 1;
+  const shouldSetGoal = !!meta.shouldSetGoal;
 
-  return `You are controlling an RPG character named Llama.\n\nGoal:\nmaximize XP and survive.\n\nState:\nHP: ${hp}\nHunger: ${hunger}\nMagic: ${magic}\nEquipped: ${equipped}\n\nNearby:\n${nearby}\n\nReturn ONLY JSON. Include a speak string every time.\n\nAvailable actions:\nmove\nattack\nequip\njump\ninteract\nspeak\nspells: fly (magic cost), shield (magic cost)\n\nJSON template:\n{\n  "speak": "short in-character sentence",\n  "actions": [\n    { "type": "move", "direction": "north|south|east|west" },\n    { "type": "attack", "targetId": "id from nearby if known" },\n    { "type": "equip", "item": "sword|ice gun|best available" },\n    { "type": "jump" },\n    { "type": "interact", "targetId": "id from nearby if known" },\n    { "type": "shield" },\n    { "type": "fly" }\n  ]\n}\nChoose at most 2 non-speak actions.`;
+  return `You are controlling an RPG character named Llama.
+
+Primary objective:
+maximize XP and survive.
+
+State:
+HP: ${hp}
+Hunger: ${hunger}
+Magic: ${magic}
+Equipped: ${equipped}
+Turn: ${turnNumber}
+Current 5-turn goal: ${currentGoal}
+Must choose a new 5-turn goal this turn: ${shouldSetGoal ? 'yes' : 'no'}
+
+Nearby:
+${nearby}
+
+Recent history (last 5 turns):
+${history}
+
+Goal history:
+${goalHistory}
+
+Rules:
+- Return ONLY JSON. Include a speak string every time.
+- Do NOT repeat any speak string from recent history.
+- Speak must be unique and context-specific each turn.
+- Avoid repeating an identical action sequence from the previous turn.
+- Choose a behaviorMode each turn: cautious | aggressive | exploratory | playful | tactical.
+- behaviorMode must influence both speak and actions.
+- Include one new observation or interpretation in speak each turn.
+- If Must choose a new 5-turn goal is yes, include a concrete "goal" string that can be completed by attacking a Monster or interacting with Food.
+- If Must choose a new 5-turn goal is no, keep pursuing the current 5-turn goal and omit "goal" unless the old goal is impossible.
+- Players are allies; never attack Player ids such as host. Attack only Monster ids.
+- To get food, interact with a Food targetId when nearby; do not merely say you will find food.
+- To fight successfully, attack a nearby Monster targetId; do not claim to attack a Player.
+
+Available actions:
+move
+attack (Monster only)
+equip
+jump
+interact (Food pickup or other target)
+speak
+spells: fly (magic cost), shield (magic cost)
+
+JSON template:
+{
+  "speak": "short in-character sentence with a fresh observation",
+  "behaviorMode": "cautious|aggressive|exploratory|playful|tactical",
+  "goal": "only on new-goal turns: concrete 5-turn goal",
+  "actions": [
+    { "type": "move", "direction": "north|south|east|west" },
+    { "type": "attack", "targetId": "Monster id from nearby" },
+    { "type": "equip", "item": "sword|ice gun|best available" },
+    { "type": "jump" },
+    { "type": "interact", "targetId": "Food id from nearby" },
+    { "type": "shield" },
+    { "type": "fly" }
+  ]
 }
-
+Choose at most 2 non-speak actions.`;
+}
 
 const ACTION_TYPES = new Set(['move', 'attack', 'equip', 'jump', 'interact', 'fly', 'shield']);
 const DIRECTIONS = new Set(['north', 'south', 'east', 'west']);
@@ -114,6 +219,8 @@ function normalizeDecision(value) {
 
   return {
     speak: sanitizeText(value.speak || value.say || value.message, MAX_SPEAK_CHARS) || base.speak,
+    behaviorMode: sanitizeText(value.behaviorMode || value.mode, 24).toLowerCase(),
+    goal: sanitizeText(typeof value.goal === 'string' ? value.goal : (value.goal?.text || value.nextGoal), 120),
     actions
   };
 }
@@ -138,7 +245,7 @@ export default async function handler(req, res) {
   }
 
   const body = readJsonBody(req.body);
-  const prompt = buildPrompt(body.state || {});
+  const prompt = buildPrompt(body.state || {}, body);
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
@@ -151,8 +258,8 @@ export default async function handler(req, res) {
       },
       body: JSON.stringify({
         model: GROQ_MODEL,
-        temperature: 0.3,
-        max_tokens: 120,
+        temperature: 0.75,
+        max_tokens: 180,
         response_format: { type: 'json_object' },
         messages: [
           { role: 'system', content: 'Return only valid JSON for the RPG character controller. The JSON must always include speak.' },

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -4089,6 +4089,17 @@ async function initCore(runtimeContext) {
     onBeforeSpawn: (...args) => trimTravelSpawnPopulationIfNeeded(...args),
     onRemoteSpawnRequest: requestHostSpawnEvent,
     getMonsters: () => monsters,
+    getFoodPickups: () => [
+      ...mushroomPickups.map((pickup, index) => ({ id: `food:mushroom:${pickup?.id || index}:${index}`, type: 'mushroom', pickup, position: pickup?.position || pickup?.mesh?.position })),
+      ...applePickups.map((pickup, index) => ({ id: `food:apple:${pickup?.id || index}:${index}`, type: 'apple', pickup, position: pickup?.mesh?.getWorldPosition?.(new THREE.Vector3()) || pickup?.mesh?.position })),
+      ...meatPickups.map((pickup, index) => ({ id: `food:meat:${pickup?.id || index}:${index}`, type: 'meat', pickup, position: pickup?.mesh?.position }))
+    ].filter((entry) => entry.pickup && entry.position && (entry.pickup.active !== false) && (!entry.pickup.mesh || entry.pickup.mesh.visible !== false)),
+    onFoodPickupCollected: (target, actorPosition) => {
+      if (target?.type === 'mushroom') return pickupMushroom(target.pickup, actorPosition);
+      if (target?.type === 'apple') return pickupApple(target.pickup, actorPosition);
+      if (target?.type === 'meat') return pickupMeat(target.pickup, actorPosition);
+      return false;
+    },
     onMonsterHit: handleMonsterDamage
   });
   if (multiplayer?.roomId) {
@@ -6419,12 +6430,12 @@ async function initCore(runtimeContext) {
     }
   }
 
-  function pickupMushroom(pickup) {
+  function pickupMushroom(pickup, actorPosition = playerControls?.playerModel?.position) {
     if (!pickup?.active) return false;
     const pickupPosition = pickup.position || pickup.mesh?.position;
     if (!pickupPosition) return false;
-    if (playerControls?.playerModel) {
-      const playerPosition = playerControls.playerModel.position;
+    if (actorPosition) {
+      const playerPosition = actorPosition;
       const horizontalDistance = Math.hypot(
         playerPosition.x - pickupPosition.x,
         playerPosition.z - pickupPosition.z
@@ -6444,10 +6455,10 @@ async function initCore(runtimeContext) {
     return true;
   }
 
-  function pickupApple(pickup) {
+  function pickupApple(pickup, actorPosition = playerControls?.playerModel?.position) {
     if (!pickup?.mesh) return false;
-    if (playerControls?.playerModel) {
-      const playerPosition = playerControls.playerModel.position;
+    if (actorPosition) {
+      const playerPosition = actorPosition;
       const applePosition = pickup.mesh.getWorldPosition
         ? pickup.mesh.getWorldPosition(tempTreePosition)
         : pickup.mesh.position;
@@ -6486,10 +6497,10 @@ async function initCore(runtimeContext) {
   }
 
 
-  function pickupMeat(pickup) {
+  function pickupMeat(pickup, actorPosition = playerControls?.playerModel?.position) {
     if (!pickup?.mesh) return false;
-    if (playerControls?.playerModel) {
-      const playerPosition = playerControls.playerModel.position;
+    if (actorPosition) {
+      const playerPosition = actorPosition;
       const meatPosition = pickup.mesh.position;
       const horizontalDistance = Math.hypot(
         playerPosition.x - meatPosition.x,

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -22,7 +22,7 @@ const LLAMA_NAME = "Llama";
 const LLAMA_MODEL = "/models/Chimpanzee.fbx";
 const LLAMA_DECISION_INTERVAL_MS = 10_000;
 const LLAMA_REQUEST_TIMEOUT_MS = 5_000;
-const LLAMA_ACTION_DURATION_MS = 3_000;
+const LLAMA_ACTION_DURATION_MS = 6_000;
 const LLAMA_SPEECH_MAX_CHARS = 96;
 const LLAMA_PROMPT_NEARBY_RADIUS = 32;
 const LLAMA_DRIFT_STOP_DISTANCE = 3.25;
@@ -30,6 +30,10 @@ const LLAMA_ALLOWED_ACTION_TYPES = new Set(['move', 'attack', 'equip', 'jump', '
 const LLAMA_ALLOWED_DIRECTIONS = new Set(['north', 'south', 'east', 'west']);
 const LLAMA_MAX_ACTIONS = 2;
 const LLAMA_TEXT_FIELD_MAX_CHARS = 80;
+const LLAMA_HISTORY_LIMIT = 5;
+const LLAMA_GOAL_INTERVAL_TURNS = 5;
+const LLAMA_GOAL_HISTORY_LIMIT = 8;
+const LLAMA_FOOD_INTERACT_DISTANCE = 1.1;
 const FRIENDLY_MAX_ACTIVE = 6;
 const FRIENDLY_ACTIVE_RADIUS = 360;
 const FRIENDLY_PLAYER_SPAWN_BLOCK_RADIUS = 32;
@@ -63,6 +67,8 @@ export function createFriendlyNpcManager({
   onBeforeSpawn,
   onRemoteSpawnRequest,
   getMonsters,
+  getFoodPickups,
+  onFoodPickupCollected,
   onMonsterHit
 } = {}) {
   const friendlies = [];
@@ -78,6 +84,11 @@ export function createFriendlyNpcManager({
   let llamaDecision = null;
   let llamaActionStartedAt = 0;
   let llamaActionTargetId = null;
+  let llamaTurnNumber = 0;
+  let llamaCurrentGoal = null;
+  const llamaGoalHistory = [];
+  const llamaRecentHistory = [];
+  const llamaNearbyTargets = new Map();
   const getSpawnNearPlayerPosition = (position) => {
     return getSpawnPosition(position);
   };
@@ -226,6 +237,56 @@ export function createFriendlyNpcManager({
     return dz >= 0 ? 'south' : 'north';
   };
 
+  const getPickupPosition = (pickup) => {
+    const source = pickup?.mesh || pickup;
+    if (source?.getWorldPosition) return source.getWorldPosition(new THREE.Vector3());
+    return (pickup?.position || pickup?.mesh?.position || null)?.clone?.() || null;
+  };
+
+  const collectFoodTargetsForLlama = (llama, origin) => {
+    if (typeof getFoodPickups !== 'function') return [];
+    return (getFoodPickups() || []).map((entry, index) => {
+      const pickup = entry?.pickup || entry;
+      const position = entry?.position?.clone?.() || getPickupPosition(pickup);
+      if (!pickup || !position) return null;
+      const type = sanitizeLlamaActionField(entry?.type || pickup?.id || 'food', 24) || 'food';
+      const id = sanitizeLlamaActionField(entry?.id, 60) || `food:${type}:${index}`;
+      return {
+        type,
+        id,
+        pickup,
+        position,
+        distance: origin.distanceTo(position)
+      };
+    }).filter(Boolean).filter((entry) => entry.distance <= LLAMA_PROMPT_NEARBY_RADIUS);
+  };
+
+  const getLlamaActionSignature = (actions = []) => actions
+    .map((action) => {
+      if (!action?.type) return '';
+      if (action.type === 'move') return `${action.type}:${action.direction || (Array.isArray(action.vector) ? action.vector.map((n) => Math.round(n * 10) / 10).join(',') : '')}`;
+      return `${action.type}:${action.targetId || action.item || ''}`;
+    })
+    .filter(Boolean)
+    .join(' > ');
+
+  const rememberLlamaHistory = (entry) => {
+    llamaRecentHistory.push({ ...entry, turn: llamaTurnNumber });
+    while (llamaRecentHistory.length > LLAMA_HISTORY_LIMIT) llamaRecentHistory.shift();
+  };
+
+  const finishLlamaGoal = (status, note = '') => {
+    if (!llamaCurrentGoal) return;
+    llamaGoalHistory.push({ ...llamaCurrentGoal, status, note, endedTurn: llamaTurnNumber });
+    while (llamaGoalHistory.length > LLAMA_GOAL_HISTORY_LIMIT) llamaGoalHistory.shift();
+    llamaCurrentGoal = null;
+  };
+
+  const updateLatestLlamaOutcome = (outcome) => {
+    const latest = llamaRecentHistory[llamaRecentHistory.length - 1];
+    if (latest) latest.outcome = outcome;
+  };
+
   const collectLlamaNearby = (llama) => {
     if (!llama?.model?.position) return [];
     const origin = llama.model.position;
@@ -248,12 +309,24 @@ export function createFriendlyNpcManager({
       const distance = origin.distanceTo(player.model.position);
       if (distance > LLAMA_PROMPT_NEARBY_RADIUS) return;
       nearby.push({
-        type: 'Player',
+        type: 'Player (ally - do not attack)',
         id: player.id,
         distance: Math.round(distance),
         direction: describeDirection(origin, player.model.position),
         level: player.level,
         hp: player.hp
+      });
+    });
+    llamaNearbyTargets.clear();
+    collectFoodTargetsForLlama(llama, origin).forEach((food) => {
+      llamaNearbyTargets.set(food.id, food);
+      nearby.push({
+        type: `Food:${food.type}`,
+        id: food.id,
+        distance: Math.round(food.distance),
+        direction: describeDirection(origin, food.position),
+        level: null,
+        hp: null
       });
     });
     nearby.sort((a, b) => a.distance - b.distance);
@@ -317,6 +390,11 @@ export function createFriendlyNpcManager({
     }
     return {
       speak: sanitizeLlamaSpeech(source.speak || source.say || source.message || 'Still hunting XP.'),
+      behaviorMode: sanitizeLlamaActionField(source.behaviorMode || source.mode, 24).toLowerCase(),
+      goal: sanitizeLlamaActionField(
+        typeof source.goal === 'string' ? source.goal : (source.goal?.text || source.nextGoal || ''),
+        120
+      ),
       actions: normalized
     };
   };
@@ -329,7 +407,13 @@ export function createFriendlyNpcManager({
     llamaLastRequestAt = now;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), LLAMA_REQUEST_TIMEOUT_MS);
+    const nextTurn = llamaTurnNumber + 1;
     const payload = {
+      history: llamaRecentHistory,
+      currentGoal: llamaCurrentGoal,
+      goalHistory: llamaGoalHistory,
+      turnNumber: nextTurn,
+      shouldSetGoal: ((nextTurn - 1) % LLAMA_GOAL_INTERVAL_TURNS) === 0,
       state: {
         hp: llama.health,
         maxHp: llama.maxHealth,
@@ -355,9 +439,22 @@ export function createFriendlyNpcManager({
       .then((data) => {
         console.log('[Llama] decision response', data);
         const decision = normalizeLlamaDecision(data?.decision || data);
+        llamaTurnNumber = nextTurn;
+        if (payload.shouldSetGoal && decision.goal) {
+          finishLlamaGoal('failed', 'replaced by a new 5-turn goal');
+          llamaCurrentGoal = { text: decision.goal, startedTurn: llamaTurnNumber, status: 'active' };
+        }
         llamaDecision = decision;
         llamaActionStartedAt = 0;
         llamaActionTargetId = null;
+        rememberLlamaHistory({
+          speak: decision.speak,
+          behaviorMode: decision.behaviorMode || 'unspecified',
+          actions: decision.actions,
+          actionSignature: getLlamaActionSignature(decision.actions),
+          goal: llamaCurrentGoal?.text || null,
+          outcome: 'started'
+        });
         setLlamaSpeech(llama, decision.speak || 'For XP and survival!');
       })
       .catch((error) => {
@@ -461,6 +558,7 @@ export function createFriendlyNpcManager({
       llamaActionStartedAt = now;
     }
     if (now - llamaActionStartedAt > LLAMA_ACTION_DURATION_MS) {
+      updateLatestLlamaOutcome(`timed out during ${llamaDecision.actions[0]?.type || 'action'}`);
       llamaDecision.actions.shift();
       llamaActionStartedAt = 0;
       llamaActionTargetId = null;
@@ -503,8 +601,39 @@ export function createFriendlyNpcManager({
         const damage = Number.isFinite(hitContext.damage) ? Math.max(1, Math.round(hitContext.damage)) : llama.attackDamage;
         const killed = entity.applyDamage?.(damage, { attackTypes: hitContext.attackTypes || ['llama', 'melee'] });
         context.onMonsterHit?.(entity, { damage, killed: !!killed, sourceId: LLAMA_ID, attackTypes: hitContext.attackTypes || ['llama', 'melee'] });
-        if (killed) window.onMonsterKill?.(entity, { withFriend: true });
+        updateLatestLlamaOutcome(`hit monster for ${damage}`);
+        if (killed) {
+          window.onMonsterKill?.(entity, { withFriend: true });
+          updateLatestLlamaOutcome('completed attack: monster defeated');
+          finishLlamaGoal('completed', 'defeated a monster');
+        }
       }, context);
+      return;
+    }
+
+    if (action.type === 'interact') {
+      const foodTarget = llamaNearbyTargets.get(action.targetId);
+      if (!foodTarget?.pickup || !foodTarget.position) {
+        llamaDecision.actions.shift();
+        llamaActionStartedAt = 0;
+        updateLatestLlamaOutcome('failed interact: target unavailable');
+        idleDriftLlama(llama, delta);
+        return;
+      }
+      const toFood = foodTarget.position.clone().sub(llama.model.position);
+      toFood.y = 0;
+      if (toFood.length() > LLAMA_FOOD_INTERACT_DISTANCE) {
+        moveLlama(llama, toFood, delta);
+        return;
+      }
+      const collected = typeof onFoodPickupCollected === 'function'
+        ? onFoodPickupCollected(foodTarget, llama.model.position.clone())
+        : false;
+      llamaDecision.actions.shift();
+      llamaActionStartedAt = 0;
+      updateLatestLlamaOutcome(collected ? `collected ${foodTarget.type}` : `failed to collect ${foodTarget.type}`);
+      if (collected) finishLlamaGoal('completed', `collected ${foodTarget.type}`);
+      idleDriftLlama(llama, delta);
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce repeated Llama speech/action patterns and make its decisions more context-aware by giving the model recent-turn history, behavior modes, and multi-turn goals.
- Allow Llama to actually collect food and make progress on self-set goals so `interact`/`attack` actions have visible outcomes.

### Description
- Enhance the Llama API prompt in `api/llama.js` to include formatted recent history, goal history, turn number, a 5-turn goal cadence, anti-repetition rules, required `behaviorMode`, and guidance to treat players as allies, and increase `temperature` and `max_tokens` for more varied responses.
- Extend the API response normalization to accept `behaviorMode` and `goal` and return them alongside `speak` and `actions` in `api/llama.js`.
- Add turn tracking, recent-history and goal history, action-signature tracking, nearby food target collection, outcome updates, and longer action durations in `friendlyNpcManager.js`, plus handling to execute `interact` on food targets and record attack/goal outcomes.
- Wire game pickups into the NPC manager in `app/bootstrapGameApp.js` by exposing `getFoodPickups` and `onFoodPickupCollected` and update pickup functions to accept an `actorPosition` so Llama can collect mushrooms, apples, and meat.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build finished; standard chunk-size warnings from Rollup were present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b3a0ad03c83259915aaa1d072dd30)