### PR TITLE
Fix ground texture restoration after high contrast mode toggle

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -1651,10 +1651,17 @@ async function initCore(runtimeContext) {
         material.userData.baseGroundMap = material.map ?? null;
       }
       if (highContrastEnabled) {
+        const currentMap = material.map ?? null;
+        if (currentMap !== highContrastGroundTexture) {
+          material.userData.preHighContrastGroundMap = currentMap;
+        }
         if (material.color?.setHex) material.color.setHex(0xffffff);
         if (highContrastGroundTexture) material.map = highContrastGroundTexture;
       } else {
-        material.map = material.userData.baseGroundMap ?? null;
+        const restoredMap = Object.prototype.hasOwnProperty.call(material.userData, 'preHighContrastGroundMap')
+          ? material.userData.preHighContrastGroundMap
+          : material.userData.baseGroundMap;
+        material.map = restoredMap ?? null;
       }
       material.needsUpdate = true;
     }


### PR DESCRIPTION
### Motivation
- Toggling high contrast mode previously replaced the ground material map with a high-contrast texture and did not reliably restore the original ground texture when disabling the mode, leaving the ground white instead of returning to its prior appearance.

### Description
- In `app/bootstrapGameApp.js` preserve the active ground `material.map` into `material.userData.preHighContrastGroundMap` before assigning the high-contrast texture, and restore that preserved map when `highContrastMode` is disabled, falling back to the original `baseGroundMap` if no preserved pre-toggle map exists.

### Testing
- Ran the production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105a01537c832b95e5c34ed052b692)