### PR TITLE
Adjust dog interaction overlays and friendly prompt labels

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -12720,10 +12720,11 @@ async function initCore(runtimeContext) {
     delete mesh.userData.buildHealthBar;
   };
 
+  const DOG_INTERACT_DISTANCE = 2.5;
   const feedDogBtn = document.createElement('button');
   feedDogBtn.type = 'button';
   feedDogBtn.textContent = 'Feed Dog';
-  feedDogBtn.style.cssText = 'position:fixed;left:50%;bottom:37%;transform:translateX(-50%);z-index:1200;display:none;padding:8px 12px;';
+  feedDogBtn.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%, -50%);z-index:1200;display:none;padding:8px 12px;';
   document.body.appendChild(feedDogBtn);
   const animalNameLabels = new Map();
   const areInteractionLabelsBlocked = () => {
@@ -13259,7 +13260,7 @@ async function initCore(runtimeContext) {
   };
   feedDogBtn.addEventListener('click', () => {
     const playerPos = playerModel?.position;
-    const target = animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
+    const target = animalManager?.getNearestFeedableDog?.(playerPos, DOG_INTERACT_DISTANCE);
     const dog = target?.animal;
     if (!dog) return;
     const maxHealth = Math.max(1, Number(dog.maxHealth || 1));
@@ -13767,8 +13768,22 @@ async function initCore(runtimeContext) {
         const shouldShow = !labelsBlocked && Boolean(buildState.selectedNoteId) && closestNoteDistance <= closestInteractDistance;
         buildInteractionBtn.style.display = shouldShow ? 'block' : 'none';
 
-        const nearbyDog = labelsBlocked ? null : animalManager?.getNearestFeedableDog?.(playerPos, 2.5);
-        feedDogBtn.style.display = nearbyDog ? 'block' : 'none';
+        const nearbyDog = labelsBlocked ? null : animalManager?.getNearestFeedableDog?.(playerPos, DOG_INTERACT_DISTANCE);
+        if (nearbyDog?.animal?.model) {
+          const buttonAnchor = nearbyDog.animal.model.position.clone().add(new THREE.Vector3(0, 2, 0));
+          buttonAnchor.project(camera);
+          if (buttonAnchor.z < 0 || buttonAnchor.z > 1) {
+            feedDogBtn.style.display = 'none';
+          } else {
+            const x = (buttonAnchor.x * 0.5 + 0.5) * window.innerWidth;
+            const y = (-buttonAnchor.y * 0.5 + 0.5) * window.innerHeight;
+            feedDogBtn.style.display = 'block';
+            feedDogBtn.style.left = `${x}px`;
+            feedDogBtn.style.top = `${y + 24}px`;
+          }
+        } else {
+          feedDogBtn.style.display = 'none';
+        }
       }
     }
     updateBuildHealthBars();
@@ -14722,6 +14737,11 @@ async function initCore(runtimeContext) {
             animalNameLabels.set(animal.id, label);
           }
           label.textContent = name;
+          const distanceToPlayer = playerModel?.position?.distanceTo?.(animal.model.position) ?? Number.POSITIVE_INFINITY;
+          if (distanceToPlayer > DOG_INTERACT_DISTANCE) {
+            label.style.display = 'none';
+            return;
+          }
           const pos = animal.model.position.clone().add(new THREE.Vector3(0, 2, 0));
           pos.project(camera);
           if (pos.z < 0 || pos.z > 1) { label.style.display = 'none'; return; }

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -1582,6 +1582,12 @@ export class PlayerControls {
     return !!friendly && (this.questManager?.isQuestFriend?.(friendly) || friendly?.model?.userData?.isQuestFriend === true);
   }
 
+  getFriendlyPromptLabel(friendly) {
+    if (this.isQuestFriend(friendly)) return 'Talk to Quest Guy';
+    if (friendly?.model?.userData?.npcRole === 'merchant') return 'Talk to Merchant';
+    return 'Talk to Friendly';
+  }
+
   getClosestFriendly(maxDistance) {
     if (!this.playerModel) return null;
     const friendlies = Array.isArray(window.friendlies) ? window.friendlies : [];
@@ -1963,9 +1969,7 @@ export class PlayerControls {
     if (nearby?.friendly && closest?.type === 'friendly' && closest.friendly === nearby.friendly) {
       this.friendlyInteractButton.classList.remove('hidden');
       this.friendlyInteractButton.disabled = false;
-      this.friendlyInteractButton.textContent = this.isQuestFriend(nearby.friendly)
-        ? (this.isMobile ? 'Talk' : 'Interact')
-        : (this.isMobile ? 'Talk' : 'Interact (X)');
+      this.friendlyInteractButton.textContent = this.getFriendlyPromptLabel(nearby.friendly);
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Improve UX for feeding companions by moving the `Feed Dog` button to follow the dog in screen space and align with the name-tag area. 
- Ensure companion name-tags and the feed button are only visible when the player is sufficiently close to avoid clutter. 
- Make friendly interaction labels explicit to clarify who the player is talking to (quest friend, merchant, or generic friendly).

### Description
- Added `DOG_INTERACT_DISTANCE` and used it for feed checks and name-tag visibility to centralize the proximity threshold in `app/bootstrapGameApp.js`.
- Repositioned the `Feed Dog` button to be world-anchored: it projects the dog's world position to screen space and places the button just below the dog's anchor point when on-screen and within `DOG_INTERACT_DISTANCE`.
- Hid companion name-tags unless the player is within `DOG_INTERACT_DISTANCE` and the dog projects on-screen in `app/bootstrapGameApp.js`.
- Added `getFriendlyPromptLabel(friendly)` to `controls/controls.js` and changed the friendly interaction button text to role-specific prompts: `Talk to Quest Guy`, `Talk to Merchant`, or `Talk to Friendly`.
- Files modified: `app/bootstrapGameApp.js` and `controls/controls.js`.

### Testing
- Built the project with `npm run -s build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cd49441608331909203bd786a01e5)