### PR TITLE
Add crab wildlife behavior, weighted spawning, and crab meat drops

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -961,7 +961,8 @@ async function initCore(runtimeContext) {
   const mushroomItemIds = new Set(MUSHROOM_ENTRIES.map((entry) => entry.id));
   const appleItemIds = new Set([APPLE_ITEM_ID]);
   const woodItemIds = new Set([WOOD_ITEM_ID]);
-  const meatItemIds = new Set([MEAT_ITEM_ID]);
+  const CRAB_MEAT_ITEM_ID = 'crab_meat';
+  const meatItemIds = new Set([MEAT_ITEM_ID, CRAB_MEAT_ITEM_ID]);
   const zombieBrainsItemIds = new Set([ZOMBIE_BRAINS_ITEM_ID]);
   const saltItemIds = new Set([SALT_ITEM_ID]);
   const sauteedMushroomsItemIds = new Set([SAUTEED_MUSHROOMS_ITEM_ID]);
@@ -4183,10 +4184,13 @@ async function initCore(runtimeContext) {
       if (!wasDead || !position) return;
       notifyAchievementProgress('animalsKilled', 1);
       window.questManager?.handleAnimalKilled?.(animal);
+      const isCrab = String(animal?.type || '').toLowerCase() === 'crab';
       for (let i = 0; i < 2; i += 1) {
         const angle = (i / 2) * Math.PI * 2;
         const offset = new THREE.Vector3(Math.cos(angle) * 0.35, 0, Math.sin(angle) * 0.35);
-        spawnMeatPickup(position.clone().add(offset));
+        spawnMeatPickup(position.clone().add(offset), isCrab
+          ? { itemId: 'crab_meat', color: 0xb22222 }
+          : undefined);
       }
     }
   });
