### PR TITLE
Prevent bomb/bazooka self-damage and owner-allied companion friendly-fire

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -8672,7 +8672,7 @@ async function initCore(runtimeContext) {
     const isHost = !multiplayer || multiplayer.isHost;
     const damage = getExplosiveDamage(shooterId, baseDamage);
 
-    if (playerModel?.position) {
+    if (playerModel?.position && !isPlayerOwnExplosiveTarget(shooterId, localId)) {
       const distance = hitPosition.distanceTo(playerModel.position);
       if (distance <= damageRadius) {
         const localControls = runtimeContext.systems.playerControls ?? window.playerControls;
@@ -8700,6 +8700,7 @@ async function initCore(runtimeContext) {
 
     for (const [id, { model }] of Object.entries(otherPlayers)) {
       if (!model?.position) continue;
+      if (isPlayerOwnExplosiveTarget(shooterId, id)) continue;
       const distance = hitPosition.distanceTo(model.position);
       if (distance > damageRadius) continue;
       const player = otherPlayers[id];
@@ -8724,6 +8725,7 @@ async function initCore(runtimeContext) {
       if (isHost) {
         for (const monster of creatures) {
           if (!monster?.model?.position) continue;
+          if (shouldIgnoreExplosiveCreatureDamage(monster, shooterId ?? localId)) continue;
           const distance = hitPosition.distanceTo(monster.model.position);
           if (distance > damageRadius) continue;
           const attackTypes = getAttackTypes(attackLabel, ['explosive']);
@@ -8748,6 +8750,7 @@ async function initCore(runtimeContext) {
       } else {
         for (const monster of creatures) {
           if (!monster?.model?.position) continue;
+          if (shouldIgnoreExplosiveCreatureDamage(monster, shooterId ?? localId)) continue;
           const distance = hitPosition.distanceTo(monster.model.position);
           if (distance > damageRadius) continue;
           sendMonsterAttackIntent?.({
@@ -8786,6 +8789,31 @@ async function initCore(runtimeContext) {
         }
       });
     }
+  }
+
+  function isPlayerOwnExplosiveTarget(shooterId, targetPlayerId) {
+    return !!shooterId && !!targetPlayerId && shooterId === targetPlayerId;
+  }
+
+  function getCompanionOwnerId(animal) {
+    if (!animal) return null;
+    const rawId = String(animal.id || '');
+    if (rawId.startsWith('companionDog:')) {
+      return rawId.slice('companionDog:'.length).split(':')[0] || null;
+    }
+    if (animal?.model?.userData?.isCompanion && !animal?.model?.userData?.remoteSynced) {
+      return multiplayer?.getId?.() || null;
+    }
+    return null;
+  }
+
+  function shouldIgnoreExplosiveCreatureDamage(creature, shooterId) {
+    if (!creature || !shooterId) return false;
+    const creatureId = String(creature.id || '');
+    if (creatureId === `questFriend:${shooterId}`) return true;
+    const companionOwnerId = getCompanionOwnerId(creature);
+    if (companionOwnerId && companionOwnerId === shooterId) return true;
+    return false;
   }
 
   function getBombDamage(shooterId) {


### PR DESCRIPTION
### Motivation
- Prevent players from being harmed by their own bombs/bazooka missiles and avoid damaging their companion dogs or quest friend. 
- Ensure the same owner-aware immunity applies in both host-authoritative and client-intent code paths to keep multiplayer behavior consistent. 
- Avoid the prior runtime/physics aliasing issues by skipping owner-owned companion/quest entities during explosive AoE processing.

### Description
- Added helper functions `isPlayerOwnExplosiveTarget`, `getCompanionOwnerId`, and `shouldIgnoreExplosiveCreatureDamage` to identify shooter-owned targets and companions in `app/bootstrapGameApp.js`. 
- Updated `applyExplosiveImpactDamage` to skip applying damage to the firing player and to skip other players when `shooterId` equals the target player id. 
- Applied `shouldIgnoreExplosiveCreatureDamage` in both the host damage loop and the non-host `sendMonsterAttackIntent` path so a shooter’s `companionDog:*` and `questFriend:<id>` are excluded from bomb/bazooka AoE. 
- Kept `getBombDamage`, `applyBombImpactDamage`, and `applyMissileImpactDamage` using the shared explosive-impact path so changes cover both bombs and bazooka missiles.

### Testing
- Ran `node --check app/bootstrapGameApp.js` to verify syntax and it succeeded. 
- Verified file changes with `git status --short` and committed the updated `app/bootstrapGameApp.js`. 
- No automated unit test suite was present for this change, so only static syntax checks and a commit validation were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f65528818832ba3b8babc31549768)