### PR TITLE
Fix note modal reference and add Block build option

### DIFF
--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -7917,6 +7917,7 @@ async function initCore(runtimeContext) {
         <h3>Build with Wood</h3>
         <p style="margin:0 0 10px 0;">You have ${safeWoodCount} wood. Choose what to build.</p>
         <div class="build-type-grid" style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-bottom:10px;">
+          <button type="button" class="retro-build-btn" data-build-choice="block">Block</button>
           <button type="button" class="retro-build-btn" data-build-choice="arrow">Arrow</button>
           <button type="button" class="retro-build-btn" data-build-choice="torch">Torch</button>
           <button type="button" class="retro-build-btn" data-build-choice="shield">Shield</button>
@@ -13426,6 +13427,9 @@ async function initCore(runtimeContext) {
   const buildConfirmBtn = buildUi.querySelector('#build-confirm-btn');
   const buildUpBtn = buildUi.querySelector('#build-up-btn');
   const buildDownBtn = buildUi.querySelector('#build-down-btn');
+  const noteViewModal = document.createElement('div');
+  noteViewModal.className = 'build-modal-overlay hidden';
+  document.body.appendChild(noteViewModal);
   let buildVerticalInput = 0;
   const buildHorizontalKeys = new Set();
   window.addEventListener('keydown', (event) => {

--- a/app/bootstrapGameApp.js
+++ b/app/bootstrapGameApp.js
@@ -7975,6 +7975,13 @@ async function initCore(runtimeContext) {
     cancelText: 'Cancel'
   });
 
+  const escapeBuildModalText = (value) => String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
   const startWoodBuildCraftingFlow = (itemId, quantity) => {
     const totalQuantity = Math.max(1, Math.floor(Number.isFinite(quantity) ? quantity : 1));
     const availableWood = Math.max(0, Math.floor(inventoryState.wood?.count || 0));


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` when opening a note by ensuring the note view modal element exists before any handlers reference it.
- Expose an explicit `Block` choice in the wood build picker so players can place block builds from the GUI.

### Description
- Create and mount a `noteViewModal` overlay element (`document.createElement('div')`, class `build-modal-overlay hidden`) early when the build UI is initialized so `noteViewModal` is defined before `showNoteInteraction` runs.
- Add a `Block` button (`data-build-choice="block"`) to the `openBuildTypePicker` modal markup so block placement can be selected from the wood build picker.
- Changes are contained in `app/bootstrapGameApp.js`.

### Testing
- Ran `npm run build` which completed successfully (production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171fa7583c83259ca298fdc8d53d50)