### PR TITLE
Fix floating terrain by removing unloaded mountains from height resolver set

### DIFF
--- a/environment/nature.js
+++ b/environment/nature.js
@@ -1081,6 +1081,9 @@ export async function createNature({
       if (physics?.collider) rapierWorld?.removeCollider(physics.collider, true);
       if (physics?.rb) removeRigidBodySafely(rapierWorld, physics.rb);
     }
+    for (const mountain of entry.mountains ?? []) {
+      activeMountains.delete(mountain);
+    }
     disposeMountains(entry.mountains);
     treeTiles.delete(tileKey);
     climbableAreasByTile.delete(tileKey);


### PR DESCRIPTION
### Motivation
- Tile unloads disposed mountain meshes but left stale references in the `activeMountains` set, allowing the mountain terrain height resolver to keep contributing heights at old positions and causing characters to appear to float.

### Description
- Add explicit removal of each mountain from `activeMountains` inside `removeTileEntry` in `environment/nature.js` before calling `disposeMountains` to ensure the resolver no longer considers unloaded mountains.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bf6bf6bc832597487e942cf0282f)