### PR TITLE
Fix Rapier aliasing crash by caching monster collider handles

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -3729,8 +3729,9 @@ async function initCore(runtimeContext) {
     const rb = rapierWorld.createRigidBody(rbDesc);
     rb.setEnabledRotations(false, true, false, true);
     const colDesc = RAPIER.ColliderDesc.capsule(0.6 * scale, 0.3 * scale);
-    rapierWorld.createCollider(colDesc, rb);
+    const collider = rapierWorld.createCollider(colDesc, rb);
     model.userData.rb = rb;
+    monster.setColliderHandles?.(typeof collider?.handle === 'number' ? [collider.handle] : []);
     rbToMesh.set(rb, model);
     if (monster.syncBodyFromTransform) {
       monster.syncBodyFromTransform({ zeroVelocity: true });
@@ -3749,6 +3750,7 @@ async function initCore(runtimeContext) {
       removeRigidBodySafely(rapierWorld, body);
     }
     monster.model.userData.rb = null;
+    monster.setColliderHandles?.([]);
     monster.setBackgroundMode?.(true);
   }
 

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -94,6 +94,7 @@ export class MonsterCharacter extends CharacterBase {
     this.healthBar = this.createHealthBar();
     this.healthBarVisibleUntil = 0;
     this.backgroundMode = false;
+    this.colliderHandles = [];
     this.isProvoked = false;
     this.model.userData.monsterProperties = this.monsterProperties;
     this.model.userData.lastHitAttackTypes = [];
@@ -103,6 +104,14 @@ export class MonsterCharacter extends CharacterBase {
 
   get body() {
     return this.model?.userData?.rb ?? null;
+  }
+
+  setColliderHandles(handles) {
+    if (!Array.isArray(handles)) {
+      this.colliderHandles = [];
+      return;
+    }
+    this.colliderHandles = handles.filter((handle) => Number.isInteger(handle));
   }
 
   setMode(mode) {
@@ -142,17 +151,9 @@ export class MonsterCharacter extends CharacterBase {
     const resolver = context?.resolveGroundY;
     if (typeof resolver !== 'function') return null;
     const referenceY = Number.isFinite(context?.referenceY) ? context.referenceY : this.model?.position?.y;
-    const body = this.body;
-    const excludedColliderHandles = [];
-    if (body && typeof body.numColliders === 'function' && typeof body.collider === 'function') {
-      const colliderCount = body.numColliders();
-      for (let i = 0; i < colliderCount; i += 1) {
-        const collider = body.collider(i);
-        if (typeof collider?.handle === 'number') {
-          excludedColliderHandles.push(collider.handle);
-        }
-      }
-    }
+    const excludedColliderHandles = Array.isArray(this.colliderHandles)
+      ? this.colliderHandles.filter((handle) => Number.isInteger(handle))
+      : [];
     const result = resolver(
       x,
       Number.isFinite(referenceY) ? referenceY + 4 : 4,


### PR DESCRIPTION
### Motivation
- Prevent Rapier runtime panics caused by inspecting a monster body’s colliders during per-frame ground sampling, which triggered "recursive use of an object detected" unsafe-aliasing errors.

### Description
- Add a `colliderHandles` cache on `MonsterCharacter` and a `setColliderHandles(handles)` method to manage the cached collider handles safely.
- Replace per-frame calls to `body.numColliders()` / `body.collider(i)` in `resolveGroundSample` with reading the integer-validated `colliderHandles` array for `excludedColliderHandles`.
- Populate the cache when creating a monster collider in `attachMonsterPhysics` and clear it in `detachMonsterPhysics` using `monster.setColliderHandles?.([...])` and `monster.setColliderHandles?.([])`.
- Keep the exclusion filter numeric-safe by filtering handles with `Number.isInteger` before use.

### Testing
- Ran `npm run build`, which completed successfully. 
- The build emitted non-blocking Rollup warnings (a `/* @__PURE__ */` comment parsing warning and chunk-size warnings) but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f696d465c832bbac444b2fa1243d8)