### PR TITLE
Monsters intercept player heading to chase ahead with lateral spread

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -15171,13 +15171,21 @@ async function initCore(runtimeContext) {
             detachMonsterPhysics(monster);
           }
 
+          const playerHeadingDirection = Number.isFinite(locationState.heading)
+            ? new THREE.Vector3(
+              -Math.sin(THREE.MathUtils.degToRad(locationState.heading)),
+              0,
+              Math.cos(THREE.MathUtils.degToRad(locationState.heading))
+            )
+            : null;
           const aiContext = {
             enableFriendlyDrift: true,
             friendlyAvoidanceZones,
             resolveGroundY,
             walkableSlopeDegrees: 42,
             groundOffset: 0.9 * (Number.isFinite(monster.sizeScale) ? monster.sizeScale : 1),
-            friendlyTargets: combatFriendlies
+            friendlyTargets: combatFriendlies,
+            playerHeadingDirection
           };
           const MAX_AI_DELTA_SECONDS = 0.5;
 

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -50,6 +50,8 @@ const FRIENDLY_DRIFT_AVOID_HARD_RADIUS = 3;
 const FRIENDLY_DRIFT_AVOID_MIN_FACTOR = 0.02;
 const ENEMY_DISENGAGE_RADIUS = 22;
 const MONSTER_MAX_WALKABLE_SLOPE_DEGREES = 42;
+const INTERCEPT_AHEAD_DISTANCE = 2.2;
+const INTERCEPT_LATERAL_VARIANCE = 1.8;
 
 export class MonsterCharacter extends CharacterBase {
   constructor({ model, mixer, actions, monsterConfig = {} }) {
@@ -99,6 +101,7 @@ export class MonsterCharacter extends CharacterBase {
     this.model.userData.monsterProperties = this.monsterProperties;
     this.model.userData.lastHitAttackTypes = [];
     this.model.userData.isProvoked = false;
+    this.interceptLateralOffset = THREE.MathUtils.randFloatSpread(INTERCEPT_LATERAL_VARIANCE);
     this.setLevel(1, { preserveHealth: false });
   }
 
@@ -690,6 +693,18 @@ export class MonsterCharacter extends CharacterBase {
     }
 
     const targetPos = primaryTarget.model.position.clone();
+    const headingDirection = context?.playerHeadingDirection;
+    const canInterceptHeading = primaryTarget.id === 'local'
+      && headingDirection?.isVector3
+      && headingDirection.lengthSq() > 0.0001;
+    if (canInterceptHeading) {
+      const normalizedHeading = headingDirection.clone().setY(0).normalize();
+      const lateral = new THREE.Vector3(-normalizedHeading.z, 0, normalizedHeading.x)
+        .multiplyScalar(this.interceptLateralOffset || 0);
+      targetPos
+        .addScaledVector(normalizedHeading, INTERCEPT_AHEAD_DISTANCE)
+        .add(lateral);
+    }
     const distance = this.model.position.distanceTo(targetPos);
     const attackRange = this.getAttackRange();
     const canAttack = !this.attackStartTime && now >= this.nextAttackTime;


### PR DESCRIPTION
### Motivation
- Let active monsters anticipate the local player's movement when GPS heading is available so pursuit feels more natural and they try to get ahead of the player.
- Avoid monsters stacking on the same intercept point by giving each monster a lateral variance so they spread out while still aiming ahead of the player.

### Description
- Add `playerHeadingDirection` to the AI context in `app/bootstrapGameApp.js` by converting `locationState.heading` into a world-space `THREE.Vector3` and passing it as `playerHeadingDirection` to monster updates.
- Introduce `INTERCEPT_AHEAD_DISTANCE` and `INTERCEPT_LATERAL_VARIANCE` in `characters/MonsterCharacter.js` and initialize a per-monster `interceptLateralOffset` with `THREE.MathUtils.randFloatSpread` so each monster gets a random lateral offset.
- Modify the combat target calculation in `MonsterCharacter.updateCombatAI` so when the primary target is the local player and a valid `playerHeadingDirection` is present the monster shifts its `targetPos` ahead along the heading by `INTERCEPT_AHEAD_DISTANCE` and applies the per-monster lateral offset, while preserving existing facing, movement and attack logic.
- Keep the existing attack loop and facing behavior intact so attacks, lunges and standoffs function as before but oriented toward the ahead-of-player intercept point.

### Testing
- Ran `npm run -s build` and the build completed successfully; Vite/Rollup emitted non-blocking bundle-size warnings and a comment-removal notice but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1718907488832588cda545fa2e98ed)