### PR TITLE
Disable PvP, respect companion/friendly behavior, refine attack hit checks, and update caching/manifest

### DIFF
--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -770,8 +770,11 @@ export class MonsterCharacter extends CharacterBase {
           : this.attackDamage;
         hitTargets.forEach((target) => {
           if (!target?.model) return;
-          const dist = this.model.position.distanceTo(target.model.position);
-          if (dist <= attackRange) {
+          const verticalScale = String(this.model?.userData?.behavior || "").toLowerCase() === "companion" ? 3 : 1;
+          const delta = target.model.position.clone().sub(this.model.position);
+          const horizontalDist = Math.hypot(delta.x, delta.z);
+          const verticalDist = Math.abs(delta.y);
+          if (horizontalDist <= attackRange && verticalDist <= attackRange * verticalScale) {
             onHit?.(target, {
               direction: this.model.userData.direction.clone(),
               strength: MONSTER_ATTACK.knockbackStrength,

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="icon" href="data:,">
-  <link rel="manifest" href="/manifest.webmanifest">
 </head>
 <body>
   <div id="game-container">

--- a/items/melee.js
+++ b/items/melee.js
@@ -1,6 +1,5 @@
-import { appContext } from '../src/runtime/appContext.js';
 import * as THREE from 'three';
-import { BASE_HEALTH_SEGMENTS, convertPointsToSegments } from '../healthUtils.js';
+import { convertPointsToSegments } from '../healthUtils.js';
 
 export const ATTACKS = {
   mutantPunch: { damage: 1, range: 1.5, hitTime: 100, hitWindow: 300, knockbackStrength: 2, region: 'forward', types: ['melee', 'punch'] },
@@ -174,54 +173,13 @@ export function updateMeleeAttacks({
           attackTypes
         }) || hit;
       }
-      for (const target of players) {
-        if (target === attacker) continue;
-        if (!target.model || !target.model.position) continue;
-        if (isTargetInAttackRange(attacker.model, target.model.position, attackCfg)) {
-          hit = true;
-          onEntityHit?.({
-            targetType: target.id === 'local' ? 'player' : 'remotePlayer',
-            targetId: target.id,
-            targetPosition: target.model.position.clone(),
-            attackTypes
-          });
-          if (target.id === 'local') {
-            const blockedByShield = window.tryBlockLocalPlayerHitWithShield?.({
-              attackerModel: attacker.model,
-              damage: attackDamage,
-              attackTypes
-            });
-            if (blockedByShield) continue;
-            window.localHealth = Math.max(0, window.localHealth - attackDamage);
-            window.lastHitAttackTypes = attackTypes;
-            const playerControls = appContext.systems.playerControls ?? window.playerControls;
-            if (playerControls) {
-              const dir = new THREE.Vector3().subVectors(target.model.position, attacker.model.position).normalize();
-              playerControls.applyKnockback({ direction: dir, strength: attackCfg.knockbackStrength });
-            }
-          } else {
-            const tp = otherPlayers[target.id];
-            if (tp) {
-              const previousHealth = Number.isFinite(tp.health) ? tp.health : BASE_HEALTH_SEGMENTS;
-              const nextHealth = Math.max(0, previousHealth - attackDamage);
-              tp.health = nextHealth;
-              tp.lastHitAttackTypes = attackTypes;
-              if (nextHealth <= 0 && previousHealth > 0) {
-                tp.isDead = true;
-                if (attacker.id === 'local') {
-                  window.onPlayerKill?.(target.id);
-                }
-              } else if (nextHealth > 0 && tp.isDead) {
-                tp.isDead = false;
-              }
-            }
-          }
-        }
-      }
+      // PvP is disabled: melee attacks should not damage players.
 
       if (isHost && Array.isArray(monsters)) {
         for (const monster of monsters) {
           if (!monster?.model?.position) continue;
+          const behavior = String(monster.model?.userData?.behavior || '').toLowerCase();
+          if (behavior === 'companion' || behavior === 'friendly') continue;
           if (isTargetInAttackRange(attacker.model, monster.model.position, attackCfg)) {
             hit = true;
             const dir = new THREE.Vector3()
@@ -246,6 +204,8 @@ export function updateMeleeAttacks({
       } else if (!isHost && Array.isArray(monsters)) {
         for (const monster of monsters) {
           if (!monster?.model?.position) continue;
+          const behavior = String(monster.model?.userData?.behavior || '').toLowerCase();
+          if (behavior === 'companion' || behavior === 'friendly') continue;
           if (isTargetInAttackRange(attacker.model, monster.model.position, attackCfg)) {
             hit = true;
             sendMonsterAttack?.({

--- a/items/projectiles.js
+++ b/items/projectiles.js
@@ -1,8 +1,7 @@
-import { appContext } from '../src/runtime/appContext.js';
 import * as THREE from "three";
 import RAPIER from '@dimforge/rapier3d-compat';
 import { updateArrowProjectile } from "./arrow.js";
-import { BASE_HEALTH_SEGMENTS, convertPointsToSegments } from "../healthUtils.js";
+import { convertPointsToSegments } from "../healthUtils.js";
 import { getTerrainHeight } from '../environment/terrainHeight.js';
 import { getAttackTypes } from './melee.js';
 import { removeRigidBodySafely } from '../physics/rapierSafety.js';
@@ -235,48 +234,7 @@ export function updateProjectiles({
       continue;
     }
 
-    for (const [id, { model }] of Object.entries(otherPlayers)) {
-      if (proj.userData.shooterId && proj.userData.shooterId === id) continue;
-      if (age < 80) continue;
-      const playerBox = getObjectBox(model);
-      if (!playerBox) continue;
-      if (projBox.intersectsBox(playerBox)) {
-        if (typeof proj.userData.onPlayerImpact === 'function') {
-          const handled = proj.userData.onPlayerImpact(proj.position.clone(), proj);
-          if (handled) {
-            removeProjectile(i);
-            removed = true;
-            break;
-          }
-        }
-        const player = otherPlayers[id];
-        if (player) {
-          const baseDamage = Number.isFinite(proj.userData.damage) ? proj.userData.damage : 1;
-          const damage = proj.userData.shooterId === localId ? getStrengthDamage(baseDamage) : baseDamage;
-          const attackTypes = getAttackTypes(
-            proj.userData.attackLabel || 'bowArrowProjectile',
-            proj.userData.attackTypes || ['projectile']
-          );
-          const previousHealth = Number.isFinite(player.health) ? player.health : BASE_HEALTH_SEGMENTS;
-          const nextHealth = Math.max(0, previousHealth - damage);
-          player.health = nextHealth;
-          player.lastHitAttackTypes = attackTypes;
-          if (nextHealth <= 0 && previousHealth > 0) {
-            player.isDead = true;
-            if (proj.userData.shooterId === localId) {
-              window.onPlayerKill?.(id);
-            }
-          } else if (nextHealth > 0 && player.isDead) {
-            player.isDead = false;
-          }
-          console.log(`💥 Hit player: ${id}, Health: ${player.health}`);
-        }
-        if (proj.userData?.isArrow) playArrowBlockedSFX();
-        removeProjectile(i);
-        removed = true;
-        break;
-      }
-    }
+    // PvP is disabled: projectiles do not collide with or damage other players.
 
     if (removed) continue;
 
@@ -299,39 +257,7 @@ export function updateProjectiles({
 
     if (removed) continue;
 
-    const localBox = getObjectBox(playerModel);
-    if (!localBox) continue;
-    if (projBox.intersectsBox(localBox) && age >= 80 && proj.userData.shooterId !== localId) {
-      if (typeof proj.userData.onPlayerImpact === 'function') {
-        const handled = proj.userData.onPlayerImpact(proj.position.clone(), proj);
-        if (handled) {
-          removeProjectile(i);
-          removed = true;
-          continue;
-        }
-      }
-      console.log(`💥 You were hit`);
-      if (proj.userData?.isArrow) playArrowBlockedSFX();
-      removeProjectile(i);
-      removed = true;
-
-      if (typeof window.localHealth === 'number') {
-        const baseDamage = Number.isFinite(proj.userData.damage) ? proj.userData.damage : 1;
-        const damage = proj.userData.shooterId === localId ? getStrengthDamage(baseDamage) : baseDamage;
-        const attackTypes = getAttackTypes(
-          proj.userData.attackLabel || 'bowArrowProjectile',
-          proj.userData.attackTypes || ['projectile']
-        );
-        window.localHealth = Math.max(0, window.localHealth - damage);
-        window.lastHitAttackTypes = attackTypes;
-        console.log(`❤️ Your Health: ${window.localHealth}`);
-      }
-
-      const playerControls = appContext.systems.playerControls ?? window.playerControls;
-      if (playerControls) {
-        playerControls.applyKnockback({ direction: vel, strength: 3 });
-      }
-    }
+    // PvP is disabled: projectiles do not collide with or damage the local player.
 
     if (removed) continue;
 
@@ -339,6 +265,8 @@ export function updateProjectiles({
       for (const monster of monsters) {
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
+        const behavior = String(monster?.model?.userData?.behavior || "").toLowerCase();
+        if (behavior === "companion" || behavior === "friendly") continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {
           if (typeof proj.userData.onMonsterImpact === 'function') {
             const handled = proj.userData.onMonsterImpact({
@@ -383,6 +311,8 @@ export function updateProjectiles({
       for (const monster of monsters) {
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
+        const behavior = String(monster?.model?.userData?.behavior || "").toLowerCase();
+        if (behavior === "companion" || behavior === "friendly") continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {
           if (typeof proj.userData.onMonsterImpact === 'function') {
             const handled = proj.userData.onMonsterImpact({

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,15 @@
   ],
   "headers": [
     {
+      "source": "/((?!.*\\.).*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {
@@ -38,7 +47,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=0, must-revalidate"
+          "value": "no-store, no-cache, must-revalidate"
         }
       ]
     }


### PR DESCRIPTION
### Motivation

- Disable player-vs-player damage and collision so melee and projectiles no longer hurt other players or the local player.
- Prevent companion/friendly monsters from being targeted by player attacks and projectiles.
- Improve attack hit detection to account for horizontal and vertical distance and handle companion vertical offsets for jump attacks.
- Reduce client caching for SPA routes and remove the manifest link from `index.html`.

### Description

- Updated `MonsterCharacter` to compute horizontal and vertical distances for attack hits and apply a larger vertical tolerance for models flagged as `behavior: "companion"` when checking attack collisions.
- Removed PvP damage/collision code paths from `items/melee.js`, so players are no longer damaged by melee attacks, and added checks to skip monsters whose `model.userData.behavior` is `companion` or `friendly` before applying damage.
- Removed player collision and local-player damage handling from `items/projectiles.js`, and added the same companion/friendly exclusion for monster projectile hits; retained monster damage, knockback, and kill notification flows.
- Cleaned up unused imports (`BASE_HEALTH_SEGMENTS` and `appContext`) and kept `convertPointsToSegments` where used.
- Removed the `<link rel="manifest">` from `index.html`.
- Updated `vercel.json` to add a `Cache-Control: no-store, no-cache, must-revalidate` header for SPA routes and changed `index.html` cache to `no-store, no-cache, must-revalidate` while preserving long-term immutable caching for asset file types.

### Testing

- Built the project with `npm run build` and the build completed successfully.
- Ran linter with `npm run lint` and no lint errors were reported.
- Executed unit/integration tests with `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c39451f483258b0a1e1dda394bf2)