### PR TITLE
Fix mushroom giant height lift and model-based clone powerup

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -8153,7 +8153,9 @@ async function initCore(runtimeContext) {
 
     for (let i = 0; i < count; i += 1) {
       const cloneMesh = SkeletonUtils.clone(playerModel);
-      cloneMesh.userData = { ...(cloneMesh.userData || {}) };
+      cloneMesh.userData = cloneMesh.userData || {};
+      delete cloneMesh.userData.mixer;
+      delete cloneMesh.userData.actions;
       cloneMesh.userData.isPlayerCopy = true;
       cloneMesh.userData.health = 20;
       cloneMesh.userData.dead = false;

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -41,6 +41,7 @@ import { createAnimalManager } from '../environment/animals.js';
 import { createApples, APPLE_ITEM_ID } from '../items/apple.js';
 import { createHomeSystem } from '../home.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import RAPIER from '@dimforge/rapier3d-compat';
 import { removeRigidBodySafely } from '../physics/rapierSafety.js';
 import { createStaticBoxColliderForObject, removeStaticBoxCollider, syncStaticBoxColliderForObject } from '../physics/staticBoxCollider.js';
@@ -8133,25 +8134,52 @@ async function initCore(runtimeContext) {
   };
 
   const clearPlayerCopies = () => {
-    (playerPowerups.clones || []).forEach((clone) => clone?.mesh?.parent?.remove?.(clone.mesh));
+    (playerPowerups.clones || []).forEach((clone) => {
+      if (clone?.actions) {
+        Object.values(clone.actions).forEach((action) => action?.stop?.());
+      }
+      clone?.mixer?.stopAllAction?.();
+      clone?.mesh?.parent?.remove?.(clone.mesh);
+    });
     playerPowerups.clones = [];
   };
 
   const spawnPlayerCopies = (count = 7) => {
     clearPlayerCopies();
     if (!playerModel?.parent) return;
+
+    const sourceActions = playerModel?.userData?.actions || {};
+    const actionEntries = Object.entries(sourceActions).filter(([, action]) => action?.getClip);
+
     for (let i = 0; i < count; i += 1) {
-      const cloneMesh = new THREE.Mesh(
-        new THREE.CapsuleGeometry(0.15, 0.5, 4, 8),
-        new THREE.MeshStandardMaterial({ color: 0x9fb8ff, transparent: true, opacity: 0.9, roughness: 0.7, metalness: 0.05 })
-      );
-      cloneMesh.castShadow = true;
-      cloneMesh.receiveShadow = true;
+      const cloneMesh = SkeletonUtils.clone(playerModel);
+      cloneMesh.userData = { ...(cloneMesh.userData || {}) };
       cloneMesh.userData.isPlayerCopy = true;
       cloneMesh.userData.health = 20;
       cloneMesh.userData.dead = false;
+
+      cloneMesh.traverse((child) => {
+        if (!child?.isMesh) return;
+        child.castShadow = true;
+        child.receiveShadow = true;
+      });
+
+      const mixer = new THREE.AnimationMixer(cloneMesh);
+      const actions = {};
+      actionEntries.forEach(([key, action]) => {
+        const clip = action?.getClip?.();
+        if (!clip) return;
+        actions[key] = mixer.clipAction(clip);
+      });
+
       playerModel.parent.add(cloneMesh);
-      playerPowerups.clones.push({ mesh: cloneMesh, angle: (i / count) * Math.PI * 2, radius: 1.8 + (i % 2) * 0.6 });
+      playerPowerups.clones.push({
+        mesh: cloneMesh,
+        mixer,
+        actions,
+        angle: (i / count) * Math.PI * 2,
+        radius: 1.8 + (i % 2) * 0.6
+      });
     }
   };
 
@@ -8169,7 +8197,7 @@ async function initCore(runtimeContext) {
   };
 
 
-  const updatePlayerCopies = () => {
+  const updatePlayerCopies = (deltaSeconds = 0) => {
     const now = Date.now();
     if (now >= playerPowerups.cloneUntil) return;
     const basePos = playerModel?.position;
@@ -8183,6 +8211,24 @@ async function initCore(runtimeContext) {
         basePos.z + Math.sin(angle) * clone.radius
       );
       clone.mesh.quaternion.copy(playerModel.quaternion);
+
+      const currentActionName = playerModel?.userData?.currentAction;
+      const sourceAction = currentActionName ? playerModel?.userData?.actions?.[currentActionName] : null;
+      const cloneAction = currentActionName ? clone?.actions?.[currentActionName] : null;
+      if (cloneAction) {
+        if (!clone.currentAction || clone.currentAction !== currentActionName) {
+          clone.actions?.[clone.currentAction]?.fadeOut?.(0.1);
+          cloneAction.reset().fadeIn(0.1).play();
+          clone.currentAction = currentActionName;
+        }
+        if (sourceAction && Number.isFinite(sourceAction.time)) {
+          const clipDuration = cloneAction.getClip?.()?.duration || 0;
+          cloneAction.time = clipDuration > 0 ? (sourceAction.time % clipDuration) : sourceAction.time;
+          cloneAction.timeScale = Number.isFinite(sourceAction.timeScale) ? sourceAction.timeScale : 1;
+          cloneAction.paused = !!sourceAction.paused;
+        }
+      }
+      clone.mixer?.update?.(deltaSeconds);
       if (clone.mesh.userData.health <= 0) {
         clone.mesh.visible = false;
         clone.mesh.userData.dead = true;
@@ -8534,7 +8580,6 @@ async function initCore(runtimeContext) {
       updateHungerUI();
       statsState.energy = statsState.hunger;
       updateEnergyEffects();
-    updatePlayerCopies();
     }
     if (key === 'magic') {
       updateMagicUI();
@@ -14864,6 +14909,7 @@ async function initCore(runtimeContext) {
     }
 
     const mixerDelta = mixerClock.getDelta();
+    updatePlayerCopies(mixerDelta);
 
     // 1) Always advance animation mixers (every frame)
     Object.values(otherPlayers).forEach(p => {

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -8144,6 +8144,25 @@ async function initCore(runtimeContext) {
     playerPowerups.clones = [];
   };
 
+
+  const clonePlayerModelForPowerup = () => {
+    if (!playerModel) return null;
+    const originalUserData = playerModel.userData || {};
+    const cloneUserData = { ...originalUserData };
+    delete cloneUserData.mixer;
+    delete cloneUserData.actions;
+    delete cloneUserData.attack;
+    playerModel.userData = cloneUserData;
+
+    let cloneMesh = null;
+    try {
+      cloneMesh = SkeletonUtils.clone(playerModel);
+    } finally {
+      playerModel.userData = originalUserData;
+    }
+    return cloneMesh;
+  };
+
   const spawnPlayerCopies = (count = 7) => {
     clearPlayerCopies();
     if (!playerModel?.parent) return;
@@ -8152,7 +8171,8 @@ async function initCore(runtimeContext) {
     const actionEntries = Object.entries(sourceActions).filter(([, action]) => action?.getClip);
 
     for (let i = 0; i < count; i += 1) {
-      const cloneMesh = SkeletonUtils.clone(playerModel);
+      const cloneMesh = clonePlayerModelForPowerup();
+      if (!cloneMesh) continue;
       cloneMesh.userData = cloneMesh.userData || {};
       delete cloneMesh.userData.mixer;
       delete cloneMesh.userData.actions;

--- a/controls/controls.js
+++ b/controls/controls.js
@@ -3326,10 +3326,17 @@ export class PlayerControls {
     const safeScale = Number.isFinite(scale) && scale > 0 ? scale : DEFAULT_PLAYER_SCALE;
     if (!this.playerModel?.scale?.setScalar) return;
     const currentScale = Number.isFinite(this.playerModel.scale.x) ? this.playerModel.scale.x : DEFAULT_PLAYER_SCALE;
+
+    const bounds = new THREE.Box3().setFromObject(this.playerModel);
+    const currentHeight = Math.max(0, bounds.max.y - bounds.min.y);
+
     this.playerModel.scale.setScalar(safeScale);
+
     if (this.playerModel?.position) {
-      const yLiftPerScale = 0.55;
-      this.playerModel.position.y += (safeScale - currentScale) * yLiftPerScale;
+      const yLiftFromHeight = ((safeScale / Math.max(currentScale, 0.001)) - 1) * currentHeight * 0.5;
+      const yLiftFallback = (safeScale - currentScale) * 0.55;
+      const yLift = Number.isFinite(yLiftFromHeight) && yLiftFromHeight > 0 ? yLiftFromHeight : yLiftFallback;
+      this.playerModel.position.y += yLift;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the giant mushroom (Mushroom 15) from sinking the enlarged player model into the ground by adjusting player vertical position when scale changes.
- Replace capsule placeholder copies spawned by the clone mushroom (Mushroom 8) with actual clones of the player’s selected model so clones visually match (e.g. `Chimpanzee.fbx`, `cowboy.fbx`, `base_character_2.fbx`, `seagull.fbx`) and behave like the player.
- Ensure clones animate and move in sync with the player and are cleaned up fully when the effect ends to avoid leftover objects and running mixers.

### Description
- Compute a model-height-based Y lift in `PlayerControls.setPlayerScale` and apply that lift when changing scale to avoid ground clipping (uses `THREE.Box3().setFromObject` to measure current height and adjust `playerModel.position.y`).
- Add an import for `SkeletonUtils` and change the clone powerup implementation in `app/bootstrapGameApp.js` to use `SkeletonUtils.clone(playerModel)` so clones are actual model copies rather than capsule meshes.
- Create per-clone `THREE.AnimationMixer` instances and per-clone actions from the player’s action clips, and synchronize clone action state (`currentAction`, `time`, `timeScale`, `paused`) to mirror the player in `updatePlayerCopies` which now accepts a `deltaSeconds` and advances clone mixers.
- Improve clone cleanup in `clearPlayerCopies` to stop clone actions, stop mixers, and remove clone objects from the scene; ensure `updatePlayerCopies` is invoked with `mixerDelta` each frame so clone animations are updated in real time.

### Testing
- Ran a production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107ac094c8832b8ef84ad83c68051e)