### PR TITLE
Add host-centric networking topology flag and relay routing

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -208,6 +208,17 @@ const LOW_END_BUCKET_INTERVALS = Object.freeze({
   remoteLabels: 2,
   audio: 3
 });
+const NETWORK_TOPOLOGY_MODE = (import.meta.env.VITE_NETWORK_TOPOLOGY_MODE || 'star').toLowerCase() === 'mesh'
+  ? 'mesh'
+  : 'star';
+const HOST_CRITICAL_MESSAGE_TYPES = new Set([
+  'entityControl',
+  'entityStates',
+  'attackMonster',
+  'spawnRequest',
+  'projectile',
+  'inventoryThrowProjectile'
+]);
 
 appContext.debugFlags.PERF = PERF;
 appContext.debugFlags.DEBUG_CONSOLE = false;
@@ -991,7 +1002,7 @@ async function initCore(runtimeContext) {
       return false;
     }
     if (!coalesceKey) {
-      multiplayer.send(payload);
+      sendNetworkPayload(payload);
       recordNetSent(1);
       return true;
     }
@@ -1005,8 +1016,20 @@ async function initCore(runtimeContext) {
     if (!multiplayer || netSendQueue.size === 0) return;
     const pending = Array.from(netSendQueue.values());
     netSendQueue.clear();
-    pending.forEach((payload) => multiplayer.send(payload));
+    pending.forEach((payload) => sendNetworkPayload(payload));
     recordNetSent(pending.length);
+  };
+  const sendNetworkPayload = (payload) => {
+    if (!multiplayer || !payload) return false;
+    const isHostCritical = NETWORK_TOPOLOGY_MODE === 'star'
+      && HOST_CRITICAL_MESSAGE_TYPES.has(payload.type);
+    const hostId = multiplayer.getHostId?.();
+    if (!multiplayer.isHost && isHostCritical && hostId) {
+      multiplayer.sendTo(hostId, payload);
+      return true;
+    }
+    multiplayer.send(payload);
+    return true;
   };
   const tickNetStats = (nowMs) => {
     const elapsed = nowMs - netStats.windowStartMs;
@@ -1016,9 +1039,11 @@ async function initCore(runtimeContext) {
     netStats.windowStartMs = nowMs;
     window.netRuntimeStats = {
       msgsPerSecond: Number(netStats.messagesPerSecond.toFixed(2)),
+      rttMs: Number.isFinite(multiplayer?.lastPingMs) ? multiplayer.lastPingMs : null,
       coalesced: netStats.coalesced,
       dropped: netStats.dropped,
       queueDepth: netSendQueue.size,
+      topologyMode: NETWORK_TOPOLOGY_MODE,
       intervals: {
         presenceSendIntervalMs,
         entityBroadcastIntervalMs,

--- a/peerConnection.js
+++ b/peerConnection.js
@@ -31,6 +31,7 @@ const VALID_MESSAGE_TYPES = new Set([
 ]);
 const MAX_PENDING_PAYLOADS = 75;
 const COALESCED_PAYLOAD_TYPES = new Set(['entitySnapshot', 'entityStates']);
+const NETWORK_TOPOLOGY_MODE = (import.meta.env.VITE_NETWORK_TOPOLOGY_MODE || 'star').toLowerCase();
 
 export class Multiplayer {
   constructor(playerName, onPeerData) {
@@ -59,6 +60,7 @@ export class Multiplayer {
     this.unsubscribeRoomListener = null;
     this.hostRecalcTimer = null;
     this.roomPeerIds = [];
+    this.networkTopologyMode = NETWORK_TOPOLOGY_MODE === 'mesh' ? 'mesh' : 'star';
     
     this.initPeer(); // Start async setup
   }
@@ -268,11 +270,22 @@ export class Multiplayer {
       }
     }
 
-    for (const peerId of orderedPeerIds) {
+    const desiredConnections = this.getDesiredPeerConnections(orderedPeerIds, hostPeerId);
+    for (const peerId of desiredConnections) {
       if (peerId !== this.id && !this.connections[peerId] && this.shouldAttemptConnection(peerId)) {
         this.connectToPeer(peerId);
       }
     }
+  }
+  getDesiredPeerConnections(orderedPeerIds, hostPeerId) {
+    if (!Array.isArray(orderedPeerIds)) return [];
+    if (this.networkTopologyMode === 'mesh') {
+      return orderedPeerIds.filter(peerId => peerId !== this.id);
+    }
+    if (!hostPeerId || hostPeerId === this.id) {
+      return orderedPeerIds.filter(peerId => peerId !== this.id);
+    }
+    return [hostPeerId];
   }
 
   resetRealtimeListeners() {
@@ -482,6 +495,10 @@ export class Multiplayer {
 
   getHostId() {
     return this.currentHostId;
+  }
+
+  getTopologyMode() {
+    return this.networkTopologyMode;
   }
 
   sendTo(peerId, data) {


### PR DESCRIPTION
### Motivation
- Reduce direct peer-to-peer links for gameplay-critical messages and enable A/B testing of star (host-relay) vs mesh topologies to measure RTT and messages/sec.
- Ensure gameplay-critical intents and authoritative replication (control/state, combat, spawn, projectiles) flow through a single host when configured to avoid desyncs.
- Expose runtime network metrics for diagnostics and experiment tracking so topology impact can be measured via `window.netRuntimeStats`.

### Description
- Added a topology feature flag driven by `VITE_NETWORK_TOPOLOGY_MODE` and normalized into runtime state as `networkTopologyMode` in `peerConnection.js` and `app/bootstrapGameApp.js` (defaults to `star`, optional `mesh`).
- In `peerConnection.js` adjusted `recalculateHostAndPeers()` to use a new `getDesiredPeerConnections()` helper so `mesh` mode connects to all peers while `star` mode connects non-host peers primarily to the current host, and added `getTopologyMode()` accessor.
- In `app/bootstrapGameApp.js` introduced `HOST_CRITICAL_MESSAGE_TYPES` and a `sendNetworkPayload()` router used by `queueNetMessage()`/flush to route critical payloads (`entityControl`, `entityStates`, `attackMonster`, `spawnRequest`, `projectile`, `inventoryThrowProjectile`) to the host via `multiplayer.sendTo(hostId, ...)` when in `star` mode and not host, otherwise fall back to `multiplayer.send()`.
- Extended `window.netRuntimeStats` with `rttMs` and `topologyMode` to enable easy measurement of latency and message rates under different topologies.

### Testing
- Ran a production build with `npm run -s build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7b95a66c8331969368ad6f5b38c2)