### PR TITLE
Register mountains as ground, disable mountain climb areas, and raise spawns above mountain geometry

### DIFF
--- a/environment/nature.js
+++ b/environment/nature.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { setClimbableAreas } from '../controls/climb.js';
 import { removeRigidBodySafely } from '../physics/rapierSafety.js';
-import { registerTerrainHeightResolver } from './terrainHeight.js';
+import { registerTerrainHeightResolver, getTerrainHeightWithoutResolvers } from './terrainHeight.js';
 import * as BufferGeometryUtils from
   'three/examples/jsm/utils/BufferGeometryUtils.js';
 
@@ -346,6 +346,12 @@ export async function createNature({
     return Math.max(1, Math.ceil(evictRadius / 2));
   };
   let tileBuffer = getTreeTileBuffer(activeTileCache);
+  const getWorldGenerationTerrainHeight = (x, z) => {
+    const sampler = typeof getTerrainHeightWithoutResolvers === 'function'
+      ? getTerrainHeightWithoutResolvers
+      : getTerrainHeight;
+    return sampler?.(x, z) ?? 0;
+  };
 
   const getTileKey = (tile) => `${tile.x},${tile.y}`;
   const getTileFromKey = (tileKey) => {
@@ -591,7 +597,7 @@ export async function createNature({
       0.3,
       0.75
     );
-    const terrainY = getTerrainHeight?.(centerX, centerZ) ?? tree.position.y;
+    const terrainY = getWorldGenerationTerrainHeight(centerX, centerZ) ?? tree.position.y;
     const rbDesc = rapier.RigidBodyDesc.fixed().setTranslation(centerX, terrainY + halfHeight, centerZ);
     const rb = rapierWorld.createRigidBody(rbDesc);
     const colliderDesc = rapier.ColliderDesc.cylinder(halfHeight, colliderRadius)
@@ -900,7 +906,7 @@ export async function createNature({
         const scale =
           TREE_SCALE_MIN +
           pseudoRandom2D(worldX, worldZ, 7.7) * (TREE_SCALE_MAX - TREE_SCALE_MIN);
-        const terrainY = getTerrainHeight?.(worldX, worldZ) ?? 0;
+        const terrainY = getWorldGenerationTerrainHeight(worldX, worldZ) ?? 0;
         const tree = createTreeImpostor({
           worldX,
           worldZ,
@@ -990,7 +996,7 @@ export async function createNature({
           continue;
         }
 
-        const terrainY = getTerrainHeight?.(worldX, worldZ) ?? 0;
+        const terrainY = getWorldGenerationTerrainHeight(worldX, worldZ) ?? 0;
         const bush = createBushImpostor({
           worldX,
           worldZ,
@@ -1018,7 +1024,7 @@ export async function createNature({
           userData: { boundsRadius: footprint * 0.6 }
         };
         if (tileBlockers && isTreeBlocked(mountainProbe, tileBlockers)) continue;
-        const terrainY = getTerrainHeight?.(worldX, worldZ) ?? 0;
+        const terrainY = getWorldGenerationTerrainHeight(worldX, worldZ) ?? 0;
         const mountainHeight = MOUNTAIN_MIN_HEIGHT
           + pseudoRandom2D(worldX, worldZ, 63.5) * (MOUNTAIN_MAX_HEIGHT - MOUNTAIN_MIN_HEIGHT);
         const mountain = createMountainImpostor({
@@ -1066,7 +1072,7 @@ export async function createNature({
         const rock = new THREE.Mesh(rockGeometries[geometryIndex], rockMaterial);
         rock.castShadow = true;
         rock.receiveShadow = true;
-        const terrainY = getTerrainHeight?.(worldX, worldZ) ?? 0;
+        const terrainY = getWorldGenerationTerrainHeight(worldX, worldZ) ?? 0;
         rock.position.set(worldX, terrainY + radius * 0.36, worldZ);
         const uniformScale = radius * (1.5 + pseudoRandom2D(worldX, worldZ, 26.1) * 0.5);
         rock.scale.set(
@@ -1435,7 +1441,7 @@ export async function createNature({
     const rock = new THREE.Mesh(rockGeometries[geometryIndex], rockMaterial);
     rock.castShadow = true;
     rock.receiveShadow = true;
-    const terrainY = getTerrainHeight?.(position.x, position.z) ?? position.y ?? 0;
+    const terrainY = getWorldGenerationTerrainHeight(position.x, position.z) ?? position.y ?? 0;
     rock.position.set(position.x, terrainY + radius * 0.36, position.z);
     const uniformScale = radius * 1.8;
     rock.scale.set(uniformScale, uniformScale * 0.85, uniformScale * 0.95);

--- a/environment/nature.js
+++ b/environment/nature.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { setClimbableAreas } from '../controls/climb.js';
 import { removeRigidBodySafely } from '../physics/rapierSafety.js';
+import { registerTerrainHeightResolver } from './terrainHeight.js';
 import * as BufferGeometryUtils from
   'three/examples/jsm/utils/BufferGeometryUtils.js';
 
@@ -254,6 +255,27 @@ export async function createNature({
   scene.add(group);
 
   const treeTiles = new Map();
+  const activeMountains = new Set();
+  const mountainRaycaster = new THREE.Raycaster();
+  const mountainRayOrigin = new THREE.Vector3();
+  const mountainRayDirection = new THREE.Vector3(0, -1, 0);
+  const unregisterMountainHeightResolver = registerTerrainHeightResolver((x, z, currentHeight = 0) => {
+    let bestHeight = currentHeight;
+    for (const mountain of activeMountains) {
+      const radius = Number(mountain?.userData?.boundsRadius) || 0;
+      if (radius <= 0) continue;
+      const dx = x - mountain.position.x;
+      const dz = z - mountain.position.z;
+      if (dx * dx + dz * dz > (radius * 1.2) * (radius * 1.2)) continue;
+      mountainRayOrigin.set(x, mountain.position.y + (mountain.userData?.mountainHeight ?? 0) + 12, z);
+      mountainRaycaster.set(mountainRayOrigin, mountainRayDirection);
+      const hits = mountainRaycaster.intersectObject(mountain, true);
+      if (hits.length > 0 && Number.isFinite(hits[0].point.y) && hits[0].point.y > bestHeight) {
+        bestHeight = hits[0].point.y;
+      }
+    }
+    return bestHeight;
+  });
   const climbableAreasByTile = new Map();
   const applePickupsByTile = new Map();
   let treeCollidersEnabled = true;
@@ -1011,9 +1033,8 @@ export async function createNature({
         tileGroup.add(mountain);
         mountains.push(mountain);
 
-        const mountainAreas = buildTreeClimbAreas(mountain);
-        mountain.userData.climbAreas = mountainAreas;
-        tileClimbAreas.push(...mountainAreas);
+        mountain.userData.climbAreas = [];
+        activeMountains.add(mountain);
 
         const physics = createMountainCollider(mountain);
         if (physics) {
@@ -1453,6 +1474,7 @@ export async function createNature({
         if (physics?.rb) removeRigidBodySafely(rapierWorld, physics.rb);
       }
       disposeMountains(entry.mountains);
+      for (const mountain of entry.mountains ?? []) activeMountains.delete(mountain);
     }
     treeTiles.clear();
     climbableAreasByTile.clear();
@@ -1482,6 +1504,7 @@ export async function createNature({
         if (physics?.rb) removeRigidBodySafely(rapierWorld, physics.rb);
       }
       disposeMountains(entry.mountains);
+      for (const mountain of entry.mountains ?? []) activeMountains.delete(mountain);
     }
     treeTiles.clear();
     climbableAreasByTile.clear();
@@ -1502,6 +1525,8 @@ export async function createNature({
     treeImpostorTrunkMaterial.dispose();
     treeImpostorLeafMaterials.forEach((material) => material.dispose());
     mountainMaterials.forEach((material) => material.dispose());
+    activeMountains.clear();
+    unregisterMountainHeightResolver?.();
     group.clear();
     scene?.remove(group);
   };

--- a/environment/terrainHeight.js
+++ b/environment/terrainHeight.js
@@ -4,6 +4,7 @@ const stampDebugOptions = {
   showPriority: false,
   showInfluenceRadii: false
 };
+const extraHeightResolvers = new Set();
 
 export function getBaseTerrainHeight() {
   return FLAT_TERRAIN_HEIGHT;
@@ -62,6 +63,25 @@ export function getTerrainStampDebugSample(x, z) {
   };
 }
 
-export function getTerrainHeight() {
-  return FLAT_TERRAIN_HEIGHT;
+export function getTerrainHeight(x = 0, z = 0) {
+  return getTerrainHeightAt(x, z);
+}
+
+export function registerTerrainHeightResolver(resolver) {
+  if (typeof resolver !== "function") return () => {};
+  extraHeightResolvers.add(resolver);
+  return () => {
+    extraHeightResolvers.delete(resolver);
+  };
+}
+
+export function getTerrainHeightAt(x = 0, z = 0) {
+  let height = FLAT_TERRAIN_HEIGHT;
+  for (const resolver of extraHeightResolvers) {
+    const resolved = resolver(x, z, height);
+    if (Number.isFinite(resolved) && resolved > height) {
+      height = resolved;
+    }
+  }
+  return height;
 }

--- a/environment/terrainHeight.js
+++ b/environment/terrainHeight.js
@@ -67,6 +67,10 @@ export function getTerrainHeight(x = 0, z = 0) {
   return getTerrainHeightAt(x, z);
 }
 
+export function getTerrainHeightWithoutResolvers(_x = 0, _z = 0) {
+  return FLAT_TERRAIN_HEIGHT;
+}
+
 export function registerTerrainHeightResolver(resolver) {
   if (typeof resolver !== "function") return () => {};
   extraHeightResolvers.add(resolver);


### PR DESCRIPTION
### Motivation
- Prevent mountain geometry from being treated as climbable surfaces so players/AI don't attempt mountain-specific climbing.
- Ensure items, weapons, pickups, NPCs, animals and monsters spawned on mountain tiles end up above mountain geometry instead of being trapped inside.
- Expose mountain tops as a valid ground surface so walking/jumping/ground-snapping logic recognizes mountains as walkable ground.

### Description
- Added an extensible terrain-height resolver API in `environment/terrainHeight.js` with `registerTerrainHeightResolver`, `getTerrainHeightAt`, and updated `getTerrainHeight` to consult resolvers.
- In `environment/nature.js` imported `registerTerrainHeightResolver`, introduced an `activeMountains` set and a raycast-based resolver that returns the highest mountain surface Y for a queried `(x,z)` so `getTerrainHeight` reflects mountain tops.
- Disabled mountain climb areas by setting `mountain.userData.climbAreas = []` when mountains are created so mountains are no longer registered as climbable surfaces.
- Tracked mountain lifecycle and cleanup by removing mountains from `activeMountains` during tile cache resets and `dispose`, and unregistering the mountain height resolver on `dispose`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm test -- --runInBand` which failed because this repository has no `test` script defined.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107261260c832b9f3c974138da07f1)