### PR TITLE
Add High Contrast Mode toggle and high-contrast rendering

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -335,6 +335,12 @@ const DISPLAY_PRESETS = {
     skyBrightness: 0.25
   }
 };
+const HIGH_CONTRAST_PRESET = {
+  ambientIntensity: 2.0,
+  directionalIntensity: 2.0,
+  groundBrightness: 2.0,
+  buildingBrightness: 2.0
+};
 const PERFORMANCE_MODES = new Set(['auto', 'quality', 'balanced', 'performance']);
 const PERFORMANCE_PROFILE_CAPS = {
   low: 1.0,
@@ -1379,6 +1385,8 @@ async function initCore(runtimeContext) {
   const clampValue = (value, min, max) => Math.min(Math.max(value, min), max);
   const pickupEmissiveMaterials = new Set();
   let pickupEmissiveBrightness = 1;
+  const highContrastSkyDay = new THREE.Color(0x051024);
+  const highContrastSkyNight = new THREE.Color(0x000000);
   const captureMaterialBase = (material) => {
     if (!material) return null;
     const color = material.color?.clone ? material.color.clone() : new THREE.Color(0xffffff);
@@ -1426,6 +1434,49 @@ async function initCore(runtimeContext) {
     }
     material.emissiveIntensity = base.emissiveIntensity * clamped;
     material.needsUpdate = true;
+  };
+  const applyHighContrastMaterialState = (material, enabled) => {
+    if (!material || !material.isMaterial) return;
+    material.userData = material.userData || {};
+    if (!material.userData.baseHighContrastState) {
+      material.userData.baseHighContrastState = {
+        toneMapped: material.toneMapped,
+        color: material.color?.clone ? material.color.clone() : null,
+        emissive: material.emissive?.clone ? material.emissive.clone() : null,
+        emissiveIntensity: typeof material.emissiveIntensity === 'number' ? material.emissiveIntensity : null
+      };
+    }
+    const base = material.userData.baseHighContrastState;
+    if (!enabled) {
+      material.toneMapped = base.toneMapped;
+      if (base.color && material.color?.copy) material.color.copy(base.color);
+      if (base.emissive && material.emissive?.copy) material.emissive.copy(base.emissive);
+      if (typeof base.emissiveIntensity === 'number') material.emissiveIntensity = base.emissiveIntensity;
+      material.needsUpdate = true;
+      return;
+    }
+    material.toneMapped = false;
+    if (material.color?.copy && base.color) {
+      const luminance = base.color.r * 0.2126 + base.color.g * 0.7152 + base.color.b * 0.0722;
+      const contrastBoost = luminance > 0.45 ? 1 : 0.08;
+      material.color.copy(base.color).multiplyScalar(contrastBoost);
+      material.color.offsetHSL(0, 0.4, luminance > 0.45 ? 0.15 : -0.03);
+    }
+    if (material.emissive?.copy && base.emissive) {
+      material.emissive.copy(base.emissive).multiplyScalar(2.6);
+    }
+    if (typeof material.emissiveIntensity === 'number' && typeof base.emissiveIntensity === 'number') {
+      material.emissiveIntensity = Math.max(1.2, base.emissiveIntensity * 2.4);
+    }
+    material.needsUpdate = true;
+  };
+  const applyHighContrastToScene = (enabled) => {
+    if (!scene) return;
+    scene.traverse((child) => {
+      if (!child?.isMesh) return;
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((material) => applyHighContrastMaterialState(material, enabled));
+    });
   };
   const getAutoMode = () => {
     const now = new Date();
@@ -1491,7 +1542,7 @@ async function initCore(runtimeContext) {
   };
 
   const loadDisplaySettings = () => {
-    const defaults = { mode: 'auto', performanceMode: 'auto', ...DISPLAY_PRESETS.day };
+    const defaults = { mode: 'auto', performanceMode: 'auto', highContrastMode: false, ...DISPLAY_PRESETS.day };
     const raw = localStorage.getItem(DISPLAY_SETTINGS_KEY);
     if (!raw) return defaults;
     try {
@@ -1524,6 +1575,9 @@ async function initCore(runtimeContext) {
   if (!PERFORMANCE_MODES.has(displaySettings.performanceMode)) {
     displaySettings.performanceMode = 'auto';
   }
+  if (typeof displaySettings.highContrastMode !== 'boolean') {
+    displaySettings.highContrastMode = false;
+  }
   if (displaySettings.mode === 'auto') {
     lastAutoMode = getAutoMode();
     applyPresetForMode(lastAutoMode);
@@ -1539,22 +1593,36 @@ async function initCore(runtimeContext) {
       1
     );
     pickupEmissiveBrightness = pickupBrightness;
+    const highContrastEnabled = Boolean(displaySettings.highContrastMode);
     if (scene) {
       if (effectiveMode === 'night') {
-        scene.background = new THREE.Color(0x000000);
+        scene.background = highContrastEnabled ? highContrastSkyNight : new THREE.Color(0x000000);
       } else {
-        scene.background = skyboxTexture;
+        scene.background = highContrastEnabled ? highContrastSkyDay : skyboxTexture;
       }
     }
+    const ambientIntensity = highContrastEnabled
+      ? HIGH_CONTRAST_PRESET.ambientIntensity
+      : displaySettings.ambientIntensity;
+    const directionalIntensity = highContrastEnabled
+      ? HIGH_CONTRAST_PRESET.directionalIntensity
+      : displaySettings.directionalIntensity;
+    const groundBrightness = highContrastEnabled
+      ? HIGH_CONTRAST_PRESET.groundBrightness
+      : displaySettings.groundBrightness;
+    const buildingBrightness = highContrastEnabled
+      ? HIGH_CONTRAST_PRESET.buildingBrightness
+      : displaySettings.buildingBrightness;
     if (ambientLight) {
-      ambientLight.intensity = clampValue(displaySettings.ambientIntensity, 0, 2);
+      ambientLight.intensity = clampValue(ambientIntensity, 0, 2);
     }
     if (dirLight) {
-      dirLight.intensity = clampValue(displaySettings.directionalIntensity, 0, 2);
+      dirLight.intensity = clampValue(directionalIntensity, 0, 2);
     }
-    applyMaterialBrightness(groundTiles?.material, groundMaterialBase, displaySettings.groundBrightness);
-    applyMaterialBrightness(buildingsRenderer?.materials?.extruded, buildingMaterialBase?.extruded, displaySettings.buildingBrightness);
-    applyMaterialBrightness(buildingsRenderer?.materials?.flat, buildingMaterialBase?.flat, displaySettings.buildingBrightness);
+    applyMaterialBrightness(groundTiles?.material, groundMaterialBase, groundBrightness);
+    applyMaterialBrightness(buildingsRenderer?.materials?.extruded, buildingMaterialBase?.extruded, buildingBrightness);
+    applyMaterialBrightness(buildingsRenderer?.materials?.flat, buildingMaterialBase?.flat, buildingBrightness);
+    applyHighContrastToScene(highContrastEnabled);
     mapRenderer?.setBrightness?.(pickupBrightness);
     for (const material of pickupEmissiveMaterials) {
       if (!material || typeof material.emissiveIntensity !== 'number') continue;
@@ -1637,6 +1705,13 @@ async function initCore(runtimeContext) {
       displaySettings.performanceMode = value;
       saveDisplaySettings();
       applyRendererPerformanceSettings();
+      updateSettingsUI();
+      return;
+    }
+    if (key === 'highContrastMode') {
+      displaySettings.highContrastMode = Boolean(value);
+      saveDisplaySettings();
+      applyDisplaySettings();
       updateSettingsUI();
       return;
     }

--- a/controls/settingsPanel.js
+++ b/controls/settingsPanel.js
@@ -644,6 +644,15 @@ function buildDisplayPanel() {
     unitsSelect.appendChild(option);
   });
   unitsGroup.append(unitsLabel, unitsSelect);
+  const highContrastGroup = createElement('div', 'settings-field');
+  const highContrastLabel = createElement('label', 'settings-label', 'High Contrast Mode');
+  highContrastLabel.setAttribute('for', 'settings-display-high-contrast');
+  const highContrastToggle = createElement('input', 'settings-checkbox');
+  highContrastToggle.id = 'settings-display-high-contrast';
+  highContrastToggle.type = 'checkbox';
+  const highContrastHint = createElement('div', 'settings-muted');
+  highContrastHint.textContent = 'Boosts object contrast and lighting for better daytime phone visibility.';
+  highContrastGroup.append(highContrastLabel, highContrastToggle, highContrastHint);
 
   const createRangeField = ({ id, label, min, max, step }) => {
     const field = createElement('div', 'settings-field');
@@ -706,6 +715,7 @@ function buildDisplayPanel() {
     modeGroup,
     performanceGroup,
     unitsGroup,
+    highContrastGroup,
     ambientField.field,
     directionalField.field,
     groundField.field,
@@ -718,6 +728,7 @@ function buildDisplayPanel() {
     modeSelect,
     performanceSelect,
     unitsSelect,
+    highContrastToggle,
     sliders: {
       ambientIntensity: ambientField.input,
       directionalIntensity: directionalField.input,
@@ -1636,6 +1647,11 @@ function bindEvents() {
       update();
     });
   }
+  if (elements.displayFields?.highContrastToggle) {
+    elements.displayFields.highContrastToggle.addEventListener('change', (event) => {
+      context.appState?.setDisplaySetting?.('highContrastMode', event.target.checked);
+    });
+  }
 
   if (elements.displayFields?.sliders) {
     Object.entries(elements.displayFields.sliders).forEach(([key, slider]) => {
@@ -2038,6 +2054,9 @@ export function updateUI() {
     }
     if (elements.displayFields.unitsSelect) {
       elements.displayFields.unitsSelect.value = getDistanceUnitPreference();
+    }
+    if (elements.displayFields.highContrastToggle) {
+      elements.displayFields.highContrastToggle.checked = Boolean(displaySettings?.highContrastMode);
     }
     Object.entries(elements.displayFields.sliders || {}).forEach(([key, slider]) => {
       const value = displaySettings?.[key];


### PR DESCRIPTION
### Motivation
- Improve daytime phone visibility by offering a single toggle that boosts contrast/brightness for player, environment and objects so the scene is easier to read in bright sunlight. 

### Description
- Added a `High Contrast Mode` checkbox to the Display tab UI and wired it into the `elements.displayFields` model in `controls/settingsPanel.js`. 
- Persisted and validated a new `highContrastMode` flag in the display settings load/save path in `app/bootstrapGameApp.js`. 
- Implemented a high-contrast rendering path: added `HIGH_CONTRAST_PRESET`, high-contrast sky colors, and functions `applyHighContrastMaterialState` and `applyHighContrastToScene` that boost material/emissive contrast and temporarily change tone-mapping; the apply path is invoked from `applyDisplaySettings`. 
- Exposed the new setting to the existing settings update lifecycle via `setDisplaySetting('highContrastMode', ...)` so toggling immediately updates rendering and is saved. 

### Testing
- Ran the production build with `npm run build`, which completed successfully; Vite/Rollup emitted only non-blocking warnings about chunk sizes and a comment annotation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6cb0b914832b8b4fbd82705dd6d2)