### PR TITLE
Add persistent Llama inventory

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -4094,12 +4094,7 @@ async function initCore(runtimeContext) {
       ...applePickups.map((pickup, index) => ({ id: `food:apple:${pickup?.id || index}:${index}`, type: 'apple', pickup, position: pickup?.mesh?.getWorldPosition?.(new THREE.Vector3()) || pickup?.mesh?.position })),
       ...meatPickups.map((pickup, index) => ({ id: `food:meat:${pickup?.id || index}:${index}`, type: 'meat', pickup, position: pickup?.mesh?.position }))
     ].filter((entry) => entry.pickup && entry.position && (entry.pickup.active !== false) && (!entry.pickup.mesh || entry.pickup.mesh.visible !== false)),
-    onFoodPickupCollected: (target, actorPosition) => {
-      if (target?.type === 'mushroom') return pickupMushroom(target.pickup, actorPosition);
-      if (target?.type === 'apple') return pickupApple(target.pickup, actorPosition);
-      if (target?.type === 'meat') return pickupMeat(target.pickup, actorPosition);
-      return false;
-    },
+    onFoodPickupCollected: (target, actorPosition) => collectPickupForLlama(target, actorPosition),
     onMonsterHit: handleMonsterDamage
   });
   if (multiplayer?.roomId) {
@@ -6428,6 +6423,74 @@ async function initCore(runtimeContext) {
       pendingWorldDropRemovals.add(dropId);
       multiplayer.send({ type: 'dropWorldPickup', dropId });
     }
+  }
+
+
+  function buildLlamaPickupResult(pickup, type, amount = 1) {
+    const result = {
+      collected: true,
+      itemId: pickup?.id || type,
+      amount: Math.max(1, Math.floor(Number(amount) || 1)),
+      type
+    };
+    if (type === 'mushroom') {
+      result.healthGain = MUSHROOM_HEALTH_SEGMENTS;
+      result.hungerGain = MUSHROOM_HUNGER_GAIN;
+    } else if (type === 'apple') {
+      result.healthGain = APPLE_HEALTH_SEGMENTS;
+      result.hungerGain = APPLE_HUNGER_GAIN;
+    } else if (type === 'meat') {
+      result.healthGain = MEAT_HEALTH_SEGMENTS;
+      result.hungerGain = MEAT_HUNGER_GAIN;
+    }
+    return result;
+  }
+
+  function isActorNearPickup(actorPosition, pickupPosition, radius) {
+    if (!actorPosition || !pickupPosition) return true;
+    const horizontalDistance = Math.hypot(
+      actorPosition.x - pickupPosition.x,
+      actorPosition.z - pickupPosition.z
+    );
+    return horizontalDistance <= radius;
+  }
+
+  function collectPickupForLlama(target, actorPosition = null) {
+    const pickup = target?.pickup;
+    if (!pickup) return { collected: false };
+    if (target?.type === 'mushroom') {
+      if (!pickup.active) return { collected: false };
+      const pickupPosition = pickup.position || pickup.mesh?.position;
+      if (!isActorNearPickup(actorPosition, pickupPosition, PICKUP_RADIUS)) return { collected: false };
+      disposeMushroomPickup(pickup);
+      const index = mushroomPickups.indexOf(pickup);
+      if (index >= 0) mushroomPickups.splice(index, 1);
+      mushroomPickupGrid.remove(pickup);
+      handleDroppedWorldPickupCollected(pickup);
+      return buildLlamaPickupResult(pickup, 'mushroom');
+    }
+    if (target?.type === 'apple') {
+      if (!pickup.mesh) return { collected: false };
+      const applePosition = pickup.mesh.getWorldPosition
+        ? pickup.mesh.getWorldPosition(tempTreePosition)
+        : pickup.mesh.position;
+      if (!isActorNearPickup(actorPosition, applePosition, APPLE_PICKUP_RADIUS)) return { collected: false };
+      disposeApplePickup(pickup);
+      const index = applePickups.indexOf(pickup);
+      if (index >= 0) applePickups.splice(index, 1);
+      handleDroppedWorldPickupCollected(pickup);
+      return buildLlamaPickupResult(pickup, 'apple');
+    }
+    if (target?.type === 'meat') {
+      if (!pickup.mesh) return { collected: false };
+      if (!isActorNearPickup(actorPosition, pickup.mesh.position, MEAT_PICKUP_RADIUS)) return { collected: false };
+      disposeWoodPickup(pickup);
+      const index = meatPickups.indexOf(pickup);
+      if (index >= 0) meatPickups.splice(index, 1);
+      handleDroppedWorldPickupCollected(pickup);
+      return buildLlamaPickupResult(pickup, 'meat');
+    }
+    return { collected: false };
   }
 
   function pickupMushroom(pickup, actorPosition = playerControls?.playerModel?.position) {

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -34,6 +34,12 @@ const LLAMA_HISTORY_LIMIT = 5;
 const LLAMA_GOAL_INTERVAL_TURNS = 5;
 const LLAMA_GOAL_HISTORY_LIMIT = 8;
 const LLAMA_FOOD_INTERACT_DISTANCE = 1.1;
+const LLAMA_MAX_HUNGER_SEGMENTS = 40;
+const LLAMA_FOOD_RECOVERY = Object.freeze({
+  mushroom: { health: 1, hunger: 3 },
+  apple: { health: 1, hunger: 2 },
+  meat: { health: 4, hunger: 16 }
+});
 const FRIENDLY_MAX_ACTIVE = 6;
 const FRIENDLY_ACTIVE_RADIUS = 360;
 const FRIENDLY_PLAYER_SPAWN_BLOCK_RADIUS = 32;
@@ -133,6 +139,9 @@ export function createFriendlyNpcManager({
       pos: { x: pos.x, y: pos.y, z: pos.z },
       rot: { x: rot.x, y: rot.y, z: rot.z, w: rot.w },
       llamaSpeech: 'Ready to grind XP.',
+      llamaInventory: {},
+      llamaHunger: LLAMA_MAX_HUNGER_SEGMENTS,
+      llamaMaxHunger: LLAMA_MAX_HUNGER_SEGMENTS,
       updatedAt: Date.now(),
       version: Date.now()
     };
@@ -218,6 +227,108 @@ export function createFriendlyNpcManager({
     if (!bubble) return;
     bubble.visible = Date.now() <= (bubble.userData.visibleUntil || 0);
   };
+
+
+  const normalizeLlamaInventory = (inventory) => {
+    if (!inventory || typeof inventory !== 'object' || Array.isArray(inventory)) return {};
+    return Object.entries(inventory).reduce((result, [itemId, entry]) => {
+      const id = sanitizeLlamaActionField(itemId, 80);
+      if (!id) return result;
+      const count = Math.max(0, Math.floor(Number(entry?.count ?? entry)) || 0);
+      if (!count) return result;
+      result[id] = {
+        count,
+        type: sanitizeLlamaActionField(entry?.type || '', 24)
+      };
+      return result;
+    }, {});
+  };
+
+  const getLlamaInventory = (llama) => {
+    if (!llama?.model?.userData) return {};
+    const normalized = normalizeLlamaInventory(llama.model.userData.llamaInventory);
+    llama.model.userData.llamaInventory = normalized;
+    return normalized;
+  };
+
+  const getLlamaHunger = (llama) => Math.max(0, Math.min(
+    Number.isFinite(llama?.model?.userData?.llamaMaxHunger) ? llama.model.userData.llamaMaxHunger : LLAMA_MAX_HUNGER_SEGMENTS,
+    Number.isFinite(llama?.model?.userData?.llamaHunger) ? llama.model.userData.llamaHunger : LLAMA_MAX_HUNGER_SEGMENTS
+  ));
+
+  const setLlamaHunger = (llama, value) => {
+    if (!llama?.model?.userData) return;
+    const maxHunger = Number.isFinite(llama.model.userData.llamaMaxHunger)
+      ? llama.model.userData.llamaMaxHunger
+      : LLAMA_MAX_HUNGER_SEGMENTS;
+    llama.model.userData.llamaMaxHunger = maxHunger;
+    llama.model.userData.llamaHunger = Math.max(0, Math.min(maxHunger, Math.round(Number(value) || 0)));
+  };
+
+  const addLlamaInventoryItem = (llama, itemId, amount = 1, type = '') => {
+    const id = sanitizeLlamaActionField(itemId, 80);
+    const count = Math.max(1, Math.floor(Number(amount) || 1));
+    if (!id || !llama?.model?.userData) return null;
+    const inventory = getLlamaInventory(llama);
+    const current = inventory[id] || { count: 0, type: sanitizeLlamaActionField(type, 24) };
+    inventory[id] = {
+      ...current,
+      count: Math.max(0, Math.floor(current.count || 0)) + count,
+      type: sanitizeLlamaActionField(type || current.type || '', 24)
+    };
+    llama.model.userData.llamaInventory = inventory;
+    return id;
+  };
+
+  const removeLlamaInventoryItem = (llama, itemId, amount = 1) => {
+    const id = sanitizeLlamaActionField(itemId, 80);
+    if (!id || !llama?.model?.userData) return;
+    const inventory = getLlamaInventory(llama);
+    const current = inventory[id];
+    if (!current) return;
+    const nextCount = Math.max(0, Math.floor(current.count || 0) - Math.max(1, Math.floor(Number(amount) || 1)));
+    if (nextCount > 0) {
+      inventory[id] = { ...current, count: nextCount };
+    } else {
+      delete inventory[id];
+    }
+    llama.model.userData.llamaInventory = inventory;
+  };
+
+  const getLlamaFoodRecovery = (type, collected = {}) => {
+    const fallback = LLAMA_FOOD_RECOVERY[type] || { health: 0, hunger: 0 };
+    return {
+      health: Number.isFinite(collected.healthGain) ? collected.healthGain : fallback.health,
+      hunger: Number.isFinite(collected.hungerGain) ? collected.hungerGain : fallback.hunger
+    };
+  };
+
+  const maybeLlamaEatCollectedFood = (llama, itemId, type, collected = {}) => {
+    if (!llama?.model || !itemId) return false;
+    const maxHealth = Math.max(1, Number(llama.maxHealth || FRIENDLY_BASE_HEALTH));
+    const maxHunger = Number.isFinite(llama.model.userData.llamaMaxHunger)
+      ? llama.model.userData.llamaMaxHunger
+      : LLAMA_MAX_HUNGER_SEGMENTS;
+    llama.model.userData.llamaMaxHunger = maxHunger;
+    const currentHunger = getLlamaHunger(llama);
+    if ((llama.health || 0) >= maxHealth && currentHunger >= maxHunger) return false;
+    const recovery = getLlamaFoodRecovery(type, collected);
+    removeLlamaInventoryItem(llama, itemId, 1);
+    if (recovery.health > 0) {
+      llama.health = Math.min(maxHealth, Math.max(0, Number(llama.health || 0)) + recovery.health);
+      llama.model.userData.health = llama.health;
+      llama.updateHealthBarTexture?.();
+      llama.showHealthBar?.();
+    }
+    if (recovery.hunger > 0) {
+      setLlamaHunger(llama, currentHunger + recovery.hunger);
+    }
+    return true;
+  };
+
+  const summarizeLlamaInventory = (llama) => Object.entries(getLlamaInventory(llama))
+    .map(([itemId, entry]) => `${itemId} x${entry.count}`)
+    .slice(0, 8);
 
   const getAllPlayersForLlama = () => [
     { id: 'host', name: 'Host player', model: playerModel, level: 1, hp: FRIENDLY_BASE_HEALTH },
@@ -417,7 +528,9 @@ export function createFriendlyNpcManager({
       state: {
         hp: llama.health,
         maxHp: llama.maxHealth,
-        hunger: 40,
+        hunger: getLlamaHunger(llama),
+        maxHunger: Number.isFinite(llama.model.userData.llamaMaxHunger) ? llama.model.userData.llamaMaxHunger : LLAMA_MAX_HUNGER_SEGMENTS,
+        inventory: summarizeLlamaInventory(llama),
         magic: Number.isFinite(llama.model.userData.magic) ? llama.model.userData.magic : 30,
         level: llama.level,
         equipped: llama.model.userData.llamaEquipped || 'sword',
@@ -627,12 +740,24 @@ export function createFriendlyNpcManager({
         return;
       }
       const collected = typeof onFoodPickupCollected === 'function'
-        ? onFoodPickupCollected(foodTarget, llama.model.position.clone())
+        ? onFoodPickupCollected(foodTarget, llama.model.position.clone(), llama)
         : false;
+      const wasCollected = !!(collected?.collected ?? collected);
+      if (wasCollected) {
+        const itemId = addLlamaInventoryItem(
+          llama,
+          collected?.itemId || foodTarget.pickup?.id || foodTarget.type,
+          collected?.amount || 1,
+          foodTarget.type
+        );
+        const ateImmediately = maybeLlamaEatCollectedFood(llama, itemId, foodTarget.type, collected);
+        persistFriendlyState(llama, { force: true });
+        if (ateImmediately) setLlamaSpeech(llama, `Ate ${foodTarget.type} to recover.`);
+      }
       llamaDecision.actions.shift();
       llamaActionStartedAt = 0;
-      updateLatestLlamaOutcome(collected ? `collected ${foodTarget.type}` : `failed to collect ${foodTarget.type}`);
-      if (collected) finishLlamaGoal('completed', `collected ${foodTarget.type}`);
+      updateLatestLlamaOutcome(wasCollected ? `collected ${foodTarget.type}` : `failed to collect ${foodTarget.type}`);
+      if (wasCollected) finishLlamaGoal('completed', `collected ${foodTarget.type}`);
       idleDriftLlama(llama, delta);
       return;
     }
@@ -949,6 +1074,9 @@ const getHealthForLevel = (level) => {
           friendly.model.userData.npcKind = 'llama';
           friendly.model.userData.displayName = LLAMA_NAME;
           friendly.model.userData.llamaEquipped = record.llamaEquipped || 'sword';
+          friendly.model.userData.llamaInventory = normalizeLlamaInventory(record.llamaInventory);
+          friendly.model.userData.llamaMaxHunger = Number.isFinite(record.llamaMaxHunger) ? record.llamaMaxHunger : LLAMA_MAX_HUNGER_SEGMENTS;
+          setLlamaHunger(friendly, Number.isFinite(record.llamaHunger) ? record.llamaHunger : friendly.model.userData.llamaMaxHunger);
           friendly.enableDanceWhileEngaged = false;
           friendly.alwaysShowHealthBar = true;
         }
@@ -1020,8 +1148,13 @@ const getHealthForLevel = (level) => {
       friendly.model.quaternion.set(rotation.x, rotation.y, rotation.z, rotation.w);
       friendly.body?.setRotation(rotation, true);
     }
-    if (isLlamaId(friendly.id) && record.llamaSpeech && record.llamaSpeech !== friendly.model.userData.llamaSpeech) {
-      setLlamaSpeech(friendly, record.llamaSpeech);
+    if (isLlamaId(friendly.id)) {
+      if (record.llamaSpeech && record.llamaSpeech !== friendly.model.userData.llamaSpeech) {
+        setLlamaSpeech(friendly, record.llamaSpeech);
+      }
+      friendly.model.userData.llamaInventory = normalizeLlamaInventory(record.llamaInventory);
+      friendly.model.userData.llamaMaxHunger = Number.isFinite(record.llamaMaxHunger) ? record.llamaMaxHunger : LLAMA_MAX_HUNGER_SEGMENTS;
+      setLlamaHunger(friendly, Number.isFinite(record.llamaHunger) ? record.llamaHunger : friendly.model.userData.llamaMaxHunger);
     }
     friendly.applyPersistedState?.({
       hp: record.hp,

--- a/npcPersistence.js
+++ b/npcPersistence.js
@@ -63,6 +63,12 @@ export function createEntityPersistence({
     if (userData.llamaSpeech) payload.llamaSpeech = userData.llamaSpeech;
     if (userData.llamaEquipped) payload.llamaEquipped = userData.llamaEquipped;
 
+    if (userData.llamaInventory && typeof userData.llamaInventory === 'object' && !Array.isArray(userData.llamaInventory)) {
+      payload.llamaInventory = userData.llamaInventory;
+    }
+    if (Number.isFinite(userData.llamaHunger)) payload.llamaHunger = userData.llamaHunger;
+    if (Number.isFinite(userData.llamaMaxHunger)) payload.llamaMaxHunger = userData.llamaMaxHunger;
+
     if (includeTransform && entity.model) {
       const pos = entity.model.position;
       const rot = entity.model.quaternion;
@@ -144,7 +150,7 @@ export function createEntityPersistence({
     logDebug('persist hp', entity.id, payload.version);
   }
 
-  function persistState(entity) {
+  function persistState(entity, { force = false } = {}) {
     if (!state.isHost || !entity?.model) return;
     const entityRef = getEntityRef(entity?.id);
     if (!entityRef) return;
@@ -163,7 +169,7 @@ export function createEntityPersistence({
       movedFar = dist >= POSITION_DISTANCE_THRESHOLD;
     }
 
-    if (!movedFar && now - meta.lastPersistAt < POSITION_THROTTLE_MS) {
+    if (!force && !movedFar && now - meta.lastPersistAt < POSITION_THROTTLE_MS) {
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Llama pickups were being placed into the host/player inventory, so the Llama needs its own inventory tracked separately. 
- The Llama should be able to immediately consume food it picks up when its hunger or health is not full and have that state persisted for multiplayer sync.

### Description
- Add Llama inventory and hunger state to friendly records by initializing `llamaInventory`, `llamaHunger`, and `llamaMaxHunger` in `createLlamaRecord` and restoring them when spawning or syncing in `friendlyNpcManager.js`.
- Implement inventory helpers in `friendlyNpcManager.js`: `normalizeLlamaInventory`, `getLlamaInventory`, `addLlamaInventoryItem`, `removeLlamaInventoryItem`, `summarizeLlamaInventory`, and hunger helpers `getLlamaHunger` / `setLlamaHunger` to manage the Llama's inventory and hunger.
- Route world pickup collection through a non-player collector by adding `collectPickupForLlama` in `app/bootstrapGameApp.js` and wiring `createFriendlyNpcManager` to use it, so collected food is removed from the world and returned as a structured result (item id, amount, recovery values) instead of adding to the host inventory.
- When the Llama collects food, store it in the Llama inventory, then immediately attempt to consume it via `maybeLlamaEatCollectedFood` (which removes the item from the Llama inventory and applies health/hunger recovery); force a persistence update for the Llama state by calling `persistFriendlyState` with `{ force: true }` after collection.
- Persist the Llama fields by adding `llamaInventory`, `llamaHunger`, and `llamaMaxHunger` to the payload in `npcPersistence.js` and extend `persistState` to accept a `force` flag to bypass position-throttling when immediate save is required.

### Testing
- Performed static checks with `node --check friendlyNpcManager.js`, `node --check npcPersistence.js`, and `node --check app/bootstrapGameApp.js`, all of which succeeded. 
- Built the production bundle with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b54ee7f9483319c3a448652800349)