### PR TITLE
Fix crab collisions and add knockback/flip reactions

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -4178,6 +4178,9 @@ async function initCore(runtimeContext) {
       const dogCollider = dogColliderEntries.get(animal?.id);
       if (dogCollider) removeStaticBoxCollider(dogCollider);
       dogColliderEntries.delete(animal?.id);
+      const crabCollider = crabColliderEntries.get(animal?.id);
+      if (crabCollider) removeStaticBoxCollider(crabCollider);
+      crabColliderEntries.delete(animal?.id);
       const label = animalNameLabels.get(animal?.id);
       label?.parentNode?.removeChild(label);
       animalNameLabels.delete(animal?.id);
@@ -8661,12 +8664,16 @@ async function initCore(runtimeContext) {
           const distance = hitPosition.distanceTo(monster.model.position);
           if (distance > damageRadius) continue;
           const attackTypes = getAttackTypes(attackLabel, ['explosive']);
-          const killed = monster.applyDamage(damage, { attackTypes });
+          const direction = new THREE.Vector3()
+            .subVectors(monster.model.position, hitPosition)
+            .normalize();
+          const killed = monster.applyDamage(damage, {
+            attackTypes,
+            hitDirection: direction,
+            knockbackStrength
+          });
           monster.lastDamageSourceId = shooterId ?? localId ?? null;
           if (!killed) {
-            const direction = new THREE.Vector3()
-              .subVectors(monster.model.position, hitPosition)
-              .normalize();
             monster.applyKnockback({ direction, strength: knockbackStrength });
           }
           handleMonsterDamage?.(monster, { damage, killed, sourceId: shooterId ?? localId, attackTypes });
@@ -12823,6 +12830,7 @@ async function initCore(runtimeContext) {
     });
   };
   const dogColliderEntries = new Map();
+  const crabColliderEntries = new Map();
   const companionData = { ...(playerProfile?.companions || {}) };
   const DOG_FOOD_HEAL = 10;
   const MEAT_FEED_HEAL = 30;
@@ -14946,6 +14954,22 @@ async function initCore(runtimeContext) {
         dogColliderEntries.set(animal.id, entry || null);
       } else {
         syncStaticBoxColliderForObject(dogColliderEntries.get(animal.id));
+      }
+    });
+    (animals || []).forEach((animal) => {
+      if (!animal?.model || String(animal.type).toLowerCase() !== 'crab' || animal?.isDead) return;
+      if (!crabColliderEntries.has(animal.id)) {
+        const entry = createStaticBoxColliderForObject(animal.model, {
+          rapierWorld,
+          friction: 1.1,
+          restitution: 0,
+          useObjectPosition: true,
+          centerOffset: [0, 0.25, 0],
+          halfExtents: [0.42, 0.22, 0.42]
+        });
+        crabColliderEntries.set(animal.id, entry || null);
+      } else {
+        syncStaticBoxColliderForObject(crabColliderEntries.get(animal.id));
       }
     });
     handleBombPickupArrowHit();

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -300,6 +300,16 @@ export class MonsterCharacter extends CharacterBase {
     } else {
       this.playAnimation('Hit', MOVE_FADE);
     }
+    const isCrab = String(this.type || '').toLowerCase() === 'crab';
+    if (isCrab && this.pivot?.rotation) {
+      this.pivot.rotation.z = Math.PI;
+    }
+    if (isCrab) {
+      const hitDirection = options?.hitDirection;
+      if (hitDirection?.lengthSq?.() > 0.000001) {
+        this.applyKnockback({ direction: hitDirection, strength: options?.knockbackStrength });
+      }
+    }
     return false;
   }
 

--- a/environment/animals.js
+++ b/environment/animals.js
@@ -17,6 +17,7 @@ const CRAB_CONTACT_PUSH_BOX_HALF_DEPTH = 0.5;
 const CRAB_CONTACT_PUSH_STRENGTH = 1.8;
 const CRAB_CONTACT_DAMAGE = 1;
 const CRAB_CONTACT_DAMAGE_COOLDOWN_MS = 850;
+const CRAB_CONTACT_KNOCKBACK_STRENGTH = 1.8;
 
 const loader = new GLTFLoader();
 const animalTemplateCache = new Map();
