### PR TITLE
Add shield to mobile Equip quick-select menu

### DIFF
--- a/controls/controls.js
+++ b/controls/controls.js
@@ -870,6 +870,7 @@ export class PlayerControls {
     const appState = appContext.uiState.appState ?? window.appState;
     const inventory = appState?.getInventory?.() || {};
     const equipCandidates = [
+      { id: 'shield', label: 'Shield' },
       { id: 'bomb', label: 'Bomb' },
       { id: 'bow', label: 'Bow' },
       { id: 'bazooka', label: 'Bazooka' },


### PR DESCRIPTION
### Motivation
- Make the Shield item available from the bottom-right `Equip` quick-select menu so players can equip it directly from the mobile Equip UI.

### Description
- Added `{ id: 'shield', label: 'Shield' }` to the `equipCandidates` array in `controls/controls.js` so Shield is shown alongside other equippable items when present in inventory.

### Testing
- Ran `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105a36b874832b9713697971f5b385)