### PR TITLE
Preserve crab knockback and flip on lethal hits

### DIFF
--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -285,8 +285,19 @@ export class MonsterCharacter extends CharacterBase {
     this.model.userData.isProvoked = true;
     this.model.userData.mode = "enemy";
     this.showHealthBar();
+    const isCrab = String(this.type || '').toLowerCase() === 'crab';
+    const hitDirection = options?.hitDirection;
+    const canApplyCrabKnockback = isCrab && hitDirection?.lengthSq?.() > 0.000001;
+
+    if (isCrab && this.pivot?.rotation) {
+      this.pivot.rotation.z = Math.PI;
+    }
+    if (canApplyCrabKnockback) {
+      this.applyKnockback({ direction: hitDirection, strength: options?.knockbackStrength });
+    }
+
     if (this.health <= 0) {
-      this.markDead();
+      this.markDead({ preserveHorizontalVelocity: canApplyCrabKnockback });
       return true;
     }
     const requestedHitAnimation = typeof options?.hitAnimationName === 'string'
@@ -299,16 +310,6 @@ export class MonsterCharacter extends CharacterBase {
       this.playAnimation(resolvedHitAnimation, MOVE_FADE);
     } else {
       this.playAnimation('Hit', MOVE_FADE);
-    }
-    const isCrab = String(this.type || '').toLowerCase() === 'crab';
-    if (isCrab && this.pivot?.rotation) {
-      this.pivot.rotation.z = Math.PI;
-    }
-    if (isCrab) {
-      const hitDirection = options?.hitDirection;
-      if (hitDirection?.lengthSq?.() > 0.000001) {
-        this.applyKnockback({ direction: hitDirection, strength: options?.knockbackStrength });
-      }
     }
     return false;
   }
@@ -324,7 +325,7 @@ export class MonsterCharacter extends CharacterBase {
     return Date.now() < (this.freezeEndTime || 0);
   }
 
-  markDead() {
+  markDead({ preserveHorizontalVelocity = false } = {}) {
     if (this.isDead) return;
     this.isDead = true;
     this.deathTime = Date.now();
@@ -333,7 +334,11 @@ export class MonsterCharacter extends CharacterBase {
     const body = this.body;
     if (body) {
       const vel = body.linvel();
-      body.setLinvel({ x: 0, y: vel.y, z: 0 }, true);
+      body.setLinvel({
+        x: preserveHorizontalVelocity ? vel.x : 0,
+        y: vel.y,
+        z: preserveHorizontalVelocity ? vel.z : 0
+      }, true);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Ensure crab-specific visual flip and physics knockback still occur when a hit is lethal so the crab visibly flips and is knocked back even on death.
- Prevent immediate zeroing of horizontal velocity on death when crab knockback was just applied so the motion completes.

### Description
- Apply crab flip (`pivot.rotation.z = Math.PI`) and knockback before the lethal-hit early return in `applyDamage` so these effects run even on death. 
- Detect whether a crab knockback was applied using `canApplyCrabKnockback` and pass that into `markDead` as `preserveHorizontalVelocity`. 
- Extend `markDead` signature to `markDead({ preserveHorizontalVelocity = false } = {})` and preserve `x/z` velocity when `preserveHorizontalVelocity` is true instead of zeroing horizontal components. 
- Changes are localized to `characters/MonsterCharacter.js` and preserve existing behavior for non-crab types.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Running `npm test` failed because the project does not define a `test` script. 
- Confirmed repository scripts with `npm run` which listed `dev`, `build`, `preview`, and other build-related scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dfc3629ec8333be9a3b784d062020)