### PR TITLE
Fix crab hit reactions by resolving monster type from model metadata

### DIFF
--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -74,7 +74,7 @@ export class MonsterCharacter extends CharacterBase {
     this.speedMultiplier = 1;
     this.attackDamage = MONSTER_ATTACK.damage;
     this.monsterProperties = this.resolveMonsterProperties(monsterConfig);
-    this.type = null;
+    this.type = String(this.model?.userData?.type || this.model?.userData?.monsterType || '').trim() || null;
     this.version = 0;
     this.isDead = false;
     this.deathTime = null;
@@ -300,7 +300,8 @@ export class MonsterCharacter extends CharacterBase {
     } else {
       this.playAnimation('Hit', MOVE_FADE);
     }
-    const isCrab = String(this.type || '').toLowerCase() === 'crab';
+    const resolvedType = String(this.type || this.model?.userData?.type || this.model?.userData?.monsterType || '').toLowerCase();
+    const isCrab = resolvedType.includes('crab');
     if (isCrab && this.pivot?.rotation) {
       this.pivot.rotation.z = Math.PI;
     }


### PR DESCRIPTION
### Motivation
- Crab-specific upside-down flip and knockback were not occurring because `MonsterCharacter` could have an unset or mismatched `this.type` versus the model metadata, so crab detection needed to reliably resolve the monster type from model/userData.

### Description
- Initialize `this.type` from `model.userData.type` or `model.userData.monsterType` and update crab detection in `applyDamage` to compute a normalized `resolvedType` and use `includes('crab')`, which restores the pivot flip (`pivot.rotation.z = Math.PI`) and knockback application for crabs.

### Testing
- Ran `npm run -s test`, which exited non-zero in this environment and did not produce runnable test output; no other automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df7324cd0833382baeac124b19398)