@@ -312,6 +313,14 @@ function applyCrabContactEffects(animal, playerModel) {
   const isInvincible = localControls?.isInvincible && now < (localControls.invincibleUntil || 0);
   if (!isInvincible && Number.isFinite(window.localHealth)) {
     window.localHealth = Math.max(0, window.localHealth - CRAB_CONTACT_DAMAGE);
+    const knockbackDirection = away.clone();
+    const playerControls = window.playerControls;
+    if (playerControls && !playerControls.isKnocked) {
+      playerControls.applyKnockback?.({
+        direction: knockbackDirection,
+        strength: CRAB_CONTACT_KNOCKBACK_STRENGTH
+      });
+    }
   }
   animal.userData.nextCrabContactDamageAt = now + CRAB_CONTACT_DAMAGE_COOLDOWN_MS;
 }

--- a/items/melee.js
+++ b/items/melee.js
@@ -224,11 +224,15 @@ export function updateMeleeAttacks({
           if (!monster?.model?.position) continue;
           if (isTargetInAttackRange(attacker.model, monster.model.position, attackCfg)) {
             hit = true;
-            const killed = monster.applyDamage(attackDamage, { attackTypes });
+            const dir = new THREE.Vector3()
+              .subVectors(monster.model.position, attacker.model.position)
+              .normalize();
+            const killed = monster.applyDamage(attackDamage, {
+              attackTypes,
+              hitDirection: dir,
+              knockbackStrength: attackCfg.knockbackStrength
+            });
             if (!killed) {
-              const dir = new THREE.Vector3()
-                .subVectors(monster.model.position, attacker.model.position)
-                .normalize();
               monster.applyKnockback({ direction: dir, strength: attackCfg.knockbackStrength });
             }
             onMonsterHit?.(monster, { damage: attackDamage, killed, sourceId: attacker.id, attackTypes });

--- a/items/projectiles.js
+++ b/items/projectiles.js
@@ -359,9 +359,13 @@ export function updateProjectiles({
             proj.userData.attackLabel || 'bowArrowProjectile',
             proj.userData.attackTypes || ['projectile']
           );
-          const killed = monster.applyDamage(damage, { attackTypes });
+          const direction = vel.clone();
+          const killed = monster.applyDamage(damage, {
+            attackTypes,
+            hitDirection: direction,
+            knockbackStrength: 3
+          });
           if (!killed) {
-            const direction = vel.clone();
             monster.applyKnockback({ direction, strength: 3 });
           }
           onMonsterHit?.(monster, { damage, killed, sourceId: proj.userData.shooterId, attackTypes });


### PR DESCRIPTION
### Motivation
- The player was able to walk through crabs because crabs had no persistent physical collider, and crab contact only applied damage without knockback. 
- Crabs should behave like other damaging entities by applying knockback to the player on contact and by reacting (knockback + flip) when hit.

### Description
- Added per-animal static box colliders for crabs and per-frame sync/cleanup so crabs block player movement (`app/bootstrapGameApp.js`).
- Extended crab contact handling to apply player knockback using the existing `playerControls.applyKnockback` API and added `CRAB_CONTACT_KNOCKBACK_STRENGTH` (`environment/animals.js`).
- Made crabs play a special hit reaction: flip upside-down (`pivot.rotation.z = Math.PI`) and apply knockback when damaged by consuming `hitDirection`/`knockbackStrength` passed in `applyDamage` (`characters/MonsterCharacter.js`).
- Propagated hit-direction and knockback metadata into monster damage calls from melee and projectile systems so the crab can react correctly (`items/melee.js`, `items/projectiles.js`), and into AOE/explosive damage handling (`app/bootstrapGameApp.js`).

### Testing
- Ran syntax checks with `node --check` on `environment/animals.js`, `characters/MonsterCharacter.js`, `items/melee.js`, `items/projectiles.js`, and `app/bootstrapGameApp.js`, all succeeded.
- Attempted `npm test -- --runInBand`, which failed because this repository has no `test` script configured in `package.json` (no unit tests executed).
- Verified code changes build-time safe via `node --check` and that files containing runtime hooks call the new `hitDirection`/`knockbackStrength` parameters where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de466bf708333bf696beb97bfaa9b)