### PR TITLE
Disable PvP/friendly-fire damage and increase companion dog attack reach

### DIFF
--- a/environment/animals.js
+++ b/environment/animals.js
@@ -393,7 +393,9 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   const walkSpeed = Number.isFinite(config.walkSpeed) ? config.walkSpeed : 1.2;
   const runSpeed = Number.isFinite(config.runSpeed) ? config.runSpeed : 4.8;
   const attackDistance = Number.isFinite(config.attackDistance) ? config.attackDistance : 2.3;
-  const monsterAttackRange = Number.isFinite(config.attackRange) ? Math.max(0.5, config.attackRange) : attackDistance;
+  const isCompanionBehavior = behavior === 'companion';
+  const rawMonsterAttackRange = Number.isFinite(config.attackRange) ? Math.max(0.5, config.attackRange) : attackDistance;
+  const monsterAttackRange = isCompanionBehavior ? rawMonsterAttackRange * 3 : rawMonsterAttackRange;
   const monsterDetectRange = Number.isFinite(config.monsterDetectRange) ? Math.max(monsterAttackRange, config.monsterDetectRange) : 9;
   const ownerReturnDistance = Number.isFinite(config.ownerReturnDistance) ? Math.max(1, config.ownerReturnDistance) : 18;
   const companionAttackDamage = Number.isFinite(config.attackDamage) ? Math.max(1, config.attackDamage) : 3;
@@ -401,7 +403,6 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
   const distanceToPlayer = animal.model.position.distanceTo(playerModel.position);
   const data = animal.userData || {};
 
