### PR TITLE
Overpass proxy: add per-query cache & dedupe, upstream throttling, and deterministic retry errors

### DIFF
--- a/api/overpass.js
+++ b/api/overpass.js
@@ -1,9 +1,24 @@
+import crypto from "node:crypto";
+
 const OVERPASS_ENDPOINTS = [
   "https://overpass-api.de/api/interpreter",
   "https://overpass.kumi.systems/api/interpreter",
 ];
 const REQUEST_TIMEOUT_MS = 10_000;
 const RETRYABLE_STATUS = new Set([406, 429, 502, 503, 504]);
+const CACHE_TTL_MS = 30_000;
+const MAX_CONCURRENT_UPSTREAM = 4;
+const TOKEN_BUCKET_CAPACITY = 8;
+const TOKEN_BUCKET_REFILL_PER_SEC = 4;
+const DEFAULT_RETRY_AFTER_MS = 5_000;
+
+const responseCache = new Map();
+const inFlightByQueryKey = new Map();
+
+let activeUpstreamRequests = 0;
+let bucketTokens = TOKEN_BUCKET_CAPACITY;
+let lastRefillAt = Date.now();
+const upstreamQueue = [];
 
 function isAllowedMethod(method) {
   return method === "POST" || method === "OPTIONS";
@@ -36,32 +51,117 @@ function readDataParam(body) {
   return null;
 }
 
+function normalizeQuery(query) {
+  return query.replace(/\s+/g, " ").trim();
+}
+
+function getQueryKey(normalizedQuery) {
+  return crypto.createHash("sha256").update(normalizedQuery).digest("hex");
+}
+
+function parseRetryAfterMs(retryAfterValue) {
+  if (!retryAfterValue) return null;
+  const seconds = Number.parseFloat(retryAfterValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const retryAt = Date.parse(retryAfterValue);
+  if (!Number.isNaN(retryAt)) {
+    return Math.max(0, retryAt - Date.now());
+  }
+
+  return null;
+}
+
+function maybeRefillTokens() {
+  const now = Date.now();
+  const elapsedMs = now - lastRefillAt;
+  if (elapsedMs <= 0) return;
+  const refill = Math.floor((elapsedMs / 1000) * TOKEN_BUCKET_REFILL_PER_SEC);
+  if (refill <= 0) return;
+  bucketTokens = Math.min(TOKEN_BUCKET_CAPACITY, bucketTokens + refill);
+  lastRefillAt = now;
+}
+
+function releaseUpstreamSlot() {
+  activeUpstreamRequests = Math.max(0, activeUpstreamRequests - 1);
+  while (upstreamQueue.length > 0) {
+    maybeRefillTokens();
+    if (activeUpstreamRequests >= MAX_CONCURRENT_UPSTREAM || bucketTokens < 1) break;
+    const next = upstreamQueue.shift();
+    activeUpstreamRequests += 1;
+    bucketTokens -= 1;
+    next();
+  }
+}
+
+function acquireUpstreamSlot() {
+  return new Promise((resolve) => {
+    maybeRefillTokens();
+    if (activeUpstreamRequests < MAX_CONCURRENT_UPSTREAM && bucketTokens >= 1) {
+      activeUpstreamRequests += 1;
+      bucketTokens -= 1;
+      resolve();
+      return;
+    }
+
+    const tick = setInterval(() => {
+      maybeRefillTokens();
+      if (activeUpstreamRequests < MAX_CONCURRENT_UPSTREAM && bucketTokens >= 1) {
+        clearInterval(tick);
+        activeUpstreamRequests += 1;
+        bucketTokens -= 1;
+        resolve();
+      }
+    }, 50);
+
+    upstreamQueue.push(() => {
+      clearInterval(tick);
+      resolve();
+    });
+  });
+}
+
 async function fetchFromOverpass(body, signal) {
+  await acquireUpstreamSlot();
   let lastResponse = null;
 
-  for (let i = 0; i < OVERPASS_ENDPOINTS.length; i += 1) {
-    const endpoint = OVERPASS_ENDPOINTS[i];
-    const response = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-        Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
-      },
-      body,
-      signal,
-    });
+  try {
+    for (let i = 0; i < OVERPASS_ENDPOINTS.length; i += 1) {
+      const endpoint = OVERPASS_ENDPOINTS[i];
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+          Accept: "application/json, text/plain;q=0.9, */*;q=0.8",
+        },
+        body,
+        signal,
+      });
 
-    if (response.ok) {
-      return response;
-    }
+      if (response.ok) {
+        return response;
+      }
 
-    lastResponse = response;
-    if (!RETRYABLE_STATUS.has(response.status) || i === OVERPASS_ENDPOINTS.length - 1) {
-      return response;
+      lastResponse = response;
+      if (!RETRYABLE_STATUS.has(response.status) || i === OVERPASS_ENDPOINTS.length - 1) {
+        return response;
+      }
     }
+  } finally {
+    releaseUpstreamSlot();
   }
 
   return lastResponse;
