### PR TITLE
Address asset import compatibility warnings and Rapier init deprecation

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -2953,7 +2953,7 @@ async function initCore(runtimeContext) {
 
 
   // --- RAPIER INIT ---
-  await RAPIER.init();
+  await RAPIER.init({});
   rapierWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
   runtimeContext.systems.rapierWorld = rapierWorld;
   window.rapierWorld = rapierWorld;

--- a/docs/asset-pipeline-compatibility.md
+++ b/docs/asset-pipeline-compatibility.md
@@ -1,0 +1,16 @@
+# Asset pipeline compatibility notes
+
+## glTF `KHR_materials_pbrSpecularGlossiness`
+
+If source assets still use `KHR_materials_pbrSpecularGlossiness`, re-export them to the modern metallic-roughness workflow in your DCC/export pipeline whenever possible.
+
+If re-export is not possible, ensure your runtime loader stack includes extension support for `KHR_materials_pbrSpecularGlossiness` before shipping that asset.
+
+## FBX skinning import warnings
+
+To avoid FBX skinning warnings and keep deformation stable:
+
+- Re-export rigs with **max 4 weights per vertex**.
+- Ensure **weights are normalized** in the DCC tool before export.
+
+Runtime code now normalizes skinned mesh weights as a safety net, but exporter-side cleanup is still recommended for deterministic results.

--- a/models/monsterModel.js
+++ b/models/monsterModel.js
@@ -57,6 +57,9 @@ function configureMeshCulling(model) {
   const skinnedMeshes = [];
   model.traverse((obj) => {
     if (obj.material?.skinning === true) obj.material.skinning = true;
+    if (obj.isSkinnedMesh && typeof obj.normalizeSkinWeights === 'function') {
+      obj.normalizeSkinWeights();
+    }
     if (!obj.isMesh) return;
     obj.frustumCulled = true;
     if (obj.geometry) {

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -216,9 +216,17 @@ export function createPlayerModel(
             console.error('While stripping FBX lights:', err);
           }
 
+          let loggedSkinningExportHint = false;
           model.traverse(o => {
             if (o.isSkinnedMesh || o.isMesh) o.frustumCulled = false;
             if (o.material?.skinning === true) o.material.skinning = true;
+            if (o.isSkinnedMesh && typeof o.normalizeSkinWeights === 'function') {
+              o.normalizeSkinWeights();
+              if (!loggedSkinningExportHint) {
+                console.info('[FBX] Applied runtime skin-weight normalization. For clean imports, re-export rigs with max 4 weights/vertex and normalized weights.');
+                loggedSkinningExportHint = true;
+              }
+            }
           });
 
 
@@ -355,6 +363,9 @@ export function createPlayerModel(
                   lodModel.traverse(o => {
                     if (o.isSkinnedMesh || o.isMesh) o.frustumCulled = false;
                     if (o.material?.skinning === true) o.material.skinning = true;
+                    if (o.isSkinnedMesh && typeof o.normalizeSkinWeights === 'function') {
+                      o.normalizeSkinWeights();
+                    }
                   });
 
                   lodModel.scale.set(scale, scale, scale);


### PR DESCRIPTION
### Motivation
- Remove a deprecation warning and future-proof physics startup by switching Rapier initialization to the object-parameter API (`RAPIER.init({})`).
- Mitigate FBX skinning import inconsistencies by normalizing skinned-mesh weights at runtime as a safety net while recommending exporter-side fixes.
- Encourage migration away from legacy glTF PBR workflows by documenting `KHR_materials_pbrSpecularGlossiness` handling and exporter guidance.

### Description
- Updated Rapier startup call to use `await RAPIER.init({});` in `app/bootstrapGameApp.js` to match the current API.
- Added runtime skin-weight normalization (`normalizeSkinWeights()`) to FBX load/traverse paths for player models (primary and LOD) in `models/playerModel.js`, including a one-time informational log recommending exporter-side limits (max 4 weights/vertex and normalized weights).
- Added `normalizeSkinWeights()` to the skinned-mesh traversal in `models/monsterModel.js` to apply the same safety-net across monster rigs.
- Added `docs/asset-pipeline-compatibility.md` documenting recommendations for `KHR_materials_pbrSpecularGlossiness` and FBX skin export constraints (max 4 weights/vertex and normalized weights).

### Testing
- Ran the production build with `npm run -s build` and the build completed successfully (warnings about chunk sizes only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd056c0c08331b9cd73509f2f0cfc)