### PR TITLE
Add monster target UI and programmatic ballistic firing for bow/bomb/bazooka

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -12777,6 +12777,36 @@ async function initCore(runtimeContext) {
   feedDogBtn.textContent = 'Feed Dog';
   feedDogBtn.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%, -50%);z-index:1200;display:none;padding:8px 12px;';
   document.body.appendChild(feedDogBtn);
+  const monsterTargetButtons = new Map();
+  const WEAPON_TARGET_MAX_DISTANCE = 15;
+  const TARGET_BTN_SIZE = 32;
+  const clearMonsterTargetButtons = () => {
+    monsterTargetButtons.forEach((entry) => entry?.button?.remove());
+    monsterTargetButtons.clear();
+  };
+  const isTargetableWeaponEquipped = () => {
+    const weapon = playerControls?.getEquippedWeapon?.('right');
+    return weapon?.itemId === 'bomb' || weapon?.itemId === 'bow' || weapon?.itemId === 'bazooka';
+  };
+  const getMonsterTargetKey = (monster) => monster?.id || monster?.model?.uuid || String(Math.random());
+  const getOrCreateMonsterTargetButton = (monster) => {
+    const key = getMonsterTargetKey(monster);
+    if (monsterTargetButtons.has(key)) return monsterTargetButtons.get(key);
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = '🎯';
+    button.setAttribute('aria-label', 'Target monster');
+    button.style.cssText = `position:fixed;z-index:1200;display:none;width:${TARGET_BTN_SIZE}px;height:${TARGET_BTN_SIZE}px;border-radius:999px;padding:0;font-size:18px;line-height:1;`;
+    button.addEventListener('click', () => {
+      const model = monster?.model;
+      if (!model?.position) return;
+      playerControls?.fireProjectileAtTarget?.(model, 'right');
+    });
+    document.body.appendChild(button);
+    const entry = { key, monster, button };
+    monsterTargetButtons.set(key, entry);
+    return entry;
+  };
   const animalNameLabels = new Map();
   const areInteractionLabelsBlocked = () => {
     if (window.mapViewEnabled === true || document.body.classList.contains('map-open')) return true;
@@ -13834,6 +13864,32 @@ async function initCore(runtimeContext) {
           }
         } else {
           feedDogBtn.style.display = 'none';
+        }
+        if (labelsBlocked || !isTargetableWeaponEquipped()) {
+          clearMonsterTargetButtons();
+        } else {
+          const visibleMonsterKeys = new Set();
+          monsters.forEach((monster) => {
+            if (!monster?.model?.position || monster.isDead) return;
+            const distance = playerPos.distanceTo(monster.model.position);
+            if (distance > WEAPON_TARGET_MAX_DISTANCE) return;
+            const buttonAnchor = monster.model.position.clone().add(new THREE.Vector3(0, 2.3, 0));
+            buttonAnchor.project(camera);
+            if (buttonAnchor.z < 0 || buttonAnchor.z > 1) return;
+            if (Math.abs(buttonAnchor.x) > 1 || Math.abs(buttonAnchor.y) > 1) return;
+            const entry = getOrCreateMonsterTargetButton(monster);
+            visibleMonsterKeys.add(entry.key);
+            const x = (buttonAnchor.x * 0.5 + 0.5) * window.innerWidth;
+            const y = (-buttonAnchor.y * 0.5 + 0.5) * window.innerHeight;
+            entry.button.style.display = 'block';
+            entry.button.style.left = `${x - (TARGET_BTN_SIZE / 2)}px`;
+            entry.button.style.top = `${y + 10}px`;
+          });
+          monsterTargetButtons.forEach((entry, key) => {
+            if (!visibleMonsterKeys.has(key)) {
+              entry.button.style.display = 'none';
+            }
+          });
         }
       }
     }

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -138,6 +138,7 @@ const AUTO_AIM_CAMERA_LINGER_MS = 3000;
 const AUTO_AIM_ARC_CONFIG = Object.freeze({
   bow: { nearDistance: 6, farDistance: 45, maxLoftRadians: 0.24 },
   bomb: { nearDistance: 4, farDistance: 36, maxLoftRadians: 0.48 },
+  bazooka: { nearDistance: 5, farDistance: 50, maxLoftRadians: 0.2 },
   throw: { nearDistance: 2.5, farDistance: 16, maxLoftRadians: 0.62 }
 });
 
@@ -3379,16 +3380,31 @@ export class PlayerControls {
     return this.attemptFireProjectileForHand('right');
   }
 
