### PR TITLE
Handle Overpass throttling with typed errors and tile-safe retries

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -46,7 +46,7 @@ import { removeRigidBodySafely } from '../physics/rapierSafety.js';
 import { createStaticBoxColliderForObject, removeStaticBoxCollider, syncStaticBoxColliderForObject } from '../physics/staticBoxCollider.js';
 import { configureSpawnAlignment, getSpawnPosition, getSpawnY } from '../spawnUtils.js';
 import { createLocationProvider } from '../location.js';
-import { fetchOSMData } from '../osmClient.js';
+import { fetchOSMData, isOverpassThrottleError } from '../osmClient.js';
 import { overpassToGeoJSON } from '../osmGeoJson.js';
 import { createMapRenderer } from '../environment/mapRender.js';
 import { createBuildingsRenderer } from '../environment/buildingsRender.js';
@@ -10974,6 +10974,8 @@ async function initCore(runtimeContext) {
     return false;
   };
   const mapFetchInFlight = new Set();
+  const tileRetryTimeouts = new Map();
+  let mapRateLimitedUntil = 0;
   const debugPerf = {
     monsters: 0,
     ammoPickups: 0,
@@ -11771,6 +11773,7 @@ async function initCore(runtimeContext) {
 
     mapFetchInFlight.add(tileKey);
     let geojson;
+    const priorGeojson = tileCache.cache.get(tileKey)?.geojson ?? renderedTileGeojson.get(tileKey) ?? null;
     try {
       const overpassData = await fetchOSMData(tileCenter.lat, tileCenter.lon, TILE_FETCH_RADIUS_METERS, {
         staleDistanceMeters: TILE_SIZE_METERS * 2,
@@ -11784,6 +11787,30 @@ async function initCore(runtimeContext) {
         geojson = prefilterGeojson(overpassToGeoJSON(overpassData));
       }
     } catch (error) {
+      const isThrottle = isOverpassThrottleError(error);
+      if (isThrottle) {
+        const baseDelayMs = Number.isFinite(error?.retryAfterMs) && error.retryAfterMs > 0
+          ? error.retryAfterMs
+          : 4000;
+        const jitterMs = Math.floor(Math.random() * 1500);
+        const retryDelayMs = baseDelayMs + jitterMs;
+        mapRateLimitedUntil = Math.max(mapRateLimitedUntil, Date.now() + retryDelayMs);
+        locationState.state = 'rate_limited';
+        locationState.message = 'map data temporarily rate-limited';
+        if (tileRetryTimeouts.has(tileKey)) {
+          clearTimeout(tileRetryTimeouts.get(tileKey));
+        }
+        const timeoutId = setTimeout(() => {
+          tileRetryTimeouts.delete(tileKey);
+          if (!PERF.disableMapUpdates) {
+            void requestMapUpdate(location);
+          }
+        }, retryDelayMs);
+        tileRetryTimeouts.set(tileKey, timeoutId);
+        if (priorGeojson) {
+          updateTileMeshes(tileKey, priorGeojson);
+        }
+      }
       console.warn('OSM fetch failed:', error);
       debugState.lastError = {
         message: error?.message || 'OSM fetch failed',
@@ -11803,6 +11830,10 @@ async function initCore(runtimeContext) {
         console.warn('Failed to persist tile cache:', error);
       });
       updateTileMeshes(tileKey, geojson);
+      if (Date.now() >= mapRateLimitedUntil && locationState.state === 'rate_limited') {
+        locationState.state = 'found';
+        locationState.message = null;
+      }
     } catch (error) {
       console.warn('OSM render failed:', error);
       debugState.lastError = {

--- a/osmClient.js
+++ b/osmClient.js
@@ -1,4 +1,4 @@
-import { overpassRequestQueue } from "./requestQueue.js";
+import { RequestThrottleError, overpassRequestQueue } from "./requestQueue.js";
 import { overpassToGeoJSON } from "./osmGeoJson.js";
 
 const OVERPASS_ENDPOINTS = import.meta.env.PROD
@@ -10,6 +10,20 @@ const OVERPASS_ENDPOINTS = import.meta.env.PROD
     ];
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_STALE_DISTANCE_METERS = 600;
+const EMPTY_OVERPASS_PAYLOAD = Object.freeze({ version: 0.6, generator: "fallback", elements: [] });
+
+class OverpassHttpError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "OverpassHttpError";
+    this.code = "OVERPASS_HTTP_ERROR";
+    this.status = details.status ?? null;
+    this.endpoint = details.endpoint ?? null;
+    this.retryAfterMs = details.retryAfterMs ?? null;
+    this.isRateLimited = this.status === 429;
+    this.details = details;
+  }
+}
 
 const HIGHWAY_TAGS = [
   "footway",
@@ -77,6 +91,7 @@ async function performOverpassRequest(body) {
         body,
         signal: controller.signal,
       });
+      response.overpassEndpoint = endpoint;
       if (response.status !== 429) {
         return response;
       }
@@ -111,6 +126,24 @@ export async function fetchOSMData(lat, lon, radiusMeters, options = {}) {
     requestFn: () => performOverpassRequest(new URLSearchParams({ data: query })),
   });
 
+  if (!response?.ok) {
+    const status = Number.isFinite(response?.status) ? response.status : null;
+    const retryAfterRaw = response?.headers?.get?.("retry-after");
+    const retryAfterMs = retryAfterRaw ? Number.parseFloat(retryAfterRaw) * 1000 : null;
+    const details = {
+      status,
+      statusText: response?.statusText ?? null,
+      retryAfterMs: Number.isFinite(retryAfterMs) ? retryAfterMs : null
+    };
+    if (options.fallbackOnNonOk === true) {
+      return EMPTY_OVERPASS_PAYLOAD;
+    }
+    throw new OverpassHttpError(
+      `Overpass response non-OK: ${status ?? "unknown"} ${response?.statusText ?? ""}`.trim(),
+      details
+    );
+  }
+
   return response.json();
 }
 
@@ -118,6 +151,16 @@ export async function fetchOSMFeatures(lat, lon, radiusMeters, options = {}) {
   const data = await fetchOSMData(lat, lon, radiusMeters, options);
   return overpassToGeoJSON(data);
 }
+
+export function isOverpassThrottleError(error) {
+  if (!error) return false;
+  return error instanceof RequestThrottleError
+    || error instanceof OverpassHttpError && error.status === 429
+    || error?.code === "OVERPASS_RATE_LIMITED"
+    || error?.status === 429;
+}
+
+export { OverpassHttpError, EMPTY_OVERPASS_PAYLOAD };
 
 // Minimal usage example:
 // fetchOSMFeatures(37.7749, -122.4194, 500)

--- a/requestQueue.js
+++ b/requestQueue.js
@@ -2,11 +2,26 @@ const DEFAULT_RATE_LIMIT_MS = 5000;
 const DEFAULT_BACKOFF_MS = 1250;
 const DEFAULT_MAX_RETRIES = 5;
 const RETRYABLE_STATUS = new Set([429, 504]);
+const MAX_429_STORM_COUNT = 6;
+const COOLDOWN_JITTER_MS = 350;
 
 class StaleRequestError extends Error {
   constructor(message = "Request became stale before execution.") {
     super(message);
     this.name = "StaleRequestError";
+  }
+}
+
+class RequestThrottleError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = "RequestThrottleError";
+    this.code = "OVERPASS_RATE_LIMITED";
+    this.status = Number.isFinite(details.status) ? details.status : 429;
+    this.endpoint = details.endpoint ?? null;
+    this.attempt = Number.isFinite(details.attempt) ? details.attempt : null;
+    this.retryAfterMs = Number.isFinite(details.retryAfterMs) ? details.retryAfterMs : null;
+    this.diagnostics = details;
   }
 }
 