+}
+
+function buildErrorPayload(code, upstreamStatus, retryAfterMs) {
+  return {
+    code,
+    retryAfterMs: Number.isFinite(retryAfterMs) ? Math.max(0, Math.round(retryAfterMs)) : null,
+    upstreamStatus: Number.isFinite(upstreamStatus) ? upstreamStatus : null,
+  };
 }
 
 export default async function handler(req, res) {
@@ -79,33 +179,96 @@ export default async function handler(req, res) {
 
   const query = readDataParam(req.body);
   if (!query) {
-    return res.status(400).json({ error: "Missing Overpass query in request body." });
+    return res.status(400).json(buildErrorPayload("MISSING_QUERY", null, null));
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const normalizedQuery = normalizeQuery(query);
+  const queryKey = getQueryKey(normalizedQuery);
+  const cached = responseCache.get(queryKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Content-Type", cached.contentType);
+    res.setHeader("X-Overpass-Cache", "HIT");
+    return res.status(cached.status).send(cached.responseText);
+  }
+  responseCache.delete(queryKey);
 
+  if (inFlightByQueryKey.has(queryKey)) {
+    const shared = await inFlightByQueryKey.get(queryKey);
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Content-Type", shared.contentType);
+    res.setHeader("X-Overpass-Deduped", "1");
+    return res.status(shared.status).send(shared.responseText);
+  }
+
+  const upstreamPromise = (async () => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const requestBody = new URLSearchParams({ data: normalizedQuery }).toString();
+      const upstreamResponse = await fetchFromOverpass(requestBody, controller.signal);
+
+      if (!upstreamResponse) {
+        return {
+          type: "error",
+          status: 502,
+          payload: buildErrorPayload("NO_UPSTREAM_RESPONSE", null, null),
+        };
+      }
+
+      const responseText = await upstreamResponse.text();
+      const upstreamContentType = upstreamResponse.headers.get("content-type") || "application/json; charset=utf-8";
+      const retryAfterMs = parseRetryAfterMs(upstreamResponse.headers.get("retry-after"));
+      return {
+        type: "upstream",
+        status: upstreamResponse.status,
+        contentType: upstreamContentType,
+        responseText,
+        retryAfterMs,
+      };
+    } catch (error) {
+      const status = error?.name === "AbortError" ? 504 : 502;
+      const code = status === 504 ? "UPSTREAM_TIMEOUT" : "UPSTREAM_UNREACHABLE";
+      return {
+        type: "error",
+        status,
+        payload: buildErrorPayload(code, status, status === 504 ? DEFAULT_RETRY_AFTER_MS : null),
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  })();
+  inFlightByQueryKey.set(queryKey, upstreamPromise);
   try {
-    const requestBody = new URLSearchParams({ data: query }).toString();
-    const upstreamResponse = await fetchFromOverpass(requestBody, controller.signal);
+    const result = await upstreamPromise;
+    res.setHeader("Access-Control-Allow-Origin", "*");
 
-    if (!upstreamResponse) {
-      return res.status(502).json({ error: "No Overpass upstream response." });
+    if (result.type === "error") {
+      return res.status(result.status).json(result.payload);
     }
 
-    const responseText = await upstreamResponse.text();
-    const upstreamContentType = upstreamResponse.headers.get("content-type") || "application/json; charset=utf-8";
+    if (result.status === 429 || result.status === 504) {
+      const retryAfterMs = result.retryAfterMs ?? DEFAULT_RETRY_AFTER_MS;
+      res.setHeader("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+      res.setHeader("X-Retry-After-Ms", String(retryAfterMs));
+      return res.status(result.status).json(
+        buildErrorPayload("UPSTREAM_RETRYABLE", result.status, retryAfterMs),
+      );
+    }
 
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Content-Type", upstreamContentType);
-    return res.status(upstreamResponse.status).send(responseText);
-  } catch (error) {
-    const status = error?.name === "AbortError" ? 504 : 502;
-    return res.status(status).json({
-      error: status === 504 ? "Overpass request timed out." : "Failed to reach Overpass API.",
-      detail: error?.message || "Unknown error",
-    });
+    if (result.status >= 200 && result.status < 300) {
+      responseCache.set(queryKey, {
+        status: result.status,
+        contentType: result.contentType,
+        responseText: result.responseText,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+      });
+      res.setHeader("X-Overpass-Cache", "MISS");
+    }
+
+    res.setHeader("Content-Type", result.contentType);
+    return res.status(result.status).send(result.responseText);
   } finally {
-    clearTimeout(timeoutId);
+    inFlightByQueryKey.delete(queryKey);
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce duplicate identical queries and short-circuit redundant upstream calls with a small TTL cache to lower load on Overpass.
- Protect the instance from bursts by capping concurrency and applying a token-bucket to outgoing Overpass requests.
- Surface normalized retry hints and consistent error payloads so clients can react deterministically to upstream 429/504 and other failures.

### Description
- Add query normalization and SHA-256 keyed in-memory cache with a 30s TTL and `X-Overpass-Cache: HIT/MISS` markers, returning cached payloads before contacting upstream (`normalizeQuery`, `getQueryKey`, `responseCache`).
- Introduce per-query in-flight deduplication so concurrent identical requests share a single upstream call via `inFlightByQueryKey` and return `X-Overpass-Deduped: 1` for waiters.
- Add per-instance upstream protections: `MAX_CONCURRENT_UPSTREAM`, token-bucket parameters, and queueing with `acquireUpstreamSlot`/`releaseUpstreamSlot` to limit and throttle outbound Overpass requests.
- Parse upstream `Retry-After` (seconds or HTTP-date) and propagate normalized hints in headers (`Retry-After`, `X-Retry-After-Ms`) and in deterministic JSON error payloads `{ code, retryAfterMs, upstreamStatus }` for retryable responses.

### Testing
- Ran `node --check api/overpass.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cac6d64bc8331ada151b9cefe5eeb)