@@ -4504,7 +4508,7 @@ async function initCore(runtimeContext) {
     }
     if (spawnEvent.type === 'animal') {
       await trimTravelSpawnPopulationIfNeeded(1, spawnEvent.position);
-      await animalManager?.spawnDeerAt?.(spawnEvent.position);
+      await animalManager?.spawnWildAnimalAt?.(spawnEvent.position);
       return;
     }
     if (spawnEvent.type === 'companionDog') {
@@ -6904,13 +6908,13 @@ async function initCore(runtimeContext) {
   }
 
 
-  function spawnMeatPickup(position) {
+  function spawnMeatPickup(position, { itemId = MEAT_ITEM_ID, color = 0x6b3f23 } = {}) {
     const spawnPos = asVec3(position);
     if (!spawnPos) return null;
     applySpawnY(spawnPos, WOOD_DROP_LIFT, { allowOnBuildings: true });
     const geometry = new THREE.BoxGeometry(1.1, 0.45, 0.7);
     const material = new THREE.MeshStandardMaterial({
-      color: 0x6b3f23,
+      color,
       roughness: 0.85,
       metalness: 0.02
     });
@@ -6920,7 +6924,7 @@ async function initCore(runtimeContext) {
     mesh.position.copy(spawnPos);
     mesh.rotation.y = Math.random() * Math.PI * 2;
     scene.add(mesh);
-    const pickup = { id: MEAT_ITEM_ID, mesh };
+    const pickup = { id: itemId, mesh };
     meatPickups.push(pickup);
     return pickup;
   }

--- a/characters/CharacterSpawn.js
+++ b/characters/CharacterSpawn.js
@@ -65,7 +65,7 @@ const getSpawnPositionFromDirection = ({ basePosition, travelDirection, getSpawn
   return getSpawnPosition(predictedPos);
 };
 
-export function createCharacterSpawner({ getPlayerPosition, getSpawnPosition, spawnTypeWeights } = {}) {
+export function createCharacterSpawner({ getPlayerPosition, getSpawnPosition, spawnTypeWeights, travelMinDistance = SPAWN_TRAVEL_MIN_DISTANCE, travelMaxDistance = SPAWN_TRAVEL_MAX_DISTANCE } = {}) {
   let nextSpawnDistance = 0;
   let travelStartPosition = null;
   let lastSpawnAtMs = 0;
@@ -103,7 +103,7 @@ export function createCharacterSpawner({ getPlayerPosition, getSpawnPosition, sp
     if (!currentPos) return null;
 
     if (!Number.isFinite(nextSpawnDistance) || nextSpawnDistance <= 0) {
-      nextSpawnDistance = getNextSpawnDistance();
+      nextSpawnDistance = travelMinDistance + Math.random() * Math.max(0, travelMaxDistance - travelMinDistance);
     }
 
     if (!travelStartPosition) {
@@ -139,7 +139,7 @@ export function createCharacterSpawner({ getPlayerPosition, getSpawnPosition, sp
     gpsDistanceAccum = 0;
     lastSpawnAtMs = now;
     travelStartPosition = currentPos.clone();
-    nextSpawnDistance = getNextSpawnDistance();
+    nextSpawnDistance = travelMinDistance + Math.random() * Math.max(0, travelMaxDistance - travelMinDistance);
 
     return event;
   };

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { MonsterCharacter } from '../characters/MonsterCharacter.js';
 
-const ANIMAL_TYPES = ['Deer'];
+const ANIMAL_TYPES = ['Deer', 'Crab'];
 const SPAWN_MIN_RADIUS = 10;
 const SPAWN_MAX_RADIUS = 26;
 const SPAWN_ATTEMPTS = 10;
@@ -317,6 +317,10 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   } else if (behavior === 'attack' && distanceToPlayer <= attackDistance) {
     data.state = 'attack';
     data.stateUntil = now + 900;
+  } else if (behavior === 'idle') {
+    if (data.state === 'runAway' || data.state === 'attack') {
+      data.state = 'idle';
+    }
   } else if (data.state === 'runAway' && now > (data.runAwayUntil || 0)) {
     data.state = 'idle';
     data.stateUntil = now + randomRange(1000, 2200);
@@ -553,6 +557,20 @@ export function createAnimalManager({
 
   const getAnimals = () => animals.map(entry => entry.animal).filter(Boolean);
 
+  const pickWildAnimalType = () => (Math.random() < 0.8 ? 'Crab' : 'Deer');
+
+  const spawnWildAnimalAt = async (position) => {
+    const entry = await spawnAnimal({
+      scene,
+      getPlayerModel,
+      getTerrainHeight,
+      forcedPosition: position || null,
+      forcedType: pickWildAnimalType()
+    });
+    if (entry) animals.push(entry);
+    return entry?.animal || null;
+  };
+
   const spawnDeerAt = async (position) => {
     const entry = await spawnAnimal({
       scene,
@@ -640,6 +658,7 @@ export function createAnimalManager({
     removeAnimal,
     removeAnimalById,
     spawnDeerAt,
+    spawnWildAnimalAt,
     spawnDogAt,
     maybeSpawnDogByTravelDistance,
     setHost,

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { MonsterCharacter } from '../characters/MonsterCharacter.js';
 
-const ANIMAL_TYPES = ['Deer', 'Crab'];
+const ANIMAL_TYPES = ['Deer', 'crab'];
 const SPAWN_MIN_RADIUS = 10;
 const SPAWN_MAX_RADIUS = 26;
 const SPAWN_ATTEMPTS = 10;
@@ -18,6 +18,17 @@ const animalTemplateCache = new Map();
 let animalSpawnCursor = 0;
 
 const randomRange = (min, max) => min + Math.random() * (max - min);
+
+
+const resolveAnimalAssetBaseName = (typeName) => {
+  const raw = String(typeName || '').trim();
+  if (!raw) return '';
+  const lowered = raw.toLowerCase();
+  if (lowered === 'crab') return 'crab';
+  if (lowered === 'deer') return 'Deer';
+  if (lowered === 'dog') return 'dog';
+  return raw;
+};
 
 function getModelBounds(modelRoot) {
   if (!modelRoot) return null;
@@ -53,8 +64,9 @@ async function loadAnimalTemplate(typeName) {
   const cached = animalTemplateCache.get(typeName);
   if (cached) return cached;
 
-  const configPath = `/models/animals/${encodeURIComponent(typeName)}.json`;
-  const modelPath = `/models/animals/${encodeURIComponent(typeName)}.glb`;
+  const assetBaseName = resolveAnimalAssetBaseName(typeName);
+  const configPath = `/models/animals/${encodeURIComponent(assetBaseName)}.json`;
+  const modelPath = `/models/animals/${encodeURIComponent(assetBaseName)}.glb`;
   const config = await fetch(configPath)
     .then(res => (res.ok ? res.json() : {}))
     .catch(() => ({}));
@@ -557,7 +569,7 @@ export function createAnimalManager({
 
   const getAnimals = () => animals.map(entry => entry.animal).filter(Boolean);
 
-  const pickWildAnimalType = () => (Math.random() < 0.8 ? 'Crab' : 'Deer');
+  const pickWildAnimalType = () => (Math.random() < 0.8 ? 'crab' : 'Deer');
 
   const spawnWildAnimalAt = async (position) => {
     const entry = await spawnAnimal({

--- a/friendlyNpcManager.js
+++ b/friendlyNpcManager.js
@@ -104,8 +104,17 @@ export function createFriendlyNpcManager({
     getSpawnPosition: getSpawnNearPlayerPosition
   });
 
+  const animalSpawner = createCharacterSpawner({
+    getPlayerPosition: () => playerModel?.position?.clone?.() ?? null,
+    getSpawnPosition: getSpawnNearPlayerPosition,
+    spawnTypeWeights: [{ type: 'animal', weight: 1 }],
+    travelMinDistance: 10,
+    travelMaxDistance: 10
+  });
+
   const recordGpsTravel = (sample) => {
     characterSpawner.recordGpsTravel(sample);
+    animalSpawner.recordGpsTravel(sample);
   };
 
 
@@ -846,11 +855,19 @@ export function createFriendlyNpcManager({
       window.friendlies = friendlies;
     }
   };
+  const maybeSpawnAnimalsFromDistance = () => {
+    if (!playerModel) return;
+    const spawnEvent = animalSpawner.getSpawnEvent();
+    if (!spawnEvent?.position) return;
+    onSpawnEvent?.({ ...spawnEvent, type: 'animal' });
+  };
+
   const maybeSpawnFromDistance = () => {
     if (!playerModel) return;
     const spawnEvent = characterSpawner.getSpawnEvent();
     if (!spawnEvent?.position) return;
 
+    maybeSpawnAnimalsFromDistance();
     const currentPos = playerModel.position.clone();
     const playerIsNearFriendly = Array.from(records.values()).some((record) => {
       if (!record?.alive) return false;
@@ -929,6 +946,7 @@ export function createFriendlyNpcManager({
     setFriendlyPersistenceHost(nextHost);
     if (currentHost) {
       characterSpawner.reset();
+      animalSpawner.reset();
     }
   };
 


### PR DESCRIPTION
### Motivation
- Introduce a new wild animal type `Crab` and ensure animals can be configured to idle/wander rather than engaging players. 
- Spawn animals more frequently from player travel and allow configuring animal spawn cadence separately from other character spawns. 
- Provide a corpse pickup for crabs that integrates with existing meat/food flows.

### Description
- Added `Crab` to the animal pool and a weighted wild-animal picker so travel-based `animal` spawns pick `Crab` 80% / `Deer` 20% (`environment/animals.js`).
- Implemented `spawnWildAnimalAt` and `pickWildAnimalType` to support weighted selection and wired `handleCharacterSpawnEvent` to call `spawnWildAnimalAt` for `animal` spawn events (`environment/animals.js`, `app/bootstrapGameApp.js`).
- Respect `behavior: "idle"` for animal templates so idle-configured animals stay in idle/wander flow and do not switch to `runAway`/`attack` paths (`environment/animals.js`).
- Added a dedicated travel-distance animal spawner in `friendlyNpcManager` (configured to spawn every 10 meters) by creating an `animalSpawner` using the existing `createCharacterSpawner` API and invoking `onSpawnEvent` with `type: 'animal'` to preserve directional spawn placement (`friendlyNpcManager.js`, `characters/CharacterSpawn.js`).
- Added crab death pickups by extending `spawnMeatPickup` to accept `itemId` and `color`, added `CRAB_MEAT_ITEM_ID = 'crab_meat'`, and spawn red `crab_meat` when a crab dies while keeping `crab_meat` treated as a meat-class pickup for existing pickup/use flows (`app/bootstrapGameApp.js`).
- Extended `createCharacterSpawner` to accept `travelMinDistance` and `travelMaxDistance` so different spawners can use different distance cadences (`characters/CharacterSpawn.js`).

### Testing
- Built the project with `npm run -s build` and the build completed successfully.
- Linted/build tasks ran as part of the change verification; no runtime automated tests were added or executed beyond the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc350dd7c8331b47b55837273bf66)