### PR TITLE
Add combat target buttons for deer and crabs

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -14576,7 +14576,7 @@ async function initCore(runtimeContext) {
     monsterAnimFrustum.setFromProjectionMatrix(monsterAnimProjMatrix);
 
     for (const monster of monsters) {
-      const model = entity?.model;
+      const model = monster?.model;
       const mixer = model?.userData?.mixer;
       if (!mixer || !model) continue;
 

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -12851,34 +12851,34 @@ async function initCore(runtimeContext) {
   feedDogBtn.textContent = 'Feed Dog';
   feedDogBtn.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%, -50%);z-index:1200;display:none;padding:8px 12px;';
   document.body.appendChild(feedDogBtn);
-  const monsterTargetButtons = new Map();
+  const combatTargetButtons = new Map();
   const WEAPON_TARGET_MAX_DISTANCE = 15;
   const TARGET_BTN_SIZE = 32;
-  const clearMonsterTargetButtons = () => {
-    monsterTargetButtons.forEach((entry) => entry?.button?.remove());
-    monsterTargetButtons.clear();
+  const clearCombatTargetButtons = () => {
+    combatTargetButtons.forEach((entry) => entry?.button?.remove());
+    combatTargetButtons.clear();
   };
   const isTargetableWeaponEquipped = () => {
     const weapon = playerControls?.getEquippedWeapon?.('right');
     return weapon?.itemId === 'bomb' || weapon?.itemId === 'bow' || weapon?.itemId === 'bazooka';
   };
-  const getMonsterTargetKey = (monster) => monster?.id || monster?.model?.uuid || String(Math.random());
-  const getOrCreateMonsterTargetButton = (monster) => {
-    const key = getMonsterTargetKey(monster);
-    if (monsterTargetButtons.has(key)) return monsterTargetButtons.get(key);
+  const getCombatTargetKey = (entity, type = 'monster') => `${type}:${entity?.id || entity?.model?.uuid || Math.random()}`;
+  const getOrCreateCombatTargetButton = (entity, type = 'monster') => {
+    const key = getCombatTargetKey(entity, type);
+    if (combatTargetButtons.has(key)) return combatTargetButtons.get(key);
     const button = document.createElement('button');
     button.type = 'button';
     button.textContent = '🎯';
-    button.setAttribute('aria-label', 'Target monster');
+    button.setAttribute('aria-label', type === 'animal' ? 'Target animal' : 'Target monster');
     button.style.cssText = `position:fixed;z-index:1200;display:none;width:${TARGET_BTN_SIZE}px;height:${TARGET_BTN_SIZE}px;border-radius:999px;padding:0;font-size:18px;line-height:1;`;
     button.addEventListener('click', () => {
-      const model = monster?.model;
+      const model = entity?.model;
       if (!model?.position) return;
       playerControls?.fireProjectileAtTarget?.(model, 'right');
     });
     document.body.appendChild(button);
-    const entry = { key, monster, button };
-    monsterTargetButtons.set(key, entry);
+    const entry = { key, entity, button, type };
+    combatTargetButtons.set(key, entry);
     return entry;
   };
   const animalNameLabels = new Map();
@@ -13948,9 +13948,9 @@ async function initCore(runtimeContext) {
           feedDogBtn.style.display = 'none';
         }
         if (labelsBlocked || !isTargetableWeaponEquipped()) {
-          clearMonsterTargetButtons();
+          clearCombatTargetButtons();
         } else {
-          const visibleMonsterKeys = new Set();
+          const visibleTargetKeys = new Set();
           monsters.forEach((monster) => {
             if (!monster?.model?.position || monster.isDead) return;
             const distance = playerPos.distanceTo(monster.model.position);
@@ -13959,16 +13959,34 @@ async function initCore(runtimeContext) {
             buttonAnchor.project(camera);
             if (buttonAnchor.z < 0 || buttonAnchor.z > 1) return;
             if (Math.abs(buttonAnchor.x) > 1 || Math.abs(buttonAnchor.y) > 1) return;
-            const entry = getOrCreateMonsterTargetButton(monster);
-            visibleMonsterKeys.add(entry.key);
+            const entry = getOrCreateCombatTargetButton(monster, 'monster');
+            visibleTargetKeys.add(entry.key);
             const x = (buttonAnchor.x * 0.5 + 0.5) * window.innerWidth;
             const y = (-buttonAnchor.y * 0.5 + 0.5) * window.innerHeight;
             entry.button.style.display = 'block';
             entry.button.style.left = `${x - (TARGET_BTN_SIZE / 2)}px`;
             entry.button.style.top = `${y + 10}px`;
           });
-          monsterTargetButtons.forEach((entry, key) => {
-            if (!visibleMonsterKeys.has(key)) {
+          (animals || []).forEach((animal) => {
+            if (!animal?.model?.position || animal.isDead) return;
+            const animalType = String(animal?.type || '').toLowerCase();
+            if (animalType !== 'deer' && animalType !== 'crab') return;
+            const distance = playerPos.distanceTo(animal.model.position);
+            if (distance > WEAPON_TARGET_MAX_DISTANCE) return;
+            const buttonAnchor = animal.model.position.clone().add(new THREE.Vector3(0, 2.1, 0));
+            buttonAnchor.project(camera);
+            if (buttonAnchor.z < 0 || buttonAnchor.z > 1) return;
+            if (Math.abs(buttonAnchor.x) > 1 || Math.abs(buttonAnchor.y) > 1) return;
+            const entry = getOrCreateCombatTargetButton(animal, 'animal');
+            visibleTargetKeys.add(entry.key);
+            const x = (buttonAnchor.x * 0.5 + 0.5) * window.innerWidth;
+            const y = (-buttonAnchor.y * 0.5 + 0.5) * window.innerHeight;
+            entry.button.style.display = 'block';
+            entry.button.style.left = `${x - (TARGET_BTN_SIZE / 2)}px`;
+            entry.button.style.top = `${y + 10}px`;
+          });
+          combatTargetButtons.forEach((entry, key) => {
+            if (!visibleTargetKeys.has(key)) {
               entry.button.style.display = 'none';
             }
           });
@@ -14558,7 +14576,7 @@ async function initCore(runtimeContext) {
     monsterAnimFrustum.setFromProjectionMatrix(monsterAnimProjMatrix);
 
     for (const monster of monsters) {
-      const model = monster?.model;
+      const model = entity?.model;
       const mixer = model?.userData?.mixer;
       if (!mixer || !model) continue;
 


### PR DESCRIPTION
### Motivation
- Reuse the existing monster-target UI affordance so nearby animals (deer and crabs) show the same targeting reticle when the player has a targetable weapon equipped.
- Keep the original interaction gating so the button appears only when near the animal, on-screen, and when equipped with `bow`, `bomb`, or `bazooka`.

### Description
- Generalized the monster-only button map into a shared `combatTargetButtons` map and replaced the old `monsterTargetButtons` helpers with `getCombatTargetKey`, `getOrCreateCombatTargetButton`, and `clearCombatTargetButtons`.
- Reused the same on-screen 🎯 button and click handler that calls `playerControls.fireProjectileAtTarget` for monsters and animals, preserving the same behavior and accessibility label logic.
- Extended the per-frame UI pass to include `(animals || [])` and filter for `deer` and `crab` so those animals receive a target button when within `WEAPON_TARGET_MAX_DISTANCE` and on-screen.
- Preserved existing visibility constraints (blocked by overlays or when a non-targetable weapon is equipped) so buttons are shown/cleared in the same circumstances.

### Testing
- Ran the production build with `npm run -s build`, which completed successfully (build finished and chunks emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f31766d3083339a5cd4a3dd0eeb8f)