-  const isCompanionBehavior = behavior === 'companion';
   const isCompanion = !!animal.model?.userData?.isCompanion;
   let nearbyMonster = null;
   if (isCompanion) {
@@ -549,7 +550,9 @@ function updateAnimalMovement({ animal, config, getPlayerModel, getTerrainHeight
           const latestDistance = latestTargetPosition
             ? animal.model.position.distanceTo(latestTargetPosition)
             : Number.POSITIVE_INFINITY;
-          if (latestDistance <= monsterAttackRange) {
+          const verticalReachAllowance = isCompanionBehavior ? 5.5 : 0;
+          const verticalDelta = latestTargetPosition ? Math.abs(latestTargetPosition.y - animal.model.position.y) : Number.POSITIVE_INFINITY;
+          if (latestDistance <= monsterAttackRange || (verticalDelta <= verticalReachAllowance && latestDistance <= monsterAttackRange * 1.25)) {
             const killed = applyCompanionDamageToMonster(target, companionAttackDamage, { animal, onMonsterAttack });
             if (killed) {
               data.companionAttackTarget = null;

--- a/items/melee.js
+++ b/items/melee.js
@@ -96,6 +96,13 @@ function getStrengthDamage(attackerId, baseDamage) {
   return baseDamage;
 }
 
+
+function isProtectedCompanionTarget(entity) {
+  if (!entity?.model?.userData) return false;
+  const type = String(entity.type || entity.model.userData.type || '').toLowerCase();
+  return !!entity.model.userData.isCompanion || type === 'dog' || type.includes('companion');
+}
+
 function isAttackInterrupted(attacker, attackName) {
   const model = attacker?.model;
   if (!model?.userData) return true;
@@ -175,7 +182,7 @@ export function updateMeleeAttacks({
         }) || hit;
       }
       for (const target of players) {
-        if (target === attacker) continue;
+        continue; // Disable player-vs-player melee damage entirely.
         if (!target.model || !target.model.position) continue;
         if (isTargetInAttackRange(attacker.model, target.model.position, attackCfg)) {
           hit = true;
@@ -221,7 +228,7 @@ export function updateMeleeAttacks({
 
       if (isHost && Array.isArray(monsters)) {
         for (const monster of monsters) {
-          if (!monster?.model?.position) continue;
+          if (!monster?.model?.position || isProtectedCompanionTarget(monster)) continue;
           if (isTargetInAttackRange(attacker.model, monster.model.position, attackCfg)) {
             hit = true;
             const dir = new THREE.Vector3()
@@ -245,7 +252,7 @@ export function updateMeleeAttacks({
         }
       } else if (!isHost && Array.isArray(monsters)) {
         for (const monster of monsters) {
-          if (!monster?.model?.position) continue;
+          if (!monster?.model?.position || isProtectedCompanionTarget(monster)) continue;
           if (isTargetInAttackRange(attacker.model, monster.model.position, attackCfg)) {
             hit = true;
             sendMonsterAttack?.({

--- a/items/projectiles.js
+++ b/items/projectiles.js
@@ -35,6 +35,13 @@ const playArrowBlockedSFX = () => {
   });
 };
 
+
+const isProtectedCompanionTarget = (entity) => {
+  if (!entity?.model?.userData) return false;
+  const type = String(entity.type || entity.model.userData.type || '').toLowerCase();
+  return !!entity.model.userData.isCompanion || type === 'dog' || type.includes('companion');
+};
+
 const getObjectBox = (object) => {
   if (!object || typeof object.updateWorldMatrix !== 'function') {
     return null;
@@ -236,6 +243,7 @@ export function updateProjectiles({
     }
 
     for (const [id, { model }] of Object.entries(otherPlayers)) {
+      continue; // Disable projectile player-vs-player damage entirely.
       if (proj.userData.shooterId && proj.userData.shooterId === id) continue;
       if (age < 80) continue;
       const playerBox = getObjectBox(model);
@@ -301,7 +309,7 @@ export function updateProjectiles({
 
     const localBox = getObjectBox(playerModel);
     if (!localBox) continue;
-    if (projBox.intersectsBox(localBox) && age >= 80 && proj.userData.shooterId !== localId) {
+    if (false && projBox.intersectsBox(localBox) && age >= 80 && proj.userData.shooterId !== localId) {
       if (typeof proj.userData.onPlayerImpact === 'function') {
         const handled = proj.userData.onPlayerImpact(proj.position.clone(), proj);
         if (handled) {
@@ -337,6 +345,7 @@ export function updateProjectiles({
 
     if (isHost && Array.isArray(monsters)) {
       for (const monster of monsters) {
+        if (isProtectedCompanionTarget(monster)) continue;
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {
@@ -381,6 +390,7 @@ export function updateProjectiles({
       }
     } else if (!isHost && Array.isArray(monsters)) {
       for (const monster of monsters) {
+        if (isProtectedCompanionTarget(monster)) continue;
         const monsterBox = getObjectBox(monster?.model);
         if (!monsterBox) continue;
         if (projBox.intersectsBox(monsterBox) && age >= 80) {


### PR DESCRIPTION
### Motivation
- Prevent players from damaging companion animals (dogs) and other players during normal combat to avoid friendly fire and griefing.
- Improve companion dogs' usefulness by extending their effective reach so they can hit tall monsters reliably.

### Description
- Short-circuits player-vs-player melee hit processing to disable PvP melee damage by skipping the player-target loop in `items/melee.js`.
- Disables projectile PvP damage paths by skipping remote-player hit checks and local-player hit checks in `items/projectiles.js`.
- Adds an `isProtectedCompanionTarget` predicate (checks `model.userData.isCompanion`, type `dog`, or `companion` in the type string) and uses it to prevent player attacks and projectiles from damaging companion/dog entities in both melee and projectile monster-hit loops (`items/melee.js`, `items/projectiles.js`).
- Buffs companion-mode attack reach by multiplying configured `attackRange` by 3 when `behavior === 'companion'` and adds a vertical reach allowance during the companion lunge-hit check so dogs can hit taller monsters more reliably (`environment/animals.js`).
- Changes are limited to `environment/animals.js`, `items/melee.js`, and `items/projectiles.js`.

### Testing
- Ran the production build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17125715a48325a05cf83b4e5cd953)