### PR TITLE
Pass stable dedupe key for OSM tile fetches

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -11773,7 +11773,8 @@ async function initCore(runtimeContext) {
     let geojson;
     try {
       const overpassData = await fetchOSMData(tileCenter.lat, tileCenter.lon, TILE_FETCH_RADIUS_METERS, {
-        staleDistanceMeters: TILE_SIZE_METERS * 2
+        staleDistanceMeters: TILE_SIZE_METERS * 2,
+        dedupeKeyOverride: tileKey
       });
       debugState.lastOsmFetchAt = Date.now();
       try {

--- a/osmClient.js
+++ b/osmClient.js
@@ -99,12 +99,15 @@ export async function fetchOSMData(lat, lon, radiusMeters, options = {}) {
   const staleDistanceMeters = Number.isFinite(options.staleDistanceMeters)
     ? options.staleDistanceMeters
     : DEFAULT_STALE_DISTANCE_METERS;
+  const dedupeKeyOverride = typeof options.dedupeKeyOverride === "string" && options.dedupeKeyOverride.length > 0
+    ? options.dedupeKeyOverride
+    : null;
 
   const response = await overpassRequestQueue.enqueue({
     lat,
     lon,
     staleDistanceMeters,
-    dedupeKey: buildDedupeKey(lat, lon, radiusMeters),
+    dedupeKey: dedupeKeyOverride ?? buildDedupeKey(lat, lon, radiusMeters),
     requestFn: () => performOverpassRequest(new URLSearchParams({ data: query })),
   });
 


### PR DESCRIPTION
### Motivation
- Tile fetches for the same map tile could use slightly different center coordinates and generate different dedupe keys, so a stable tile identifier improves Overpass request deduplication for tile workloads.

### Description
- Pass a stable tile identifier by adding `dedupeKeyOverride: tileKey` to the `fetchOSMData` call in `app/bootstrapGameApp.js`.
- Add support in `fetchOSMData` (`osmClient.js`) for an optional `options.dedupeKeyOverride` string and prefer it over `buildDedupeKey(lat, lon, radiusMeters)`, preserving the existing fallback behavior for callers that do not provide an override.

### Testing
- Verified the updated call site and function by printing the modified file ranges with `nl -ba` and inspecting the changes, which succeeded. 
- Confirmed repository changes were staged and committed with `git add` and `git commit`, which returned a successful commit message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c8e641b908331b5fae3bc77474528)