### PR TITLE
Hide quest friend health bar by default and improve spawn grounding

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -2024,6 +2024,7 @@ async function initCore(runtimeContext) {
       questFriend.model.userData.hideInMapView = true;
       questFriend.model.userData.isQuestFriend = true;
       questFriend.model.userData.remoteSynced = true;
+      questFriend.alwaysShowHealthBar = false;
       questFriend.enableDanceWhileEngaged = false;
       questFriend.setNoticeRadius?.(10);
       questFriend.setWanderRadius?.(5);
@@ -2031,6 +2032,10 @@ async function initCore(runtimeContext) {
       questFriend.setDisengageRadius?.(8);
       questFriend.setLevel?.(1, { preserveHealth: false });
       questFriend.resetHealth?.();
+      questFriend.healthBarVisibleUntil = 0;
+      if (questFriend.healthBar) {
+        questFriend.healthBar.visible = false;
+      }
       scene?.add(questFriend.model);
       attachMonsterPhysics?.(questFriend);
       remoteQuestFriends.set(id, questFriend);

--- a/characters/FriendlyCharacter.js
+++ b/characters/FriendlyCharacter.js
@@ -123,7 +123,17 @@ export class FriendlyCharacter extends MonsterCharacter {
 
   updateHealthBarVisibility() {
     if (!this.healthBar) return;
-    this.healthBar.visible = !this.isDead && this.model.userData.npcRole !== 'merchant';
+    if (this.isDead || this.model.userData.npcRole === 'merchant') {
+      this.healthBar.visible = false;
+      return;
+    }
+    if (this.alwaysShowHealthBar) {
+      this.healthBar.visible = true;
+      return;
+    }
+    if (this.healthBar.visible && Date.now() > this.healthBarVisibleUntil) {
+      this.healthBar.visible = false;
+    }
   }
 
   findClosestMonster(monsters = []) {
@@ -238,19 +248,19 @@ export class FriendlyCharacter extends MonsterCharacter {
 
       if (this.isFollowingTarget && followDir) {
         this.setDirection(followDir);
-        const movement = followDir.clone().multiplyScalar(CHARACTER_MOVEMENT.walkSpeed * IDLE_SPEED_MULTIPLIER);
-        body.setLinvel({ x: movement.x, y: 0, z: movement.z }, true);
-        const angle = Math.atan2(followDir.x, followDir.z);
-        const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
-        body.setRotation(rot, true);
+        this.setHorizontalMovement(
+          followDir,
+          CHARACTER_MOVEMENT.walkSpeed * IDLE_SPEED_MULTIPLIER,
+          delta,
+          context
+        );
+        this.faceDirection(followDir);
         this.playAnimation("Walk", MOVE_FADE);
       } else {
-        body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+        this.setHorizontalMovement(new THREE.Vector3(), 0, delta, context);
         if (followDir) {
           this.setDirection(followDir);
-          const angle = Math.atan2(followDir.x, followDir.z);
-          const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
-          body.setRotation(rot, true);
+          this.faceDirection(followDir);
         }
         this.playAnimation("Idle", MOVE_FADE);
       }
@@ -264,10 +274,8 @@ export class FriendlyCharacter extends MonsterCharacter {
       const targetPos = targetSource.clone();
       const faceDir = targetPos.sub(this.model.position).normalize();
       this.setDirection(faceDir);
-      body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-      const angle = Math.atan2(faceDir.x, faceDir.z);
-      const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
-      body.setRotation(rot, true);
+      this.setHorizontalMovement(new THREE.Vector3(), 0, delta, context);
+      this.faceDirection(faceDir);
 
       if (this.enableDanceWhileEngaged && now >= this.danceUntil && now >= this.nextDanceAt) {
         const duration = DANCE_MIN_DURATION_MS
@@ -298,10 +306,13 @@ export class FriendlyCharacter extends MonsterCharacter {
     const movement = this.model.userData.direction
       .clone()
       .multiplyScalar(CHARACTER_MOVEMENT.walkSpeed * IDLE_SPEED_MULTIPLIER);
-    body.setLinvel({ x: movement.x, y: 0, z: movement.z }, true);
-    const angle = Math.atan2(this.model.userData.direction.x, this.model.userData.direction.z);
-    const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
-    body.setRotation(rot, true);
+    this.setHorizontalMovement(
+      this.model.userData.direction,
+      CHARACTER_MOVEMENT.walkSpeed * IDLE_SPEED_MULTIPLIER,
+      delta,
+      context
+    );
+    this.faceDirection(this.model.userData.direction);
     if (movement.lengthSq() > 0.0001) {
       this.playAnimation("Walk", MOVE_FADE);
     } else {

--- a/quest.js
+++ b/quest.js
@@ -17,6 +17,7 @@ const QUEST_FRIEND_FOLLOW_DISTANCE = 3;
 const QUEST_FRIEND_FOLLOW_START_DISTANCE = 4.5;
 const QUEST_GENERIC_XP = 60;
 const QUEST_FRIEND_RESPAWN_DELAY_MS = 20000;
+const QUEST_FRIEND_GROUND_OFFSET = 0.9;
 
 const TUTORIAL_QUESTS = [
   {
@@ -302,7 +303,17 @@ export class QuestManager {
     const spawnX = originX + Math.cos(angle) * radius;
     const spawnZ = originZ + Math.sin(angle) * radius;
     const terrainHeight = getTerrainHeight(spawnX, spawnZ);
-    const spawnY = Number.isFinite(terrainHeight) ? terrainHeight + 0.5 : 0.5;
+    let spawnY = Number.isFinite(terrainHeight) ? terrainHeight + QUEST_FRIEND_GROUND_OFFSET : QUEST_FRIEND_GROUND_OFFSET;
+    const resolveGroundY = window.resolveGroundY;
+    if (typeof resolveGroundY === "function") {
+      const sampledGround = resolveGroundY(spawnX, spawnY + 4, spawnZ, {
+        includeSolidHit: true,
+        walkableSlopeDegrees: 42
+      });
+      if (Number.isFinite(sampledGround?.groundY)) {
+        spawnY = sampledGround.groundY + QUEST_FRIEND_GROUND_OFFSET;
+      }
+    }
 
     loadMonsterModel(QUEST_FRIEND_MODEL, (data) => {
       try {
@@ -312,6 +323,7 @@ export class QuestManager {
         questFriend.type = QUEST_FRIEND_MODEL;
         questFriend.model.userData.hideInMapView = true;
         questFriend.model.userData.isQuestFriend = true;
+        questFriend.alwaysShowHealthBar = false;
         questFriend.enableDanceWhileEngaged = false;
         questFriend.setNoticeRadius(10);
         questFriend.setWanderRadius(QUEST_FRIEND_WANDER_RADIUS);
@@ -324,6 +336,10 @@ export class QuestManager {
         });
         questFriend.setLevel(1, { preserveHealth: false });
         questFriend.resetHealth();
+        questFriend.healthBarVisibleUntil = 0;
+        if (questFriend.healthBar) {
+          questFriend.healthBar.visible = false;
+        }
         questFriend.setPosition(spawnX, spawnY, spawnZ);
         questFriend.setHomePosition(new THREE.Vector3(spawnX, spawnY, spawnZ));
         this.scene?.add(questFriend.model);

--- a/quest.js
+++ b/quest.js
@@ -742,7 +742,11 @@ export class QuestManager {
         friend.setFollowTarget(null, { helpingPlayerFight: false });
       }
       const monsters = Array.isArray(window.monsters) ? window.monsters : [];
-      friend.updateAI(this.state.deltaSeconds, playerModel, {}, monsters);
+      friend.updateAI(this.state.deltaSeconds, playerModel, {}, monsters, {
+        resolveGroundY: typeof window.resolveGroundY === "function" ? window.resolveGroundY : null,
+        walkableSlopeDegrees: 42,
+        groundOffset: QUEST_FRIEND_GROUND_OFFSET
+      });
     }
     this.updateGpsQuestProgress();
     this.updateClimbQuestProgress();


### PR DESCRIPTION
### Motivation
- Quest friend health bars should not be visible unless relevant (when the friend is hurt or healed) to reduce HUD clutter.
- Quest friends sometimes spawn floating when chosen spawn positions are near steep terrain, so spawn Y should prefer walkable ground when available.

### Description
- Added `QUEST_FRIEND_GROUND_OFFSET` and sample `window.resolveGroundY(...)` at spawn to prefer walkable ground Y and fall back to `getTerrainHeight`, using the offset when computing `spawnY` in `quest.js`.
- Set `questFriend.alwaysShowHealthBar = false` and explicitly hide the `healthBar` (`healthBar.visible = false` and `healthBarVisibleUntil = 0`) for both local quest friend creation in `quest.js` and remote quest friend creation in `app/bootstrapGameApp.js` so health bars are hidden by default.
- Preserved existing `showHealthBar()` behavior in `MonsterCharacter` so the bar will still be shown briefly when the friend takes damage or is healed.

### Testing
- No automated tests were executed for this change; the patch was applied and committed to the repository and a PR bundle was prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10843c4778832b913b5a159d07b6fe)