@@ -61,6 +76,7 @@ class RequestQueue {
     this.globalNextAllowedAt = 0;
     this.latestLocation = null;
     this.pendingByKey = new Map();
+    this.recent429Count = 0;
   }
 
   enqueue({ lat, lon, staleDistanceMeters, requestFn, dedupeKey = null }) {
@@ -159,6 +175,17 @@ class RequestQueue {
     }
   }
 
+  buildDiagnostics(entry, details = {}) {
+    return {
+      endpoint: details.endpoint ?? entry.endpoint ?? null,
+      dedupeKey: entry.dedupeKey ?? null,
+      attempt: Number.isFinite(details.attempt) ? details.attempt : null,
+      retryAfterMs: Number.isFinite(details.retryAfterMs) ? details.retryAfterMs : null,
+      status: Number.isFinite(details.status) ? details.status : null,
+      nextAllowedAt: this.globalNextAllowedAt || null
+    };
+  }
+
   async executeWithRetry(entry) {
     let attempt = 0;
     let lastError;
@@ -173,18 +200,32 @@ class RequestQueue {
       try {
         const response = await entry.requestFn();
         if (response.ok) {
+          this.recent429Count = 0;
           return response;
         }
         if (RETRYABLE_STATUS.has(response.status)) {
           attempt += 1;
-          lastError = new Error(`Overpass request failed: ${response.status} ${response.statusText}`);
+          const retryAfterMs = parseRetryAfterMs(response.headers?.get("retry-after"));
+          const diagnostics = this.buildDiagnostics(entry, {
+            attempt,
+            retryAfterMs,
+            status: response.status,
+            endpoint: response.overpassEndpoint ?? null
+          });
+          console.warn("[RequestQueue] retryable response", diagnostics);
+          lastError = response.status === 429
+            ? new RequestThrottleError(`Overpass request failed: ${response.status} ${response.statusText}`, diagnostics)
+            : new Error(`Overpass request failed: ${response.status} ${response.statusText}`);
           if (attempt >= this.maxRetries) {
             break;
           }
-          const retryAfterMs = parseRetryAfterMs(response.headers?.get("retry-after"));
           const expBackoffMs = this.backoffMs * 2 ** (attempt - 1);
-          const jitterMs = Math.floor(Math.random() * 350);
-          const cooldownMs = Math.max(retryAfterMs ?? 0, expBackoffMs) + jitterMs;
+          if (response.status === 429) {
+            this.recent429Count = Math.min(MAX_429_STORM_COUNT, this.recent429Count + 1);
+          }
+          const stormMultiplier = response.status === 429 ? Math.max(1, this.recent429Count) : 1;
+          const jitterMs = Math.floor(Math.random() * COOLDOWN_JITTER_MS);
+          const cooldownMs = Math.max(retryAfterMs ?? 0, expBackoffMs) * stormMultiplier + jitterMs;
           this.globalNextAllowedAt = Math.max(this.globalNextAllowedAt, Date.now() + cooldownMs);
           await sleep(cooldownMs);
           continue;
@@ -210,11 +251,11 @@ function parseQueueNumber(value, fallback) {
 }
 
 const overpassQueueDefaults = {
-  maxConcurrent: parseQueueNumber(import.meta.env.VITE_OVERPASS_MAX_CONCURRENT, 2),
+  maxConcurrent: parseQueueNumber(import.meta.env.VITE_OVERPASS_MAX_CONCURRENT, 1),
   rateLimitMs: parseQueueNumber(import.meta.env.VITE_OVERPASS_RATE_LIMIT_MS, DEFAULT_RATE_LIMIT_MS),
   backoffMs: parseQueueNumber(import.meta.env.VITE_OVERPASS_BACKOFF_MS, DEFAULT_BACKOFF_MS),
   maxRetries: parseQueueNumber(import.meta.env.VITE_OVERPASS_MAX_RETRIES, DEFAULT_MAX_RETRIES),
 };
 
 export const overpassRequestQueue = new RequestQueue(overpassQueueDefaults);
-export { RequestQueue, StaleRequestError };
+export { RequestQueue, StaleRequestError, RequestThrottleError };


### PR DESCRIPTION
### Motivation
- Prevent unhandled JSON parsing and noisy failures when Overpass returns non-OK responses (429/other) by surfacing typed errors or controlled fallbacks.
- Reduce burst risk and improve observability of Overpass request storms by making the request queue throttle-aware and exponential-cooldown-aware.
- Keep map tiles and rendered content stable during transient Overpass rate limits and provide a user-visible state instead of uncaught promise errors.

### Description
- Updated `fetchOSMData` to check `response.ok` before calling `response.json()`, return an `EMPTY_OVERPASS_PAYLOAD` when requested via `fallbackOnNonOk`, and throw a typed `OverpassHttpError` with `status`/`retryAfterMs`/`endpoint` details on non-OK responses. (`osmClient.js`)
- Added `isOverpassThrottleError` helper and exported `OverpassHttpError`/`EMPTY_OVERPASS_PAYLOAD` for callers to classify and optionally fallback. (`osmClient.js`)
- Attached `overpassEndpoint` to responses coming from `performOverpassRequest` so the queue can include the endpoint in diagnostics. (`osmClient.js`)
- Introduced `RequestThrottleError` and enhanced `RequestQueue` to track `recent429Count`, emit structured diagnostics via `buildDiagnostics`, amplify global cooldowns after repeated 429s, add jitter, and reset 429 counters on success; also defaulted Overpass concurrency to `1`. (`requestQueue.js`)
- In the OSM/tile update path (`app/bootstrapGameApp.js`) catch throttling errors via `isOverpassThrottleError`, preserve prior tile geojson when available, avoid clearing existing rendered roads/buildings, schedule a delayed per-tile retry with jitter, and set `locationState.state = 'rate_limited'` with message `map data temporarily rate-limited` until the backoff expires.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully.
- Attempted to run a lint script via `npm run lint` but no lint script is defined in `package.json` in this repository, so linting was not executed.
- The app was statically type/shape validated by the build step (no runtime assertion tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9590aab883319be31db367e5d73a)