-  attemptFireProjectileForHand(hand = 'right') {
+  fireProjectileAtTarget(targetModel, hand = 'right') {
+    if (!targetModel?.position || !this.playerModel) return false;
+    const weapon = this.getEquippedWeapon(hand);
+    const weaponId = weapon?.itemId;
+    if (weaponId !== 'bow' && weaponId !== 'bomb' && weaponId !== 'bazooka') return false;
+
+    const eyePos = this.playerModel.position.clone().add(new THREE.Vector3(0, AUTO_AIM_TARGET_CENTER_Y, 0));
+    const targetPos = targetModel.position.clone().add(new THREE.Vector3(0, AUTO_AIM_TARGET_CENTER_Y, 0));
+    const baseDirection = targetPos.sub(eyePos);
+    if (baseDirection.lengthSq() <= 0.0001) return false;
+
+    const direction = this.getDistanceAdjustedArcDirection(baseDirection, weaponId);
+    return this.attemptFireProjectileForHand(hand, { manualDirection: direction, skipAutoAimLinger: true });
+  }
+
+  attemptFireProjectileForHand(hand = 'right', { manualDirection = null, skipAutoAimLinger = false } = {}) {
     const equippedWeapon = this.getEquippedWeapon(hand);
     if (equippedWeapon?.itemId === 'bomb' && typeof this.throwBomb === 'function') {
-      const autoAimDirection = this.getAutoAimDirection(equippedWeapon);
-      const direction = autoAimDirection ?? this.getAimDirection(true);
+      const autoAimDirection = manualDirection ? null : this.getAutoAimDirection(equippedWeapon);
+      const direction = (manualDirection?.clone?.() || autoAimDirection || this.getAimDirection(true)).normalize();
       const position = this.getProjectileSpawnPosition(direction);
       const fired = this.throwBomb(position, direction);
       if (fired) {
         this.playAction('throw');
-        this.startAutoAimCameraLinger(autoAimDirection);
+        if (!skipAutoAimLinger) this.startAutoAimCameraLinger(autoAimDirection);
       }
       return fired;
     }
@@ -3398,8 +3414,8 @@ export class PlayerControls {
     const usesIceMist = gun?.itemId === 'iceGun' && typeof this.spawnIceMist === 'function';
     const usesArrow = gun?.itemId === 'bow' && typeof this.spawnArrowProjectile === 'function';
     const usesMissile = gun?.itemId === 'bazooka' && typeof this.spawnMissileProjectile === 'function';
-    const autoAimDirection = this.getAutoAimDirection(gun);
-    const baseDirection = autoAimDirection ?? (usesIceMist ? this.getPlayerFacingDirection() : this.getAimDirection(usesArrow || usesMissile));
+    const autoAimDirection = manualDirection ? null : this.getAutoAimDirection(gun);
+    const baseDirection = manualDirection?.clone?.() || autoAimDirection || (usesIceMist ? this.getPlayerFacingDirection() : this.getAimDirection(usesArrow || usesMissile));
     const direction = baseDirection.clone();
     if (usesMissile && !autoAimDirection) {
       direction.y = Math.max(direction.y, 0.14);
@@ -3488,7 +3504,7 @@ export class PlayerControls {
         this.multiplayer.getId()
       );
     }
-    this.startAutoAimCameraLinger(autoAimDirection);
+    if (!skipAutoAimLinger) this.startAutoAimCameraLinger(autoAimDirection);
     return true;
   }
 


### PR DESCRIPTION
### Motivation
- Provide a quick, in-world targeting UI for ranged special weapons (bomb, bow, bazooka) so players can tap a target above monsters and fire the equipped projectile without moving the camera. 

### Description
- Added per-monster target buttons (`🎯`) rendered as fixed DOM buttons above monsters that are within 15 meters and visible in the camera frustum, with lifecycle and visibility checks that clear buttons when overlays block interaction or a non-targetable weapon is equipped (`app/bootstrapGameApp.js`).
- Implemented `PlayerControls.fireProjectileAtTarget(targetModel, hand)` which computes a ballistic direction to the monster using the existing lofting logic and fires via the existing firing pipeline without changing camera orientation (`controls/controls.js`).
- Extended the firing internals by updating `attemptFireProjectileForHand` to accept optional `{ manualDirection, skipAutoAimLinger }` so programmatic shots can supply an explicit direction and avoid auto-aim camera changes. 
- Added a `bazooka` entry to `AUTO_AIM_ARC_CONFIG` so bazooka shots use distance-adjusted lofting; fixed a build-time operator precedence issue to keep compatibility with the bundler.
- Files modified: `controls/controls.js` and `app/bootstrapGameApp.js`.

### Testing
- Ran the production build with `npm run build`, which completed successfully after minor syntax adjustments; build output reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0db7f81a308331ae28506649f22d3c)