### PR TITLE
Add dynamic road lights for night mode

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -146,11 +146,10 @@ if ('serviceWorker' in navigator) {
   });
 }
 
-const ROAD_LIGHT_RING_COUNT = 12;
-const ROAD_LIGHT_SIDE_OFFSET_METERS = 6;
-const ROAD_LIGHT_MIN_SPACING_METERS = 10;
-const ROAD_LIGHT_TARGET_SPACING_METERS = 10;
-const ROAD_LIGHT_MIN_DISTANCE_FROM_PLAYER_METERS = 30;
+const ROAD_LIGHT_GRID_SIZE = 4;
+const ROAD_LIGHT_GRID_COUNT = ROAD_LIGHT_GRID_SIZE * ROAD_LIGHT_GRID_SIZE;
+const ROAD_LIGHT_GRID_SPACING_METERS = 20;
+const ROAD_LIGHT_SHIFT_DISTANCE_METERS = ROAD_LIGHT_GRID_SPACING_METERS * 1.25;
 const ROAD_LIGHT_MODEL_URL = '/assets/props/road_light.glb';
 const ROAD_LIGHT_POINT_LIGHT_CONFIG = Object.freeze({
   color: 0xfff1c1,
@@ -13258,11 +13257,9 @@ async function initCore(runtimeContext) {
   const roadLightPool = [];
   const roadLightScratch = {
     playerPos: new THREE.Vector3(),
-    tangent: new THREE.Vector3(),
-    samplePos: new THREE.Vector3(),
-    toPlayer: new THREE.Vector3(),
-    side: new THREE.Vector3(),
-    spawnPos: new THREE.Vector3()
+    playerMove: new THREE.Vector3(),
+    spawnPos: new THREE.Vector3(),
+    lastPlayerPos: null
   };
 
   const isNightDisplayMode = () => {
@@ -13295,16 +13292,6 @@ async function initCore(runtimeContext) {
     return roadLightTemplatePromise;
   };
 
-  const getRoadStamps = () => {
-    const stamps = [];
-    mapRenderer?.group?.traverse?.((child) => {
-      const stamp = child?.userData?.roadStamp;
-      if (!stamp?.points || stamp.points.length < 2) return;
-      stamps.push(stamp);
-    });
-    return stamps;
-  };
-
   const updateRoadLightsNearPlayer = () => {
     if (!scene || !playerModel?.position || !isNightDisplayMode()) {
       clearRoadLightPool();
@@ -13315,67 +13302,38 @@ async function initCore(runtimeContext) {
       void ensureRoadLightTemplate();
       return;
     }
-    const stamps = getRoadStamps();
-    if (!stamps.length) {
-      clearRoadLightPool();
-      return;
-    }
     const playerPos = roadLightScratch.playerPos.copy(playerModel.position);
-    const side = roadLightScratch.side;
-    const toPlayer = roadLightScratch.toPlayer;
-    const tangent = roadLightScratch.tangent;
-    const samplePos = roadLightScratch.samplePos;
     const spawnPos = roadLightScratch.spawnPos;
-    const sampled = [];
-    for (const stamp of stamps) {
-      const points = stamp.points;
-      for (let i = 0; i < points.length - 1; i += 1) {
-        const start = points[i];
-        const end = points[i + 1];
-        tangent.set(end.x - start.x, 0, end.z - start.z);
-        const segmentLength = tangent.length();
-        if (segmentLength < 0.001) continue;
-        tangent.divideScalar(segmentLength);
-        for (let distance = 0; distance <= segmentLength; distance += ROAD_LIGHT_TARGET_SPACING_METERS) {
-          samplePos.set(start.x + tangent.x * distance, 0, start.z + tangent.z * distance);
-          const terrainY = getTerrainHeight(samplePos.x, samplePos.z);
-          samplePos.y = Number.isFinite(terrainY) ? terrainY : playerPos.y;
-          const distToPlayer = samplePos.distanceTo(playerPos);
-          if (distToPlayer < ROAD_LIGHT_MIN_DISTANCE_FROM_PLAYER_METERS) continue;
-          sampled.push({
-            center: samplePos.clone(),
-            tangent: tangent.clone(),
-            distanceToPlayer: distToPlayer
-          });
-        }
-      }
+    const playerMove = roadLightScratch.playerMove;
+    if (roadLightScratch.lastPlayerPos) {
+      playerMove.copy(playerPos).sub(roadLightScratch.lastPlayerPos).setY(0);
+    } else {
+      playerMove.set(0, 0, 0);
     }
-    if (!sampled.length) {
-      clearRoadLightPool();
-      return;
+    if (playerMove.lengthSq() > 0.0001) {
+      playerMove.normalize();
     }
-    sampled.sort((a, b) => a.distanceToPlayer - b.distanceToPlayer);
-    const selected = [];
-    for (const entry of sampled) {
-      const isTooClose = selected.some((existing) => existing.center.distanceTo(entry.center) < ROAD_LIGHT_MIN_SPACING_METERS);
-      if (isTooClose) continue;
-      selected.push(entry);
-      if (selected.length >= ROAD_LIGHT_RING_COUNT / 2) break;
+    if (!roadLightScratch.lastPlayerPos) {
+      roadLightScratch.lastPlayerPos = playerPos.clone();
     }
-    if (!selected.length) {
-      clearRoadLightPool();
-      return;
-    }
+    roadLightScratch.lastPlayerPos.copy(playerPos);
+
+    // Shift the grid one cell in the movement direction once player crosses threshold.
+    const shouldShiftForward = playerMove.lengthSq() > 0.01;
+    const shiftOffsetX = shouldShiftForward ? playerMove.x * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
+    const shiftOffsetZ = shouldShiftForward ? playerMove.z * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
+    const gridCenterX = Math.round((playerPos.x + shiftOffsetX) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
+    const gridCenterZ = Math.round((playerPos.z + shiftOffsetZ) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
+    const halfSpan = ((ROAD_LIGHT_GRID_SIZE - 1) * ROAD_LIGHT_GRID_SPACING_METERS) * 0.5;
 
     let poolIndex = 0;
-    for (const entry of selected) {
-      toPlayer.copy(playerPos).sub(entry.center);
-      const sideSign = Math.sign(entry.tangent.x * toPlayer.z - entry.tangent.z * toPlayer.x) || 1;
-      side.set(-entry.tangent.z, 0, entry.tangent.x);
-      for (const offsetSign of [sideSign, -sideSign]) {
-        spawnPos.copy(entry.center).addScaledVector(side, ROAD_LIGHT_SIDE_OFFSET_METERS * offsetSign);
+    for (let row = 0; row < ROAD_LIGHT_GRID_SIZE; row += 1) {
+      for (let col = 0; col < ROAD_LIGHT_GRID_SIZE; col += 1) {
+        const x = gridCenterX + (col * ROAD_LIGHT_GRID_SPACING_METERS - halfSpan);
+        const z = gridCenterZ + (row * ROAD_LIGHT_GRID_SPACING_METERS - halfSpan);
+        spawnPos.set(x, 0, z);
         const spawnTerrain = getTerrainHeight(spawnPos.x, spawnPos.z);
-        spawnPos.y = Number.isFinite(spawnTerrain) ? spawnTerrain : entry.center.y;
+        spawnPos.y = Number.isFinite(spawnTerrain) ? spawnTerrain : playerPos.y;
         let roadLight = roadLightPool[poolIndex];
         if (!roadLight) {
           const model = template.clone(true);
@@ -13394,11 +13352,8 @@ async function initCore(runtimeContext) {
         }
         roadLight.model.visible = true;
         roadLight.model.position.copy(spawnPos);
-        roadLight.model.rotation.y = Math.atan2(entry.tangent.x, entry.tangent.z);
         poolIndex += 1;
-        if (poolIndex >= ROAD_LIGHT_RING_COUNT) break;
       }
-      if (poolIndex >= ROAD_LIGHT_RING_COUNT) break;
     }
 
     for (let i = poolIndex; i < roadLightPool.length; i += 1) {

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -146,10 +146,11 @@ if ('serviceWorker' in navigator) {
   });
 }
 
-const ROAD_LIGHT_GRID_SIZE = 4;
+const ROAD_LIGHT_GRID_SIZE = 3;
 const ROAD_LIGHT_GRID_COUNT = ROAD_LIGHT_GRID_SIZE * ROAD_LIGHT_GRID_SIZE;
-const ROAD_LIGHT_GRID_SPACING_METERS = 20;
+const ROAD_LIGHT_GRID_SPACING_METERS = 40;
 const ROAD_LIGHT_SHIFT_DISTANCE_METERS = ROAD_LIGHT_GRID_SPACING_METERS * 1.25;
+const ROAD_LIGHT_REPOSITION_INTERVAL_MS = 7000;
 const ROAD_LIGHT_MODEL_URL = '/assets/props/road_light.glb';
 const ROAD_LIGHT_POINT_LIGHT_CONFIG = Object.freeze({
   color: 0xfff1c1,
@@ -13259,7 +13260,10 @@ async function initCore(runtimeContext) {
     playerPos: new THREE.Vector3(),
     playerMove: new THREE.Vector3(),
     spawnPos: new THREE.Vector3(),
-    lastPlayerPos: null
+    lastPlayerPos: null,
+    gridCenterX: null,
+    gridCenterZ: null,
+    nextRepositionAtMs: 0
   };
 
   const isNightDisplayMode = () => {
@@ -13303,6 +13307,7 @@ async function initCore(runtimeContext) {
       return;
     }
     const playerPos = roadLightScratch.playerPos.copy(playerModel.position);
+    const nowMs = performance.now();
     const spawnPos = roadLightScratch.spawnPos;
     const playerMove = roadLightScratch.playerMove;
     if (roadLightScratch.lastPlayerPos) {
@@ -13318,12 +13323,22 @@ async function initCore(runtimeContext) {
     }
     roadLightScratch.lastPlayerPos.copy(playerPos);
 
-    // Shift the grid one cell in the movement direction once player crosses threshold.
-    const shouldShiftForward = playerMove.lengthSq() > 0.01;
-    const shiftOffsetX = shouldShiftForward ? playerMove.x * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
-    const shiftOffsetZ = shouldShiftForward ? playerMove.z * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
-    const gridCenterX = Math.round((playerPos.x + shiftOffsetX) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
-    const gridCenterZ = Math.round((playerPos.z + shiftOffsetZ) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
+    if (
+      roadLightScratch.gridCenterX == null
+      || roadLightScratch.gridCenterZ == null
+      || nowMs >= roadLightScratch.nextRepositionAtMs
+    ) {
+      const shouldShiftForward = playerMove.lengthSq() > 0.01;
+      const shiftOffsetX = shouldShiftForward ? playerMove.x * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
+      const shiftOffsetZ = shouldShiftForward ? playerMove.z * ROAD_LIGHT_SHIFT_DISTANCE_METERS : 0;
+      roadLightScratch.gridCenterX =
+        Math.round((playerPos.x + shiftOffsetX) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
+      roadLightScratch.gridCenterZ =
+        Math.round((playerPos.z + shiftOffsetZ) / ROAD_LIGHT_GRID_SPACING_METERS) * ROAD_LIGHT_GRID_SPACING_METERS;
+      roadLightScratch.nextRepositionAtMs = nowMs + ROAD_LIGHT_REPOSITION_INTERVAL_MS;
+    }
+    const gridCenterX = roadLightScratch.gridCenterX;
+    const gridCenterZ = roadLightScratch.gridCenterZ;
     const halfSpan = ((ROAD_LIGHT_GRID_SIZE - 1) * ROAD_LIGHT_GRID_SPACING_METERS) * 0.5;
 
     let poolIndex = 0;

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -146,6 +146,20 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+const ROAD_LIGHT_RING_COUNT = 12;
+const ROAD_LIGHT_SIDE_OFFSET_METERS = 6;
+const ROAD_LIGHT_MIN_SPACING_METERS = 10;
+const ROAD_LIGHT_TARGET_SPACING_METERS = 10;
+const ROAD_LIGHT_MIN_DISTANCE_FROM_PLAYER_METERS = 30;
+const ROAD_LIGHT_MODEL_URL = '/assets/props/road_light.glb';
+const ROAD_LIGHT_POINT_LIGHT_CONFIG = Object.freeze({
+  color: 0xfff1c1,
+  intensity: 2.6,
+  distance: 40,
+  decay: 0.5,
+  yOffset: 3.4
+});
+
 const DEFAULT_CHARACTER_MODEL = "/models/base_character_2.fbx";
 const MAX_MONSTERS_TOTAL = 24;
 const MAX_TRAVEL_SPAWN_CHARACTERS_TOTAL = 32;
@@ -13238,6 +13252,160 @@ async function initCore(runtimeContext) {
     }
   };
 
+  const roadLightLoader = new GLTFLoader();
+  let roadLightTemplate = null;
+  let roadLightTemplatePromise = null;
+  const roadLightPool = [];
+  const roadLightScratch = {
+    playerPos: new THREE.Vector3(),
+    tangent: new THREE.Vector3(),
+    samplePos: new THREE.Vector3(),
+    toPlayer: new THREE.Vector3(),
+    side: new THREE.Vector3(),
+    spawnPos: new THREE.Vector3()
+  };
+
+  const isNightDisplayMode = () => {
+    const effectiveMode = displaySettings.mode === 'auto'
+      ? (lastAutoMode || getAutoMode())
+      : displaySettings.mode;
+    return effectiveMode === 'night';
+  };
+
+  const clearRoadLightPool = () => {
+    roadLightPool.forEach((entry) => {
+      if (!entry?.model) return;
+      entry.model.visible = false;
+    });
+  };
+
+  const ensureRoadLightTemplate = async () => {
+    if (roadLightTemplate) return roadLightTemplate;
+    if (!roadLightTemplatePromise) {
+      roadLightTemplatePromise = roadLightLoader.loadAsync(ROAD_LIGHT_MODEL_URL)
+        .then((gltf) => {
+          roadLightTemplate = gltf?.scene || null;
+          return roadLightTemplate;
+        })
+        .catch((error) => {
+          console.warn('Failed to load road light template.', error);
+          return null;
+        });
+    }
+    return roadLightTemplatePromise;
+  };
+
+  const getRoadStamps = () => {
+    const stamps = [];
+    mapRenderer?.group?.traverse?.((child) => {
+      const stamp = child?.userData?.roadStamp;
+      if (!stamp?.points || stamp.points.length < 2) return;
+      stamps.push(stamp);
+    });
+    return stamps;
+  };
+
+  const updateRoadLightsNearPlayer = () => {
+    if (!scene || !playerModel?.position || !isNightDisplayMode()) {
+      clearRoadLightPool();
+      return;
+    }
+    const template = roadLightTemplate;
+    if (!template) {
+      void ensureRoadLightTemplate();
+      return;
+    }
+    const stamps = getRoadStamps();
+    if (!stamps.length) {
+      clearRoadLightPool();
+      return;
+    }
+    const playerPos = roadLightScratch.playerPos.copy(playerModel.position);
+    const side = roadLightScratch.side;
+    const toPlayer = roadLightScratch.toPlayer;
+    const tangent = roadLightScratch.tangent;
+    const samplePos = roadLightScratch.samplePos;
+    const spawnPos = roadLightScratch.spawnPos;
+    const sampled = [];
+    for (const stamp of stamps) {
+      const points = stamp.points;
+      for (let i = 0; i < points.length - 1; i += 1) {
+        const start = points[i];
+        const end = points[i + 1];
+        tangent.set(end.x - start.x, 0, end.z - start.z);
+        const segmentLength = tangent.length();
+        if (segmentLength < 0.001) continue;
+        tangent.divideScalar(segmentLength);
+        for (let distance = 0; distance <= segmentLength; distance += ROAD_LIGHT_TARGET_SPACING_METERS) {
+          samplePos.set(start.x + tangent.x * distance, 0, start.z + tangent.z * distance);
+          const terrainY = getTerrainHeight(samplePos.x, samplePos.z);
+          samplePos.y = Number.isFinite(terrainY) ? terrainY : playerPos.y;
+          const distToPlayer = samplePos.distanceTo(playerPos);
+          if (distToPlayer < ROAD_LIGHT_MIN_DISTANCE_FROM_PLAYER_METERS) continue;
+          sampled.push({
+            center: samplePos.clone(),
+            tangent: tangent.clone(),
+            distanceToPlayer: distToPlayer
+          });
+        }
+      }
+    }
+    if (!sampled.length) {
+      clearRoadLightPool();
+      return;
+    }
+    sampled.sort((a, b) => a.distanceToPlayer - b.distanceToPlayer);
+    const selected = [];
+    for (const entry of sampled) {
+      const isTooClose = selected.some((existing) => existing.center.distanceTo(entry.center) < ROAD_LIGHT_MIN_SPACING_METERS);
+      if (isTooClose) continue;
+      selected.push(entry);
+      if (selected.length >= ROAD_LIGHT_RING_COUNT / 2) break;
+    }
+    if (!selected.length) {
+      clearRoadLightPool();
+      return;
+    }
+
+    let poolIndex = 0;
+    for (const entry of selected) {
+      toPlayer.copy(playerPos).sub(entry.center);
+      const sideSign = Math.sign(entry.tangent.x * toPlayer.z - entry.tangent.z * toPlayer.x) || 1;
+      side.set(-entry.tangent.z, 0, entry.tangent.x);
+      for (const offsetSign of [sideSign, -sideSign]) {
+        spawnPos.copy(entry.center).addScaledVector(side, ROAD_LIGHT_SIDE_OFFSET_METERS * offsetSign);
+        const spawnTerrain = getTerrainHeight(spawnPos.x, spawnPos.z);
+        spawnPos.y = Number.isFinite(spawnTerrain) ? spawnTerrain : entry.center.y;
+        let roadLight = roadLightPool[poolIndex];
+        if (!roadLight) {
+          const model = template.clone(true);
+          model.scale.setScalar(1);
+          const lampLight = new THREE.PointLight(
+            ROAD_LIGHT_POINT_LIGHT_CONFIG.color,
+            ROAD_LIGHT_POINT_LIGHT_CONFIG.intensity,
+            ROAD_LIGHT_POINT_LIGHT_CONFIG.distance,
+            ROAD_LIGHT_POINT_LIGHT_CONFIG.decay
+          );
+          lampLight.position.set(0, ROAD_LIGHT_POINT_LIGHT_CONFIG.yOffset, 0);
+          model.add(lampLight);
+          scene.add(model);
+          roadLight = { model };
+          roadLightPool[poolIndex] = roadLight;
+        }
+        roadLight.model.visible = true;
+        roadLight.model.position.copy(spawnPos);
+        roadLight.model.rotation.y = Math.atan2(entry.tangent.x, entry.tangent.z);
+        poolIndex += 1;
+        if (poolIndex >= ROAD_LIGHT_RING_COUNT) break;
+      }
+      if (poolIndex >= ROAD_LIGHT_RING_COUNT) break;
+    }
+
+    for (let i = poolIndex; i < roadLightPool.length; i += 1) {
+      roadLightPool[i].model.visible = false;
+    }
+  };
+
   function animate() {
     requestAnimationFrame(animate);
     const frameStartMs = performance.now();
@@ -13332,6 +13500,7 @@ async function initCore(runtimeContext) {
     homeSystem?.syncHomePlacement?.();
     updateGroundTiles(playerPosition);
     natureController?.update(playerPosition);
+    updateRoadLightsNearPlayer();
     if (shouldUpdatePickupTiles(playerPosition)) {
       updatePickupTiles(playerPosition);
     }


### PR DESCRIPTION
### Motivation
- Improve night-time ambience by spawning a ring of road lights along the road nearest the player so the scene feels lit and dynamic in dark/display night mode. 
- Keep lights performant and visually consistent by limiting count, enforcing spacing, and reusing instances instead of continuously creating/destroying models.

### Description
- Added configurable constants and a point-light config to drive behavior: `ROAD_LIGHT_RING_COUNT`, spacing, offsets, and the `ROAD_LIGHT_POINT_LIGHT_CONFIG` used by the lights.
- Implemented lazy GLB template loading and a simple pool via `ensureRoadLightTemplate`, `roadLightPool`, and `clearRoadLightPool` to reuse cloned models and point lights. 
- Implemented road sampling and selection logic in `getRoadStamps` and `updateRoadLightsNearPlayer` that samples road `roadStamp.points`, filters candidates to be >=30m from the player and >=10m from each other, then places paired lights on both sides of the road (roughly 6 per side, up to 12 total). 
- Hooked the updater into the main frame loop so lights are updated every frame in night mode and automatically hidden when not in night mode, and added a small scratch object pool for per-frame math to reduce allocations. 

### Testing
- Ran the production build with `npm run build` and the build completed successfully. 
- Verified the code compiles and bundles with Vite (no runtime tests were run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b6079c294833199588883f5854916)