### PR TITLE
Add temporary placeholder handling for in-flight map tiles

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11340,6 +11340,7 @@ async function initCore(runtimeContext) {
 
   const tileRenderBounds = new Map();
   const renderedTileGeojson = new Map();
+  const tilePlaceholders = new Map();
   const isSameRenderOrigin = (nextOrigin, prevOrigin) => {
     if (!nextOrigin || !prevOrigin) {
       return nextOrigin === prevOrigin;
@@ -11375,6 +11376,50 @@ async function initCore(runtimeContext) {
       centerLon: (minLon + maxLon) / 2
     };
     return currentRenderOrigin;
+  };
+
+  const createPlaceholderTileMesh = (tile) => {
+    if (!tile || !scene) return null;
+    const tileCenterX = (tile.x + 0.5) * TILE_SIZE_METERS;
+    const tileCenterZ = -(tile.y + 0.5) * TILE_SIZE_METERS;
+    const planeSize = TILE_SIZE_METERS * 0.96;
+    const geometry = new THREE.PlaneGeometry(planeSize, planeSize, 1, 1);
+    const material = new THREE.MeshStandardMaterial({
+      color: 0x3a5a3f,
+      roughness: 1,
+      metalness: 0,
+      transparent: true,
+      opacity: 0.33,
+      depthWrite: false
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.position.set(
+      tileCenterX,
+      getTerrainHeight(tileCenterX, tileCenterZ) + 0.03,
+      tileCenterZ
+    );
+    mesh.renderOrder = 1;
+    return mesh;
+  };
+
+  const ensureTilePlaceholder = (tileKey, tile) => {
+    if (!tileKey || tilePlaceholders.has(tileKey)) return;
+    const placeholder = createPlaceholderTileMesh(tile);
+    if (!placeholder) return;
+    placeholder.name = `tile-placeholder-${tileKey}`;
+    scene.add(placeholder);
+    tilePlaceholders.set(tileKey, placeholder);
+  };
+
+  const removeTilePlaceholder = (tileKey) => {
+    if (!tileKey) return;
+    const placeholder = tilePlaceholders.get(tileKey);
+    if (!placeholder) return;
+    scene.remove(placeholder);
+    placeholder.geometry?.dispose?.();
+    placeholder.material?.dispose?.();
+    tilePlaceholders.delete(tileKey);
   };
 
   const updateTileRenderBounds = (tileKey, geojson) => {
@@ -11553,6 +11598,9 @@ async function initCore(runtimeContext) {
   window.clearTileCache = () => {
     tileCache.cache.clear();
     groundTiles.clear();
+    for (const tileKey of Array.from(tilePlaceholders.keys())) {
+      removeTilePlaceholder(tileKey);
+    }
     clearCache().catch((error) => console.warn('Failed to clear persistent tile cache:', error));
     rebuildMapFromCache();
   };
@@ -11638,6 +11686,7 @@ async function initCore(runtimeContext) {
 
   const updateTileMeshesImmediate = (tileKey, geojson) => {
     if (!tileKey || !geojson || !mapRenderer || !buildingsRenderer) return;
+    removeTilePlaceholder(tileKey);
     const previousGeojson = renderedTileGeojson.get(tileKey);
     if (previousGeojson === geojson) return;
     renderedTileGeojson.set(tileKey, geojson);
@@ -11741,6 +11790,7 @@ async function initCore(runtimeContext) {
         mapRenderer.removeTile?.(key);
         buildingsRenderer.removeTile?.(key);
         clearTerrainStampsForTile(key);
+        removeTilePlaceholder(key);
         renderedTileGeojson.delete(key);
         tileRenderBounds.delete(key);
         deferredTileUpdates.delete(key);
@@ -11770,6 +11820,7 @@ async function initCore(runtimeContext) {
     if (!tileCenter) return;
 
     mapFetchInFlight.add(tileKey);
+    ensureTilePlaceholder(tileKey, tile);
     let geojson;
     try {
       const overpassData = await fetchOSMData(tileCenter.lat, tileCenter.lon, TILE_FETCH_RADIUS_METERS, {
@@ -11788,6 +11839,7 @@ async function initCore(runtimeContext) {
         message: error?.message || 'OSM fetch failed',
         timestamp: Date.now()
       };
+      removeTilePlaceholder(tileKey);
       mapFetchInFlight.delete(tileKey);
       return;
     }

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11341,6 +11341,7 @@ async function initCore(runtimeContext) {
   const tileRenderBounds = new Map();
   const renderedTileGeojson = new Map();
   const tilePlaceholders = new Map();
+  const tilePlaceholderOps = new Map();
   const isSameRenderOrigin = (nextOrigin, prevOrigin) => {
     if (!nextOrigin || !prevOrigin) {
       return nextOrigin === prevOrigin;
@@ -11408,18 +11409,36 @@ async function initCore(runtimeContext) {
     const placeholder = createPlaceholderTileMesh(tile);
     if (!placeholder) return;
     placeholder.name = `tile-placeholder-${tileKey}`;
-    scene.add(placeholder);
-    tilePlaceholders.set(tileKey, placeholder);
+    tilePlaceholderOps.set(tileKey, { type: 'add', mesh: placeholder });
+    requestAnimationFrame(() => {
+      const op = tilePlaceholderOps.get(tileKey);
+      if (!op || op.type !== 'add' || op.mesh !== placeholder) return;
+      tilePlaceholderOps.delete(tileKey);
+      scene.add(placeholder);
+      tilePlaceholders.set(tileKey, placeholder);
+    });
   };
 
   const removeTilePlaceholder = (tileKey) => {
     if (!tileKey) return;
+    const pendingOp = tilePlaceholderOps.get(tileKey);
+    if (pendingOp?.type === 'add') {
+      pendingOp.mesh?.geometry?.dispose?.();
+      pendingOp.mesh?.material?.dispose?.();
+      tilePlaceholderOps.delete(tileKey);
+    }
     const placeholder = tilePlaceholders.get(tileKey);
     if (!placeholder) return;
-    scene.remove(placeholder);
-    placeholder.geometry?.dispose?.();
-    placeholder.material?.dispose?.();
-    tilePlaceholders.delete(tileKey);
+    tilePlaceholderOps.set(tileKey, { type: 'remove', mesh: placeholder });
+    requestAnimationFrame(() => {
+      const op = tilePlaceholderOps.get(tileKey);
+      if (!op || op.type !== 'remove' || op.mesh !== placeholder) return;
+      tilePlaceholderOps.delete(tileKey);
+      scene.remove(placeholder);
+      placeholder.geometry?.dispose?.();
+      placeholder.material?.dispose?.();
+      tilePlaceholders.delete(tileKey);
+    });
   };
 
   const updateTileRenderBounds = (tileKey, geojson) => {


### PR DESCRIPTION
### Motivation

- Provide an immediate low-detail visual for missing map tiles while OSM fetches are in-flight so the world doesn't show gaps.  
- Ensure temporary proxies are removed or upgraded when real tile geojson arrives to avoid visual duplication or stale overlays.  
- Clean up placeholders on tile eviction and cache clear to prevent orphaned meshes and memory leaks.

### Description

- Added a `tilePlaceholders` map and placeholder lifecycle helpers `createPlaceholderTileMesh`, `ensureTilePlaceholder`, and `removeTilePlaceholder` in `app/bootstrapGameApp.js`.  
- Create a semi-transparent ground-plane proxy for a tile when a fetch starts by calling `ensureTilePlaceholder` in the `requestMapUpdate` fetch-start path.  
- Remove placeholder when the real tile is applied by calling `removeTilePlaceholder` at the start of `updateTileMeshesImmediate` so rendering proceeds through the normal `updateTileMeshes` flow.  
- Clean placeholders on tile eviction (`evictTiles` handling), on fetch failure, and when `window.clearTileCache` is invoked to avoid leftover meshes and resource leaks.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8651392c8331af2902cb91972379)